### PR TITLE
Revert "We don't have python-systemd, so notify can't work"

### DIFF
--- a/pkg/salt-master.service
+++ b/pkg/salt-master.service
@@ -4,7 +4,8 @@ After=network.target
 
 [Service]
 LimitNOFILE=16384
-Type=simple
+Type=notify
+NotifyAccess=all
 ExecStart=/usr/bin/salt-master
 TasksMax=infinity
 


### PR DESCRIPTION
### What does this PR do?

This reverts commit 7917ec3a7efa9abda5932a0241070e0b048aa90d as notifying systemd should work now after the merge of #33. We can therefore simply remove the respective patch from our package:

```
tserong-suse.com-we-don-t-have-python-systemd-so-not.patch
```

### Previous Behavior

Service type for the `salt-master` systemd service was `simple`.

### New Behavior

Service type for the `salt-master` systemd service is `notify` as in upstream.

### Tests written?

No
