### PR TITLE
setvcpus/setmem: fix return value parsing issue when calling vm_state…

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1029,7 +1029,7 @@ def setmem(vm_, memory, config=False):
         salt '*' virt.setmem <domain> <size>
         salt '*' virt.setmem my_domain 768
     '''
-    if vm_state(vm_) != 'shutdown':
+    if vm_state(vm_)[vm_] != 'shutdown':
         return False
 
     dom = _get_domain(vm_)
@@ -1063,7 +1063,7 @@ def setvcpus(vm_, vcpus, config=False):
         salt '*' virt.setvcpus <domain> <amount>
         salt '*' virt.setvcpus my_domain 4
     '''
-    if vm_state(vm_) != 'shutdown':
+    if vm_state(vm_)[vm_] != 'shutdown':
         return False
 
     dom = _get_domain(vm_)


### PR DESCRIPTION
…(vm_) (bsc#1073618)

### What does this PR do?
setvcpus/setmem: fix return value parsing issue when calling vm_state(vm_)

### What issues does this PR fix or reference?
https://bugzilla.suse.com/show_bug.cgi?id=1073618
https://github.com/saltstack/salt/pull/38675/files