### PR TITLE
[WIP] jobs.job_success now allow to check if a job has executed successfully

### DIFF
--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -488,6 +488,51 @@ def print_job(jid, ext_source=None, outputter=None):
         return ret
 
 
+def job_success(jid, ext_source=None):
+    '''
+    Check if a job has been executed successfully
+
+    jid
+        The jid to look up.
+
+    ext_source
+        The external job cache to use. Default: `None`.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run jobs.job_success 20160520145827701627
+    '''
+    ret = {}
+    mminion = salt.minion.MasterMinion(__opts__)
+    returner = _get_returner((
+        __opts__['ext_job_cache'],
+        ext_source,
+        __opts__['master_job_cache']
+    ))
+
+    try:
+        data = list_job(
+            jid,
+            ext_source=ext_source
+        )
+    except TypeError:
+        return ('Requested returner could not be loaded. '
+                'No JIDs could be retrieved.')
+
+    returns = data.get('Result', {})
+
+    for minion in returns:
+        minion_ret = returns[minion].get('return', {})
+        if minion_ret['retcode'] == 0:
+            ret[minion] = True
+        else:
+            ret[minion] = False
+
+    return ret
+
+
 def last_run(ext_source=None,
              outputter=None,
              metadata=None,


### PR DESCRIPTION
Trello card: https://trello.com/c/fWtl3t9B/24-salt-should-tell-us-about-success-or-failure-of-jobs-5

Currently salt lets you check the results of a job using:

```
suma3pg:~# salt-run jobs.lookup_jid 20160520173111930120
minionsles12sp1-suma3pg.vagrant.local:
    ----------
    pid:
        15124
    retcode:
        0
    stderr:
    stdout:
```

If what we want is to check if a job has executed successfully or not, I propose `jobs.job_success` on this PR:

```
suma3pg:~ # salt-run jobs.job_success 20160520173111930120
minionsles12sp1-suma3pg.vagrant.local:
    True
```

What do you think?

/cc @isbm @renner @dmacvicar @mateiw 
