### PR TITLE
Cherry-pick changes to run salt-master as user salt.

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -25,7 +25,8 @@
 # permissions to allow the specified user to run the master. The exception is
 # the job cache, which must be deleted if this user is changed. If the
 # modified files cause conflicts, set verify_env to False.
-#user: root
+user: salt
+syndic_user: salt
 
 # The port used by the communication interface. The ret (return) port is the
 # interface used for the file server, authentication, job returns, etc.

--- a/pkg/salt-api.service
+++ b/pkg/salt-api.service
@@ -6,6 +6,7 @@ After=network.target
 [Service]
 Type=notify
 NotifyAccess=all
+User=salt
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-api
 TimeoutStopSec=3

--- a/pkg/salt-common.logrotate
+++ b/pkg/salt-common.logrotate
@@ -1,4 +1,5 @@
 /var/log/salt/master {
+	su salt salt
 	weekly
 	missingok
 	rotate 7
@@ -15,6 +16,7 @@
 }
 
 /var/log/salt/key {
+	su salt salt
 	weekly
 	missingok
 	rotate 7


### PR DESCRIPTION
### What does this PR do?
Run salt-master as user `salt`

### What issues does this PR fix or reference?
https://github.com/SUSE/spacewalk/issues/2422

### Previous Behavior
salt-master ran as `root`.

### New Behavior
salt-master should run as `salt`.

### Tests written?
No