### PR TITLE
avoid excessive syslogging by watchdog cronjob

### DIFF
--- a/pkg/suse/salt-minion
+++ b/pkg/suse/salt-minion
@@ -55,7 +55,7 @@ WATCHDOG_CRON="/etc/cron.d/salt-minion"
 
 set_watchdog() {
     if [ ! -f $WATCHDOG_CRON ]; then
-        echo -e '* * * * * root /usr/bin/salt-daemon-watcher --with-init\n' > $WATCHDOG_CRON
+        echo -e '-* * * * * root /usr/bin/salt-daemon-watcher --with-init\n' > $WATCHDOG_CRON
         # Kick the watcher for 1 minute immediately, because cron will wake up only afterwards
         /usr/bin/salt-daemon-watcher --with-init & disown
     fi


### PR DESCRIPTION
### What does this PR do?

On SLES11 systems we are installing a watchdog that is invoked by cron every minute and checks if the minion is still running. Cron will create a syslog entry for every invocation of this watchdog which results in excessive needles syslog entries. Since the watchdog is running as root, it is possible to suppress these annoying messages by simply prepending the watchdog command by a dash ("-"). Please cherry-pick to all relevant branches.