### PR TITLE
Prevent metadata download when getting installed products

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1308,7 +1308,10 @@ def list_products(all=False, refresh=False):
 
     ret = list()
     OEM_PATH = "/var/lib/suseRegister/OEM"
-    cmd = _zypper('-x', 'products')
+    cmd = _zypper()
+    if not all:
+        cmd.append('--disable-repos')
+    cmd.extend(['-x', 'products'])
     if not all:
         cmd.append('-i')
 


### PR DESCRIPTION
--disable-repos temporary disable all repos for this call. 

@isbm , @dmacvicar - maybe you want to have a look?