### PR TITLE
Catching error when PIDfile cannot be deleted (bsc#1050003)

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -881,7 +881,14 @@ class DaemonMixIn(six.with_metaclass(MixInMeta, object)):
             # We've loaded and merged options into the configuration, it's safe
             # to query about the pidfile
             if self.check_pidfile():
-                os.unlink(self.config['pidfile'])
+                try:
+                    os.unlink(self.config['pidfile'])
+                except OSError as err:
+                    self.info(
+                        'PIDfile could not be deleted: {0}'.format(
+                            self.config['pidfile']
+                        )
+                    )
 
     def set_pidfile(self):
         from salt.utils.process import set_pidfile


### PR DESCRIPTION
### What does this PR do?

Usually the PIDfile is locate in /run. If Salt is not started with root
permissions, it is not able to delete the PIDfile in /run. It should
be safe to just log and ignore this error, since Salt overwrites the
PIDfile on the next start.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/pull/43366

### Previous Behavior
Throws exceptions during shutdown.

### New Behavior
Error is just caught and logged, since PIDfile ist overwritten anyway on next start.

### Tests written?

No
