### PR TITLE
older logrotate need su directive

### DIFF
--- a/pkg/salt-common.logrotate
+++ b/pkg/salt-common.logrotate
@@ -8,6 +8,7 @@
 }
 
 /var/log/salt/minion {
+	su root root
 	weekly
 	missingok
 	rotate 7


### PR DESCRIPTION
### What does this PR do?

Older logrotate versions do not work without the su directive.
On SLE11 you just get an error message.

Upstream PR https://github.com/saltstack/salt/pull/44874

