### PR TITLE
Fixed parsing of master minion returns when batching is enabled

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -300,7 +300,7 @@ def state(
             except KeyError:
                 m_state = False
             if m_state:
-                m_state = salt.utils.check_state_result(m_ret)
+                m_state = salt.utils.check_state_result(m_ret, recurse=True)
 
         if not m_state:
             if minion not in fail_minions:
@@ -309,9 +309,10 @@ def state(
             continue
         try:
             for state_item in six.itervalues(m_ret):
-                if 'changes' in state_item and state_item['changes']:
-                    changes[minion] = m_ret
-                    break
+                if isinstance(state_item, dict):
+                    if 'changes' in state_item and state_item['changes']:
+                        changes[minion] = m_ret
+                        break
             else:
                 no_change.add(minion)
         except AttributeError:


### PR DESCRIPTION
This fixes https://bugzilla.suse.com/show_bug.cgi?id=1038814 for the CaaSP product, as we use the orchestration runner to install and update our install.