### PR TITLE
Removes Beacon configuration Deprecation Warning (#48)

### DIFF
--- a/obs/Removes-Beacon-configuration-Deprecation-Warning-48.patch
+++ b/obs/Removes-Beacon-configuration-Deprecation-Warning-48.patch
@@ -1,0 +1,42 @@
+From 3f5e4e4ad6bae3816280fb05f066487388239707 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Jo=C3=A3o=20Cavalheiro?=
+ <cavalheiro@users.noreply.github.com>
+Date: Wed, 25 Oct 2017 11:05:03 +0100
+Subject: [PATCH] Removes Beacon configuration Deprecation Warning (#48)
+
+The message "DeprecationWarning: Beacon configuration should be a list
+instead of a dictionary." was shown on the console if any beacon was defined
+not using lists.
+
+This was incompatible with beacon cfg loaders, namely inotify, that was not yet
+upgraded to support this change, causing an error whenever a list definition was
+used:
+
+File "/usr/lib/python2.7/site-packages/salt/beacons/inotify.py", line 247
+TypeError: list indices must be integers, not dict.,
+On same file we can read the comment:
+"Configuration for inotify beacon should be a dict of dicts"
+
+This commit removes the deprecation message as per @isbm suggestion.
+---
+ salt/beacons/__init__.py | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/salt/beacons/__init__.py b/salt/beacons/__init__.py
+index 21b4391227..101332a3d7 100644
+--- a/salt/beacons/__init__.py
++++ b/salt/beacons/__init__.py
+@@ -51,10 +51,6 @@ class Beacon(object):
+                 current_beacon_config = {}
+                 list(map(current_beacon_config.update, config[mod]))
+             elif isinstance(config[mod], dict):
+-                salt.utils.warn_until(
+-                    'Nitrogen',
+-                    'Beacon configuration should be a list instead of a dictionary.'
+-                )
+                 current_beacon_config = config[mod]
+ 
+             if 'enabled' in current_beacon_config:
+-- 
+2.14.2
+

--- a/obs/salt.changes
+++ b/obs/salt.changes
@@ -1,3 +1,9 @@
+Wed Oct 25 15:55:37 UTC 2017 - mdinca@suse.de
+
+- Porting PR#48
+- Added:
+  * Removes-Beacon-configuration-Deprecation-Warning-48.patch
+
 -------------------------------------------------------------------
 Wed Oct 11 12:47:37 UTC 2017 - jbreuer@suse.de
 

--- a/obs/salt.spec
+++ b/obs/salt.spec
@@ -150,6 +150,7 @@ Patch44:        escape-the-os.sep.patch
 Patch45:        bugfix-always-return-a-string-list-on-unknown-job-ta.patch
 # PATCH-FIX_UPSTREAM https://github.com/saltstack/salt/pull/44011
 Patch46:        security-fixes-cve-2017-14695-and-cve-2017-14696.patch
+Patch47:        Removes-Beacon-configuration-Deprecation-Warning-48.patch
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  logrotate
@@ -548,6 +549,7 @@ cp %{S:5} ./.travis.yml
 %patch44 -p1
 %patch45 -p1
 %patch46 -p1
+%patch47 -p1
 
 %build
 %{__python} setup.py --salt-transport=both build

--- a/salt/beacons/__init__.py
+++ b/salt/beacons/__init__.py
@@ -51,10 +51,6 @@ class Beacon(object):
                 current_beacon_config = {}
                 list(map(current_beacon_config.update, config[mod]))
             elif isinstance(config[mod], dict):
-                salt.utils.warn_until(
-                    'Nitrogen',
-                    'Beacon configuration should be a list instead of a dictionary.'
-                )
                 current_beacon_config = config[mod]
 
             if 'enabled' in current_beacon_config:


### PR DESCRIPTION
REF: https://github.com/openSUSE/salt/pull/48

The message "DeprecationWarning: Beacon configuration should be a list
instead of a dictionary." was shown on the console if any beacon was defined
not using lists.

This was incompatible with beacon cfg loaders, namely inotify, that was not yet
upgraded to support this change, causing an error whenever a list definition was
used:

File "/usr/lib/python2.7/site-packages/salt/beacons/inotify.py", line 247
TypeError: list indices must be integers, not dict.,
On same file we can read the comment:
"Configuration for inotify beacon should be a dict of dicts"

This commit removes the deprecation message as per @isbm suggestion.

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
