### PR TITLE
2016.11.3: suse specific changes to salt-api.service

### DIFF
--- a/pkg/suse/salt-api.service
+++ b/pkg/suse/salt-api.service
@@ -1,1 +1,14 @@
-../salt-api.service
+[Unit]
+Description=The Salt API
+After=network.target
+
+[Service]
+User=salt
+Type=simple
+Environment=SHELL=/bin/bash
+LimitNOFILE=8192
+ExecStart=/usr/bin/salt-api
+TimeoutStopSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -53,7 +53,9 @@ class Batch(object):
             args.append(self.opts.get('expr_form', 'glob'))
 
         self.pub_kwargs['yield_pub_data'] = True
-        ping_gen = self.local.cmd_iter(*args, **self.pub_kwargs)
+        ping_gen = self.local.cmd_iter(*args,
+                                       gather_job_timeout=self.opts['gather_job_timeout'],
+                                       **self.pub_kwargs)
 
         # Broadcast to targets
         fret = set()
@@ -174,6 +176,7 @@ class Batch(object):
                                 ret=self.opts.get('return', ''),
                                 show_jid=show_jid,
                                 verbose=show_verbose,
+                                gather_job_timeout=self.opts['gather_job_timeout'],
                                 **self.eauth)
                 # add it to our iterators and to the minion_tracker
                 iters.append(new_iter)

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -510,6 +510,12 @@ class LocalClient(object):
                 'ret': ret,
                 'batch': batch,
                 'raw': kwargs.get('raw', False)}
+
+        if 'timeout' in kwargs:
+            opts['timeout'] = kwargs['timeout']
+        if 'gather_job_timeout' in kwargs:
+            opts['gather_job_timeout'] = kwargs['gather_job_timeout']
+
         for key, val in six.iteritems(self.opts):
             if key not in opts:
                 opts[key] = val

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -89,6 +89,7 @@ def pack_sources(sources, normalize=True):
 def parse_targets(name=None,
                   pkgs=None,
                   sources=None,
+                  patches=None,
                   saltenv='base',
                   normalize=True,
                   **kwargs):
@@ -115,8 +116,8 @@ def parse_targets(name=None,
     if __grains__['os'] == 'MacOS' and sources:
         log.warning('Parameter "sources" ignored on MacOS hosts.')
 
-    if pkgs and sources:
-        log.error('Only one of "pkgs" and "sources" can be used.')
+    if len([True for x in [pkgs, sources, patches] if x]) > 1:
+        log.error('Only one of "pkgs", "sources" or "patches" can be used.')
         return None, None
 
     elif pkgs:
@@ -125,6 +126,13 @@ def parse_targets(name=None,
             return None, None
         else:
             return pkgs, 'repository'
+
+    elif patches:
+        patches = _repack_pkgs(patches, normalize=normalize)
+        if not patches:
+            return None, None
+        else:
+            return patches, 'repository'
 
     elif sources and __grains__['os'] != 'MacOS':
         sources = pack_sources(sources, normalize=normalize)

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -897,6 +897,7 @@ def install(name=None,
             fromrepo=None,
             pkgs=None,
             sources=None,
+            patches=None,
             downloadonly=None,
             skip_verify=False,
             version=None,
@@ -995,7 +996,7 @@ def install(name=None,
         refresh_db()
 
     try:
-        pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name, pkgs, sources, **kwargs)
+        pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name, pkgs, sources, patches, **kwargs)
     except MinionError as exc:
         raise CommandExecutionError(exc)
 
@@ -1050,6 +1051,8 @@ def install(name=None,
         cmd_install.extend(fromrepoopt)
 
     errors = []
+    if patches:
+        targets = ["patch:{0}".format(t) for t in targets]
 
     # Split the targets into batches of 500 packages each, so that
     # the maximal length of the command line is not broken

--- a/tests/unit/cli/batch_test.py
+++ b/tests/unit/cli/batch_test.py
@@ -24,7 +24,13 @@ class BatchTestCase(TestCase):
     '''
 
     def setUp(self):
-        opts = {'batch': '', 'conf_file': {}, 'tgt': '', 'transport': '', 'timeout': 5}
+        opts = {'batch': '',
+                'conf_file': {},
+                'tgt': '',
+                'transport': '',
+                'timeout': 5,
+                'gather_job_timeout': 5}
+
         mock_client = MagicMock()
         with patch('salt.client.get_local_client', MagicMock(return_value=mock_client)):
             with patch('salt.client.LocalClient.cmd_iter', MagicMock(return_value=[])):

--- a/tests/unit/modules/zypper_test.py
+++ b/tests/unit/modules/zypper_test.py
@@ -487,6 +487,36 @@ Repository 'DUMMY' not found by its alias, number, or URI.
                 test_out['_error'] = "The following package(s) failed to download: foo"
                 self.assertEqual(zypper.download("nmap", "foo"), test_out)
 
+    @patch('salt.modules.zypper._systemd_scope', MagicMock(return_value=False))
+    @patch('salt.modules.zypper.list_pkgs', MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.1"}]))
+    @patch.dict(zypper.__salt__, {'pkg_resource.parse_targets': MagicMock(return_value=({'vim': None}, 'repository'))})
+    def test_install_with_downloadonly(self):
+        with patch('salt.modules.zypper.__zypper__.noraise.call', MagicMock()) as zypper_mock:
+            zypper.install(pkgs=['vim'], downloadonly=True)
+            zypper_mock.assert_called_once_with(
+                '--no-refresh',
+                'install',
+                '--name',
+                '--auto-agree-with-licenses',
+                '--download-only',
+                'vim'
+            )
+
+    @patch('salt.modules.zypper._systemd_scope', MagicMock(return_value=False))
+    @patch('salt.modules.zypper.list_pkgs', MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.2"}]))
+    @patch.dict(zypper.__salt__, {'pkg_resource.parse_targets': MagicMock(return_value=({'SUSE-PATCH-XXX': None}, 'repository'))})
+    def test_install_patches(self):
+        with patch('salt.modules.zypper.__zypper__.noraise.call', MagicMock()) as zypper_mock:
+            ret = zypper.install(patches=['SUSE-PATCH-XXX'])
+            self.assertDictEqual(ret, {"vim": {"old": "1.1", "new": "1.2"}})
+            zypper_mock.assert_called_once_with(
+                '--no-refresh',
+                'install',
+                '--name',
+                '--auto-agree-with-licenses',
+                'patch:SUSE-PATCH-XXX'
+            )
+
     def test_remove_purge(self):
         '''
         Test package removal


### PR DESCRIPTION
 * run service under user salt
 * change type from notify to simple
 * set SHELL env var. When passing a ProxyCommand option to salt-ssh a valid $SHELL is needed to execute the given command
(cherry picked from commit ee911a7)