### PR TITLE
2016.11.1: Set SHELL env var for salt-api.service

### DIFF
--- a/pkg/salt-api.service
+++ b/pkg/salt-api.service
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 User=salt
 Type=simple
+Environment=SHELL=/bin/bash
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-api
 TimeoutStopSec=3


### PR DESCRIPTION
ssh `ProxyCommand` needs a valid `$SHELL` in order to execute the command.