### PR TITLE
2016.11.4: Add grains for FQDN (bsc#1063419)

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1670,6 +1670,33 @@ def append_domain():
     return grain
 
 
+def fqdns():
+    '''
+    Return all known FQDNs for the system by enumerating all interfaces and
+    then trying to reverse resolve them (excluding 'lo' interface).
+    '''
+    # Provides:
+    # fqdns
+
+    grains = {}
+    fqdns = set()
+
+    addresses = salt.utils.network.ip_addrs(include_loopback=False,
+        interface_data=_INTERFACES)
+    addresses.extend(salt.utils.network.ip_addrs6(include_loopback=False,
+        interface_data=_INTERFACES))
+
+    for ip in addresses:
+        try:
+            fqdns.add(socket.gethostbyaddr(ip)[0])
+        except (socket.error, socket.herror,
+            socket.gaierror, socket.timeout) as e:
+            log.error("Exception during resolving address: " + str(e))
+
+    grains['fqdns'] = list(fqdns)
+    return grains
+
+
 def ip_fqdn():
     '''
     Return ip address and FQDN grains

--- a/tests/integration/modules/grains.py
+++ b/tests/integration/modules/grains.py
@@ -52,6 +52,7 @@ class TestModulesGrains(integration.ModuleCase):
             'cpuarch',
             'domain',
             'fqdn',
+            'fqdns',
             'gid',
             'groupname',
             'host',


### PR DESCRIPTION
### What does this PR do?

This PR adds a grain named `fqdns` to the grains.
`fqdns` represents all the FQDNs known for the system on all available interfaces (excluding `lo`).

*Note*: `hostname != FQDN`

`hostname` is the UNIX name of the machine. A machine can have one and only one hostname.
`FQDN` is `host.domain` that resolves to an IP address that the machines is answering to.
A machine can have 1+ `FQDN`s.

### What issues does this PR fix or reference?

Part of the solution for https://bugzilla.suse.com/show_bug.cgi?id=1063419

### New Behavior

A grain called `fqdns` contains all FQDN for the system.

### Tests written?

Yes

