### PR TITLE
salt-ssh: Fix --extra-filerefs to include files even if no refs in states to apply

### DIFF
--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -135,9 +135,9 @@ def lowstate_file_refs(chunks, extras=''):
             elif state.startswith('__'):
                 continue
             crefs.extend(salt_refs(chunk[state]))
+        if saltenv not in refs:
+            refs[saltenv] = []
         if crefs:
-            if saltenv not in refs:
-                refs[saltenv] = []
             refs[saltenv].append(crefs)
     if extras:
         extra_refs = extras.split(',')


### PR DESCRIPTION
Fixes #47496
(cherry picked from commit d67239a)

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
