### PR TITLE
Fix deprecation warning (bsc#1095507)

### DIFF
--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -546,7 +546,7 @@ def thin_sum(cachedir, form='sha1'):
     thintar = gen_thin(cachedir)
     code_checksum_path = os.path.join(cachedir, 'thin', 'code-checksum')
     if os.path.isfile(code_checksum_path):
-        with salt.utils.fopen(code_checksum_path, 'r') as fh:
+        with salt.utils.files.fopen(code_checksum_path, 'r') as fh:
             code_checksum = "'{0}'".format(fh.read().strip())
     else:
         code_checksum = "'0'"


### PR DESCRIPTION
### What does this PR do?

Prevents deprecation warning

### What issues does this PR fix or reference?

bug: https://bugzilla.suse.com/show_bug.cgi?id=1095507
already fixed upstream: https://github.com/saltstack/salt/blob/develop/salt/utils/thin.py#L528

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
