### PR TITLE
Add missing dateutils import (bsc#1099945)

### DIFF
--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -28,6 +28,7 @@ else:
 
 # Import Salt libs
 import salt.utils.data
+import salt.utils.dateutils
 import salt.utils.http
 import salt.utils.files
 import salt.utils.platform


### PR DESCRIPTION
### What does this PR do?

Bugfix (L3)

### What issues does this PR fix or reference?

https://bugzilla.suse.com/show_bug.cgi?id=1099945

### Previous Behavior

`strftime` Jinja2 filter wasn't available due to the missing module import.

