### PR TITLE
Avoid failures on SLES 12 SP2 because of new systemd TaskMax limit (bsc#985112)

### DIFF
--- a/pkg/salt-master.service
+++ b/pkg/salt-master.service
@@ -6,6 +6,7 @@ After=network.target
 LimitNOFILE=16384
 Type=simple
 ExecStart=/usr/bin/salt-master
+TasksMax=infinity
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This avoids stalls in case `worker_threads` are set high enough to bump into systemd's `DefaultTaskMax` limit in SLES 12 SP2 (512).

See: https://bugzilla.suse.com/show_bug.cgi?id=985112