### PR TITLE
Removes Beacon configuration Deprecation Warning

### DIFF
--- a/salt/beacons/__init__.py
+++ b/salt/beacons/__init__.py
@@ -51,10 +51,6 @@ class Beacon(object):
                 current_beacon_config = {}
                 list(map(current_beacon_config.update, config[mod]))
             elif isinstance(config[mod], dict):
-                salt.utils.warn_until(
-                    'Nitrogen',
-                    'Beacon configuration should be a list instead of a dictionary.'
-                )
                 current_beacon_config = config[mod]
 
             if 'enabled' in current_beacon_config:


### PR DESCRIPTION
### What does this PR do?

Removes a deprecation warning when dictionaries are used to declare Salt beacons. 
Declaring beacons as lists is incompatible with beacon cfg loaders, namely inotify, that was not yet
upgraded to support this change, causing an error whenever a list definition was
used:

File "/usr/lib/python2.7/site-packages/salt/beacons/inotify.py", line 247
TypeError: list indices must be integers, not dict.,
On same file we can read the comment:
"Configuration for inotify beacon should be a dict of dicts"

This PR removes the deprecation message as per @isbm suggestion.

### What issues does this PR fix or reference?

https://bugzilla.suse.com/show_bug.cgi?id=1041993

### Previous Behavior

Deprecation warning with message "DeprecationWarning: Beacon configuration should be a list
instead of a dictionary." was visible on the logs.

### New Behavior

Deprecation warning is no longer visible.

### Tests written?

No