### PR TITLE
Backporting fix of #29422 from openSUSE-2016.3.0

### DIFF
--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -23,6 +23,10 @@ log = logging.getLogger(__name__)
 SSH_PASSWORD_PROMPT_RE = re.compile(r'(?:.*)[Pp]assword(?: for .*)?:', re.M)
 KEY_VALID_RE = re.compile(r'.*\(yes\/no\).*')
 
+# Keep these in sync with ./__init__.py
+RSTR = '_edbc7885e4f9aac9b83b35999b68d015148caf467b78fa39c05f669c0ff89878'
+RSTR_RE = re.compile(r'(?:^|\r?\n)' + RSTR + r'(?:\r?\n|$)')
+
 
 class NoPasswdError(Exception):
     pass
@@ -354,6 +358,7 @@ class Shell(object):
                 stream_stdout=False,
                 stream_stderr=False)
         sent_passwd = 0
+        send_password = True
         ret_stdout = ''
         ret_stderr = ''
 
@@ -364,7 +369,10 @@ class Shell(object):
                     ret_stdout += stdout
                 if stderr:
                     ret_stderr += stderr
-                if stdout and SSH_PASSWORD_PROMPT_RE.search(stdout):
+                if stdout and RSTR_RE.search(stdout):
+                    # We're getting results back, don't try to send passwords
+                    send_password = False
+                if stdout and SSH_PASSWORD_PROMPT_RE.search(stdout) and send_password:
                     if not self.passwd:
                         return '', 'Permission denied, no authentication information', 254
                     if sent_passwd < passwd_retries:


### PR DESCRIPTION
This fixes [bug 1019386](https://bugzilla.suse.com/show_bug.cgi?id=1019386). Original commit message below:

The SSH_PASSWORD_PROMPT_RE regexp used to detect if SSH is requesting a
password can be triggered if the shim is returning data to the server
with text that matches the regex, including inside JSON results. This
then results in the server unable to parse the JSON results. This
patch fixes this issue by looking for the shim delimiter in the output and
disabling the sending of passwords after the delimiter is found.

Fixes #29422.