### PR TITLE
Add environment variable to know if yum is invoked from Salt(bsc#1057635)

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -431,7 +431,8 @@ def latest_version(*names, **kwargs):
     out = __salt__['cmd.run_all'](cmd,
                                   output_loglevel='trace',
                                   ignore_retcode=True,
-                                  python_shell=False)
+                                  python_shell=False,
+                                  env={"SALT_RUNNING": '1'})
     if out['retcode'] != 0:
         if out['stderr']:
             # Check first if this is just a matter of the packages being
@@ -745,7 +746,8 @@ def list_repo_pkgs(*args, **kwargs):
             yum_version = _LooseVersion(
                 __salt__['cmd.run'](
                     ['yum', '--version'],
-                    python_shell=False
+                    python_shell=False,
+                    env={"SALT_RUNNING": '1'}
                 ).splitlines()[0].strip()
             )
             return yum_version < _LooseVersion('3.4.3')
@@ -768,7 +770,8 @@ def list_repo_pkgs(*args, **kwargs):
                 cmd_prefix + [pkg_src],
                 output_loglevel='trace',
                 ignore_retcode=True,
-                python_shell=False
+                python_shell=False,
+                env={"SALT_RUNNING": '1'}
             )
             if out['retcode'] == 0:
                 _parse_output(out['stdout'], strict=True)
@@ -782,7 +785,8 @@ def list_repo_pkgs(*args, **kwargs):
             out = __salt__['cmd.run_all'](cmd,
                                           output_loglevel='trace',
                                           ignore_retcode=True,
-                                          python_shell=False)
+                                          python_shell=False,
+                                          env={"SALT_RUNNING": '1'})
             if out['retcode'] != 0 and 'Error:' in out['stdout']:
                 continue
             _parse_output(out['stdout'])
@@ -828,7 +832,8 @@ def list_upgrades(refresh=True, **kwargs):
     out = __salt__['cmd.run_all'](cmd,
                                   output_loglevel='trace',
                                   ignore_retcode=True,
-                                  python_shell=False)
+                                  python_shell=False,
+                                  env={"SALT_RUNNING": '1'})
     if out['retcode'] != 0 and 'Error:' in out:
         return {}
 
@@ -958,12 +963,13 @@ def refresh_db(**kwargs):
             clean_cmd.extend(args)
             update_cmd.extend(args)
 
-    __salt__['cmd.run'](clean_cmd, python_shell=False)
+    __salt__['cmd.run'](clean_cmd, python_shell=False, env={"SALT_RUNNING": '1'})
     if check_update_:
         result = __salt__['cmd.retcode'](update_cmd,
                                          output_loglevel='trace',
                                          ignore_retcode=True,
-                                         python_shell=False)
+                                         python_shell=False,
+                                         env={"SALT_RUNNING": '1'})
         return retcodes.get(result, False)
     return True
 
@@ -1429,7 +1435,8 @@ def install(name=None,
                 cmd,
                 output_loglevel='trace',
                 python_shell=False,
-                redirect_stderr=True
+                redirect_stderr=True,
+                env={"SALT_RUNNING": '1'}
             )
             if out['retcode'] != 0:
                 errors.append(out['stdout'])
@@ -1449,7 +1456,8 @@ def install(name=None,
                 cmd,
                 output_loglevel='trace',
                 python_shell=False,
-                redirect_stderr=True
+                redirect_stderr=True,
+                env={"SALT_RUNNING": '1'}
             )
             if out['retcode'] != 0:
                 errors.append(out['stdout'])
@@ -1469,7 +1477,8 @@ def install(name=None,
                 cmd,
                 output_loglevel='trace',
                 python_shell=False,
-                redirect_stderr=True
+                redirect_stderr=True,
+                env={"SALT_RUNNING": '1'}
             )
             if out['retcode'] != 0:
                 errors.append(out['stdout'])
