### PR TITLE
Feat: add grain for all FQDNs (bsc#1063419)

### DIFF
--- a/pkg/suse/salt-common.logrotate
+++ b/pkg/suse/salt-common.logrotate
@@ -8,6 +8,7 @@
 }
 
 /var/log/salt/minion {
+	su root root
 	weekly
 	missingok
 	rotate 7

--- a/pkg/suse/salt-minion
+++ b/pkg/suse/salt-minion
@@ -55,7 +55,7 @@ WATCHDOG_CRON="/etc/cron.d/salt-minion"
 
 set_watchdog() {
     if [ ! -f $WATCHDOG_CRON ]; then
-        echo -e '* * * * * root /usr/bin/salt-daemon-watcher --with-init\n' > $WATCHDOG_CRON
+        echo -e '-* * * * * root /usr/bin/salt-daemon-watcher --with-init\n' > $WATCHDOG_CRON
         # Kick the watcher for 1 minute immediately, because cron will wake up only afterwards
         /usr/bin/salt-daemon-watcher --with-init & disown
     fi

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1756,6 +1756,33 @@ def append_domain():
     return grain
 
 
+def fqdns():
+    '''
+    Return all known FQDNs for the system by enumerating all interfaces and
+    then trying to reverse resolve them (excluding 'lo' interface).
+    '''
+    # Provides:
+    # fqdns
+
+    grains = {}
+    fqdns = set()
+
+    addresses = salt.utils.network.ip_addrs(include_loopback=False,
+        interface_data=_INTERFACES)
+    addresses.extend(salt.utils.network.ip_addrs6(include_loopback=False,
+        interface_data=_INTERFACES))
+
+    for ip in addresses:
+        try:
+            fqdns.add(socket.gethostbyaddr(ip)[0])
+        except (socket.error, socket.herror,
+            socket.gaierror, socket.timeout) as e:
+            log.error("Exception during resolving address: " + str(e))
+
+    grains['fqdns'] = list(fqdns)
+    return grains
+
+
 def ip_fqdn():
     '''
     Return ip address and FQDN grains

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -588,7 +588,6 @@ def version_cmp(pkg1, pkg2, ignore_epoch=False):
 
         salt '*' pkg.version_cmp '0.2-001' '0.2.0.1-002'
     '''
-
     return __salt__['lowpkg.version_cmp'](pkg1, pkg2, ignore_epoch=ignore_epoch)
 
 
@@ -1440,18 +1439,20 @@ def install(name=None,
             else:
                 pkgstr = pkgpath
 
-            # Lambda to trim the epoch from the currently-installed version if
-            # no epoch is specified in the specified version
-            norm_epoch = lambda x, y: x.split(':', 1)[-1] \
-                if ':' not in y \
-                else x
             cver = old_as_list.get(pkgname, [])
             if reinstall and cver:
                 for ver in cver:
-                    ver = norm_epoch(ver, version_num)
+                    if diff_attr:
+                        # Since diff_attr was provided, the version info
+                        # is a dict.
+                        ver2 = ver['version']
+                    else:
+                        # No diff_attr was provided, so version is directly
+                        # in ver.
+                        ver2 = ver
                     if salt.utils.compare_versions(ver1=version_num,
                                                    oper='==',
-                                                   ver2=ver,
+                                                   ver2=ver2,
                                                    cmp_func=version_cmp):
                         # This version is already installed, so we need to
                         # reinstall.
@@ -1462,10 +1463,17 @@ def install(name=None,
                     to_install.append((pkgname, pkgstr))
                 else:
                     for ver in cver:
-                        ver = norm_epoch(ver, version_num)
+                        if diff_attr:
+                            # Since diff_attr was provided, the version info
+                            # is a dict.
+                            ver2 = ver['version']
+                        else:
+                            # No diff_attr was provided, so version is directly
+                            # in ver.
+                            ver2 = ver
                         if salt.utils.compare_versions(ver1=version_num,
                                                        oper='>=',
-                                                       ver2=ver,
+                                                       ver2=ver2,
                                                        cmp_func=version_cmp):
                             to_install.append((pkgname, pkgstr))
                             break

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -505,6 +505,7 @@ import salt
 import salt.auth
 import salt.utils
 import salt.utils.event
+from salt.ext.six import BytesIO
 
 # Import salt-api libs
 import salt.netapi
@@ -830,18 +831,6 @@ def urlencoded_processor(entity):
 
     :param entity: raw POST data
     '''
-    if six.PY3:
-        # https://github.com/cherrypy/cherrypy/pull/1572
-        contents = six.StringIO()
-        entity.fp.read(fp_out=contents)
-        contents.seek(0)
-        body_str = contents.read()
-        body_bytes = salt.utils.to_bytes(body_str)
-        body_bytes = six.BytesIO(body_bytes)
-        body_bytes.seek(0)
-        # Patch fp
-        entity.fp = body_bytes
-        del contents
     # First call out to CherryPy's default processor
     cherrypy._cpreqbody.process_urlencoded(entity)
     cherrypy._cpreqbody.process_urlencoded(entity)
@@ -860,10 +849,10 @@ def json_processor(entity):
         body = entity.fp.read()
     else:
         # https://github.com/cherrypy/cherrypy/pull/1572
-        contents = six.StringIO()
+        contents = BytesIO()
         body = entity.fp.read(fp_out=contents)
         contents.seek(0)
-        body = contents.read()
+        body = salt.utils.to_unicode(contents.read())
         del contents
     try:
         cherrypy.serving.request.unserialized_data = json.loads(body)
@@ -884,10 +873,10 @@ def yaml_processor(entity):
         body = entity.fp.read()
     else:
         # https://github.com/cherrypy/cherrypy/pull/1572
-        contents = six.StringIO()
+        contents = BytesIO()
         body = entity.fp.read(fp_out=contents)
         contents.seek(0)
-        body = contents.read()
+        body = salt.utils.to_unicode(contents.read())
     try:
         cherrypy.serving.request.unserialized_data = yaml.safe_load(body)
     except ValueError:
@@ -910,10 +899,10 @@ def text_processor(entity):
         body = entity.fp.read()
     else:
         # https://github.com/cherrypy/cherrypy/pull/1572
-        contents = six.StringIO()
+        contents = BytesIO()
         body = entity.fp.read(fp_out=contents)
         contents.seek(0)
-        body = contents.read()
+        body = salt.utils.to_unicode(contents.read())
     try:
         cherrypy.serving.request.unserialized_data = json.loads(body)
     except ValueError:

--- a/salt/netapi/rest_cherrypy/tools/websockets.py
+++ b/salt/netapi/rest_cherrypy/tools/websockets.py
@@ -54,6 +54,6 @@ class SynchronizingWebsocket(WebSocket):
         This ensures completion of the underlying websocket connection
         and can be used to synchronize parallel senders.
         '''
-        if message.data == 'websocket client ready':
+        if message.data.decode('utf-8') == 'websocket client ready':
             self.pipe.send(message)
         self.send('server received message', False)

--- a/salt/pillar/sql_base.py
+++ b/salt/pillar/sql_base.py
@@ -168,7 +168,7 @@ More complete example for MySQL (to also show configuration)
             as_list: True
             with_lists: [1,3]
 '''
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 # Please don't strip redundant parentheses from this file.
 # I have added some for clarity.
@@ -275,7 +275,7 @@ class SqlBaseExtPillar(six.with_metaclass(abc.ABCMeta, object)):
                 # May set 'as_list' from qb[1][2].
             else:
                 defaults.update(qb[1])
-                if defaults['with_lists']:
+                if defaults['with_lists'] and isinstance(defaults['with_lists'], six.string_types):
                     defaults['with_lists'] = [
                         int(i) for i in defaults['with_lists'].split(',')
                     ]
@@ -437,8 +437,7 @@ class SqlBaseExtPillar(six.with_metaclass(abc.ABCMeta, object)):
                 cursor.execute(details['query'], (minion_id,))
 
                 # Extract the field names the db has returned and process them
-                self.process_fields([row[0] for row in cursor.description],
-                                           details['depth'])
+                self.process_fields([row[0] for row in cursor.description], details['depth'])
                 self.enter_root(root)
                 self.as_list = details['as_list']
                 if details['with_lists']:

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -966,7 +966,14 @@ class DaemonMixIn(six.with_metaclass(MixInMeta, object)):
             # We've loaded and merged options into the configuration, it's safe
             # to query about the pidfile
             if self.check_pidfile():
-                os.unlink(self.config['pidfile'])
+                try:
+                    os.unlink(self.config['pidfile'])
+                except OSError as err:
+                    self.info(
+                        'PIDfile could not be deleted: {0}'.format(
+                            self.config['pidfile']
+                        )
+                    )
 
     def set_pidfile(self):
         from salt.utils.process import set_pidfile

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -969,7 +969,7 @@ class DaemonMixIn(six.with_metaclass(MixInMeta, object)):
                 try:
                     os.unlink(self.config['pidfile'])
                 except OSError as err:
-                    self.info(
+                    logging.getLogger(__name__).info(
                         'PIDfile could not be deleted: {0}'.format(
                             self.config['pidfile']
                         )

--- a/salt/utils/psutil_compat.py
+++ b/salt/utils/psutil_compat.py
@@ -26,7 +26,7 @@ else:
     # Psuedo "from psutil import *"
     _globals = globals()
     for attr in psutil.__all__:
-        _temp = __import__('psutil', globals(), locals(), [attr], -1)
+        _temp = __import__('psutil', globals(), locals(), [attr], -1 if six.PY2 else 0)
         try:
             _globals[attr] = getattr(_temp, attr)
         except AttributeError:

--- a/tests/integration/modules/test_grains.py
+++ b/tests/integration/modules/test_grains.py
@@ -51,6 +51,7 @@ class TestModulesGrains(ModuleCase):
             'cpuarch',
             'domain',
             'fqdn',
+            'fqdns',
             'gid',
             'groupname',
             'host',

--- a/tests/support/cptestcase.py
+++ b/tests/support/cptestcase.py
@@ -38,8 +38,10 @@ from tests.support.case import TestCase
 # pylint: disable=import-error
 import cherrypy  # pylint: disable=3rd-party-module-not-gated
 import salt.ext.six as six
-from salt.ext.six.moves import StringIO
+from salt.ext.six import BytesIO
 # pylint: enable=import-error
+
+import salt.utils
 
 # Not strictly speaking mandatory but just makes sense
 cherrypy.config.update({'environment': "test_suite"})
@@ -92,7 +94,7 @@ class BaseCherryPyTestCase(TestCase):
         fd = None
         if body is not None:
             h['content-length'] = '{0}'.format(len(body))
-            fd = StringIO(body)
+            fd = BytesIO(salt.utils.to_bytes(body))
 
         if headers is not None:
             h.update(headers)

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -6,6 +6,7 @@
 # Import Python libs
 from __future__ import absolute_import
 import os
+import socket
 
 # Import Salt Testing Libs
 from tests.support.mixins import LoaderModuleMockMixin
@@ -462,3 +463,30 @@ PATCHLEVEL = 3
         self.assertEqual(os_grains.get('osrelease'), os_release_map['osrelease'])
         self.assertListEqual(list(os_grains.get('osrelease_info')), os_release_map['osrelease_info'])
         self.assertEqual(os_grains.get('osmajorrelease'), os_release_map['osmajorrelease'])
+
+    @skipIf(not salt.utils.is_linux(), 'System is not Linux')
+    def test_fqdns_return(self):
+        '''
+        test the return for a dns grain. test for issue:
+        https://github.com/saltstack/salt/issues/41230
+        '''
+        reverse_resolv_mock = [('foo.bar.baz', [], ['1.2.3.4']),
+        ('rinzler.evil-corp.com', [], ['5.6.7.8']),
+        ('foo.bar.baz', [], ['fe80::a8b2:93ff:fe00:0']),
+        ('bluesniff.foo.bar', [], ['fe80::a8b2:93ff:dead:beef'])]
+        ret = {'fqdns': ['rinzler.evil-corp.com', 'foo.bar.baz', 'bluesniff.foo.bar']}
+        self._run_fqdns_test(reverse_resolv_mock, ret)
+
+    def _run_fqdns_test(self, reverse_resolv_mock, ret):
+        with patch.object(salt.utils, 'is_windows', MagicMock(return_value=False)):
+            with patch('salt.utils.network.ip_addrs',
+            MagicMock(return_value=['1.2.3.4', '5.6.7.8'])),\
+            patch('salt.utils.network.ip_addrs6',
+            MagicMock(return_value=['fe80::a8b2:93ff:fe00:0', 'fe80::a8b2:93ff:dead:beef'])):
+                with patch.object(socket, 'gethostbyaddr', side_effect=reverse_resolv_mock):
+                    fqdns = core.fqdns()
+                    self.assertEqual(fqdns, ret)
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(CoreGrainsTestCase, needs_daemon=False)

--- a/tests/unit/modules/test_yumpkg.py
+++ b/tests/unit/modules/test_yumpkg.py
@@ -27,6 +27,78 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
     def setup_loader_modules(self):
         return {yumpkg: {'rpm': None}}
 
+    def test_install_pkg(self):
+        '''
+        Test package installation.
+
+        :return:
+        '''
+        def _add_data(data, key, value):
+            data.setdefault(key, []).append(value)
+
+        rpm_out = [
+            'python-urlgrabber_|-(none)_|-3.10_|-8.el7_|-noarch_|-(none)_|-1487838471',
+            'alsa-lib_|-(none)_|-1.1.1_|-1.el7_|-x86_64_|-(none)_|-1487838475',
+            'gnupg2_|-(none)_|-2.0.22_|-4.el7_|-x86_64_|-(none)_|-1487838477',
+            'rpm-python_|-(none)_|-4.11.3_|-21.el7_|-x86_64_|-(none)_|-1487838477',
+            'pygpgme_|-(none)_|-0.3_|-9.el7_|-x86_64_|-(none)_|-1487838478',
+            'yum_|-(none)_|-3.4.3_|-150.el7.centos_|-noarch_|-(none)_|-1487838479',
+            'lzo_|-(none)_|-2.06_|-8.el7_|-x86_64_|-(none)_|-1487838479',
+            'qrencode-libs_|-(none)_|-3.4.1_|-3.el7_|-x86_64_|-(none)_|-1487838480',
+            'ustr_|-(none)_|-1.0.4_|-16.el7_|-x86_64_|-(none)_|-1487838480',
+            'shadow-utils_|-2_|-4.1.5.1_|-24.el7_|-x86_64_|-(none)_|-1487838481',
+            'util-linux_|-(none)_|-2.23.2_|-33.el7_|-x86_64_|-(none)_|-1487838484',
+            'openssh_|-(none)_|-6.6.1p1_|-33.el7_3_|-x86_64_|-(none)_|-1487838485',
+            'virt-what_|-(none)_|-1.13_|-8.el7_|-x86_64_|-(none)_|-1487838486',
+        ]
+        with patch.dict(yumpkg.__grains__, {'osarch': 'x86_64', 'os': 'RedHat'}), \
+             patch.dict(yumpkg.__salt__, {'cmd.run': MagicMock(return_value=os.linesep.join(rpm_out))}), \
+             patch.dict(yumpkg.__salt__, {'cmd.run_all': MagicMock(return_value={'retcode': 0})}), \
+             patch.dict(yumpkg.__salt__, {'pkg_resource.add_pkg': _add_data}), \
+             patch.dict(yumpkg.__salt__, {'pkg_resource.parse_targets': MagicMock(return_value=({'python-urlgrabber': '0.0.1'} , 'repository'))}), \
+             patch.dict(yumpkg.__salt__, {'pkg_resource.format_pkg_list': pkg_resource.format_pkg_list}), \
+             patch.dict(yumpkg.__salt__, {'config.get': MagicMock()}), \
+             patch.dict(yumpkg.__salt__, {'lowpkg.version_cmp': MagicMock(return_value=-1)}):
+            pkgs = yumpkg.install(name='python-urlgrabber')
+            self.assertEqual(pkgs, {})
+
+
+    def test_install_pkg_with_diff_attr(self):
+        '''
+        Test package installation with diff_attr.
+
+        :return:
+        '''
+        def _add_data(data, key, value):
+            data.setdefault(key, []).append(value)
+
+        rpm_out = [
+            'python-urlgrabber_|-(none)_|-3.10_|-8.el7_|-noarch_|-(none)_|-1487838471',
+            'alsa-lib_|-(none)_|-1.1.1_|-1.el7_|-x86_64_|-(none)_|-1487838475',
+            'gnupg2_|-(none)_|-2.0.22_|-4.el7_|-x86_64_|-(none)_|-1487838477',
+            'rpm-python_|-(none)_|-4.11.3_|-21.el7_|-x86_64_|-(none)_|-1487838477',
+            'pygpgme_|-(none)_|-0.3_|-9.el7_|-x86_64_|-(none)_|-1487838478',
+            'yum_|-(none)_|-3.4.3_|-150.el7.centos_|-noarch_|-(none)_|-1487838479',
+            'lzo_|-(none)_|-2.06_|-8.el7_|-x86_64_|-(none)_|-1487838479',
+            'qrencode-libs_|-(none)_|-3.4.1_|-3.el7_|-x86_64_|-(none)_|-1487838480',
+            'ustr_|-(none)_|-1.0.4_|-16.el7_|-x86_64_|-(none)_|-1487838480',
+            'shadow-utils_|-2_|-4.1.5.1_|-24.el7_|-x86_64_|-(none)_|-1487838481',
+            'util-linux_|-(none)_|-2.23.2_|-33.el7_|-x86_64_|-(none)_|-1487838484',
+            'openssh_|-(none)_|-6.6.1p1_|-33.el7_3_|-x86_64_|-(none)_|-1487838485',
+            'virt-what_|-(none)_|-1.13_|-8.el7_|-x86_64_|-(none)_|-1487838486',
+        ]
+        with patch.dict(yumpkg.__grains__, {'osarch': 'x86_64', 'os': 'RedHat'}), \
+             patch.dict(yumpkg.__salt__, {'cmd.run': MagicMock(return_value=os.linesep.join(rpm_out))}), \
+             patch.dict(yumpkg.__salt__, {'cmd.run_all': MagicMock(return_value={'retcode': 0})}), \
+             patch.dict(yumpkg.__salt__, {'pkg_resource.add_pkg': _add_data}), \
+             patch.dict(yumpkg.__salt__, {'pkg_resource.parse_targets': MagicMock(return_value=({'python-urlgrabber': '0.0.1'} , 'repository'))}), \
+             patch.dict(yumpkg.__salt__, {'pkg_resource.format_pkg_list': pkg_resource.format_pkg_list}), \
+             patch.dict(yumpkg.__salt__, {'config.get': MagicMock()}), \
+             patch.dict(yumpkg.__salt__, {'lowpkg.version_cmp': MagicMock(return_value=-1)}):
+            pkgs = yumpkg.install(name='python-urlgrabber', diff_attr=['version', 'epoch', 'release', 'arch'])
+            self.assertEqual(pkgs, {})
+
+
     def test_list_pkgs(self):
         '''
         Test packages listing.

--- a/tests/unit/utils/test_parsers.py
+++ b/tests/unit/utils/test_parsers.py
@@ -21,6 +21,7 @@ import salt.utils.parsers
 import salt.log.setup as log
 import salt.config
 import salt.syspaths
+from salt.utils.parsers import DaemonMixIn
 
 
 class ErrorMock(object):  # pylint: disable=too-few-public-methods
@@ -828,6 +829,62 @@ class SaltRunOptionParserTestCase(LogSettingsParserTests):
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+class DaemonMixInTestCase(LogSettingsParserTests):
+    '''
+    Tests parsing Salt Master options
+    '''
+    def setUp(self):
+        '''
+        Setting up
+        '''
+        # Set defaults
+        self.default_config = salt.config.DEFAULT_MASTER_OPTS
+
+        # Log file
+        self.log_file = '/tmp/salt_run_parser_test'
+        # Function to patch
+        self.config_func = 'salt.config.master_config'
+
+        # Mock log setup
+        self.setup_log()
+
+        # Assign parser
+        self.parser = salt.utils.parsers.SaltRunOptionParser
+
+        # Set PID
+        self.pid = '/some/fake.pid'
+
+        # Setup mixin
+        self.mixin = DaemonMixIn()
+        self.mixin.info = None
+        self.mixin.config = {}
+        self.mixin.config['pidfile'] = self.pid
+
+    def test_pid_file_deletion(self):
+        '''
+        PIDfile deletion without exception.
+        '''
+        with patch('os.unlink', MagicMock()) as os_unlink:
+            with patch('os.path.isfile', MagicMock(return_value=True)):
+	        with patch.object(self.mixin, 'info', MagicMock()):
+		    self.mixin._mixin_before_exit()
+	            assert self.mixin.info.call_count == 0
+	            assert os_unlink.call_count == 1
+
+    def test_pid_file_deletion_with_oserror(self):
+        '''
+        PIDfile deletion with exception
+        '''
+        with patch('os.unlink', MagicMock(side_effect=OSError())) as os_unlink:
+            with patch('os.path.isfile', MagicMock(return_value=True)):
+	        with patch.object(self.mixin, 'info', MagicMock()):
+		    self.mixin._mixin_before_exit()
+	            assert os_unlink.call_count == 1
+	            self.mixin.info.assert_called_with(
+                       'PIDfile could not be deleted: {}'.format(self.pid))
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
 class SaltSSHOptionParserTestCase(LogSettingsParserTests):
     '''
     Tests parsing Salt Master options
@@ -960,3 +1017,22 @@ class SaltAPIParserTestCase(LogSettingsParserTests):
 
 # Hide the class from unittest framework when it searches for TestCase classes in the module
 del LogSettingsParserTests
+
+
+if __name__ == '__main__':
+    from integration import run_tests  # pylint: disable=import-error,wrong-import-position
+    run_tests(MasterOptionParserTestCase,
+              MinionOptionParserTestCase,
+              ProxyMinionOptionParserTestCase,
+              SyndicOptionParserTestCase,
+              SaltCMDOptionParserTestCase,
+              SaltCPOptionParserTestCase,
+              SaltKeyOptionParserTestCase,
+              SaltCallOptionParserTestCase,
+              SaltRunOptionParserTestCase,
+              SaltSSHOptionParserTestCase,
+              SaltCloudParserTestCase,
+              SPMParserTestCase,
+              SaltAPIParserTestCase,
+              DaemonMixInTestCase,
+              needs_daemon=False)


### PR DESCRIPTION
This PR adds a grain named fqdns to the grains.
fqdns represents all the FQDNs known for the system on all available interfaces (excluding lo).

Note: hostname != FQDN

hostname is the UNIX name of the machine. A machine can have one and only one hostname.
FQDN is host.domain that resolves to an IP address that the machines is answering to.
A machine can have 1+ FQDNs.

Upstream PR:
https://github.com/saltstack/salt/pull/45060

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
