### PR TITLE
Fix services sles

### DIFF
--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -66,8 +66,8 @@ def __virtual__():
             return (False, 'Cannot load rh_service module: '
                            'osrelease grain, {0}, not a float,'.format(osrelease))
         if __grains__['os'] == 'SUSE':
-            if osrelease > 11:
-                return (False, 'Cannot load rh_service module on SUSE >= 11')
+            if osrelease >= 12:
+                return (False, 'Cannot load rh_service module on SUSE >= 12')
         if __grains__['os'] == 'Fedora':
             if osrelease > 15:
                 return (False, 'Cannot load rh_service module on Fedora >= 15')

--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -37,6 +37,7 @@ def __virtual__():
         'Arch ARM',
         'ALT',
         'SUSE  Enterprise Server',
+        'SUSE',
         'OEL',
         'Linaro',
         'elementary OS',


### PR DESCRIPTION
    Fix numerical check of osrelease
    
    After making the version check numerical in 9975508 it no longer matched
    SLES 11 properly to use the rh_service module as '11.4 > 11' evaluates
    to true. Without using the rh_service module, not all methods are
    implemented to use the service state on sle11.

    Make the suse check consistent with rh_service.py
