### PR TITLE
align OS grains from older SLES with current one (bsc#975757)

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1185,14 +1185,19 @@ def os_data():
                         for line in fhr:
                             if 'enterprise' in line.lower():
                                 grains['lsb_distrib_id'] = 'SLES'
+                                grains['lsb_distrib_codename'] = re.sub(r'\(.+\)', '', line).strip()
                             elif 'version' in line.lower():
                                 version = re.sub(r'[^0-9]', '', line)
                             elif 'patchlevel' in line.lower():
                                 patch = re.sub(r'[^0-9]', '', line)
                     grains['lsb_distrib_release'] = version
                     if patch:
-                        grains['lsb_distrib_release'] += ' SP' + patch
-                    grains['lsb_distrib_codename'] = 'n.a'
+                        grains['lsb_distrib_release'] += '.' + patch
+                        patchstr = 'SP' + patch
+                        if grains['lsb_distrib_codename'] and patchstr not in grains['lsb_distrib_codename']:
+                            grains['lsb_distrib_codename'] += ' ' + patchstr
+                    if not grains['lsb_distrib_codename']:
+                        grains['lsb_distrib_codename'] = 'n.a'
                 elif os.path.isfile('/etc/altlinux-release'):
                     # ALT Linux
                     grains['lsb_distrib_id'] = 'altlinux'


### PR DESCRIPTION
Try to unify the os grains between SLE11 and SLE12 independent of existing os-release file:

This commit change SLES11 SP3 and lower in the following way:

    oscodename: n.a => SUSE Linux Enterprise Server 11 SP3
    osrelease:   "11 SP3" => 11.3
    osrelease_info: ["11 SP3"] => [11, 3]

@isbm , @dmacvicar : this is a proposal. What do you think?