@@ -1654,7 +1663,8 @@ def upgrade(name=None,
 
     result = __salt__['cmd.run_all'](cmd,
                                      output_loglevel='trace',
-                                     python_shell=False)
+                                     python_shell=False,
+                                     env={"SALT_RUNNING": '1'})
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
     ret = salt.utils.compare_dicts(old, new)
@@ -1745,7 +1755,8 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=W0613
     out = __salt__['cmd.run_all'](
         [_yum(), '-y', 'remove'] + targets,
         output_loglevel='trace',
-        python_shell=False
+        python_shell=False,
+        env={"SALT_RUNNING": '1'}
     )
 
     if out['retcode'] != 0 and out['stderr']:
@@ -1882,7 +1893,8 @@ def hold(name=None, pkgs=None, sources=None, normalize=True, **kwargs):  # pylin
             else:
                 out = __salt__['cmd.run_all'](
                     [_yum(), 'versionlock', target],
-                    python_shell=False
+                    python_shell=False,
+                    env={"SALT_RUNNING": '1'}
                 )
 
                 if out['retcode'] == 0:
@@ -1991,7 +2003,8 @@ def unhold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W06
             else:
                 out = __salt__['cmd.run_all'](
                     [_yum(), 'versionlock', 'delete'] + search_locks,
-                    python_shell=False
+                    python_shell=False,
+                    env={"SALT_RUNNING": '1'}
                 )
 
                 if out['retcode'] == 0:
@@ -2042,7 +2055,8 @@ def list_holds(pattern=__HOLD_PATTERN, full=True):
     _check_versionlock()
 
     out = __salt__['cmd.run']([_yum(), 'versionlock', 'list'],
-                              python_shell=False)
+                              python_shell=False,
+                              env={"SALT_RUNNING": '1'})
     ret = []
     for line in salt.utils.itertools.split(out, '\n'):
         match = _get_hold(line, pattern=pattern, full=full)
@@ -2107,7 +2121,8 @@ def group_list():
     out = __salt__['cmd.run_stdout'](
         [_yum(), 'grouplist', 'hidden'],
         output_loglevel='trace',
-        python_shell=False
+        python_shell=False,
+        env={"SALT_RUNNING": '1'}
     )
     key = None
     for line in salt.utils.itertools.split(out, '\n'):
@@ -2174,7 +2189,8 @@ def group_info(name, expand=False):
     out = __salt__['cmd.run_stdout'](
         cmd,
         output_loglevel='trace',
-        python_shell=False
+        python_shell=False,
+        env={"SALT_RUNNING": '1'}
     )
 
     g_info = {}
@@ -2834,7 +2850,8 @@ def download(*packages):
     __salt__['cmd.run'](
         cmd,
         output_loglevel='trace',
-        python_shell=False
+        python_shell=False,
+        env={"SALT_RUNNING": '1'}
     )
     ret = {}
     for dld_result in os.listdir(CACHE_DIR):
@@ -2909,7 +2926,8 @@ def _get_patches(installed_only=False):
     cmd = [_yum(), '--quiet', 'updateinfo', 'list', 'all']
     ret = __salt__['cmd.run_stdout'](
         cmd,
-        python_shell=False
+        python_shell=False,
+        env={"SALT_RUNNING": '1'}
     )
     for line in salt.utils.itertools.split(ret, os.linesep):
         inst, advisory_id, sev, pkg = re.match(r'([i|\s]) ([^\s]+) +([^\s]+) +([^\s]+)',


### PR DESCRIPTION
### What does this PR do?
Back port of https://github.com/openSUSE/salt/pull/90

Add an environment variable in the yum invocation to know if yum is invoked from Salt
Since yum (and zypper) allow plugins, it is very useful knowing if yum/zypper is invoked from Salt

### What issues does this PR fix or reference?
https://github.com/SUSE/spacewalk/issues/3833

### Previous Behavior
Everytime yum is called from Salt, there's no way to know where was it called from.

### New Behavior
Everytime yum is called from Salt, we can actually know if was invoked from Salt so plugins could react accordingly in case it's needed (like zypper module is already doing).

### Tests written?

No
