### PR TITLE
2015.8.12: SUSE specific salt-service.api

### DIFF
--- a/pkg/suse/salt-api.service
+++ b/pkg/suse/salt-api.service
@@ -1,1 +1,15 @@
-../salt-api.service
+[Unit]
+Description=The Salt API
+After=network.target
+
+[Service]
+User=salt
+Type=simple
+Environment=SHELL=/bin/bash
+LimitNOFILE=8192
+ExecStart=/usr/bin/salt-api
+TimeoutStopSec=3
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
Use a SUSE specific salt-service api instead of the generic `pkg/salt-service.api`
Includes changes from the package patches.
Adds SHELL env var for the salt-api.service. This is because `ssh -o ProxyCommand` needs a valid $SHELL in order to execute the given command.