### PR TITLE
Group gid fix

### DIFF
--- a/salt/states/group.py
+++ b/salt/states/group.py
@@ -72,9 +72,16 @@ def _changes(name,
             delusers = [salt.utils.win_functions.get_sam_name(user).lower() for user in delusers]
 
     change = {}
+    ret = {}
     if gid:
-        if lgrp['gid'] != gid:
-            change['gid'] = gid
+        try:
+            gid = int(gid)
+            if lgrp['gid'] != gid:
+                change['gid'] = gid
+        except (TypeError, ValueError):
+            ret['result'] = False
+            ret['comment'] = 'Invalid gid'
+            return ret
 
     if members:
         # -- if new member list if different than the current


### PR DESCRIPTION
### What does this PR do?

Fixes the _changes() function to correctly evaluate  the group id.


### What issues does this PR fix or reference?

gid was being passed as a string, while the lgrp['gid'] was being passed as an integer.

Added casting or string ``gid`` to integer for accurate comparison.


### Previous Behavior

The return was false even though the group was successfully created.



### New Behavior

This updated code now compares an integer with an integer for the gid.

### Tests written?

No

### Commits signed with GPG?

No

###  Previous Error 

**Evaluation**

``` python
gid  == <type 'str'>
lgrp['gid'] == <type 'int'>
```

**Output**

```

    [ERROR   ] {'Failed': {'gid': '1030'}}
    local:
    ----------
           ID: oinstall_group
     Function: group.present
        Name: oinstall
      Result: False
      Comment: Group {0} has been created but, some changes could not be applied
     Started: 08:59:43.531683
     Duration: 88.538 ms
     Changes:   
              ----------
              Failed:
                  ----------
                  gid:
                      1030
```
###  Fixed Evaluation

**Evaluation**

``` python
    if gid:
       try:
           gid = int(gid)
           if lgrp['gid'] != gid:
                change['gid'] = gid
       except (TypeError, ValueError):
           ret['result'] = False
           ret['comment'] = 'Invalid gid'
           return ret

```

Changed evaluation from (string != int) to (int != int) 

###  Versions tested

**SLES12SP3** / Salt 2016.11.4 (Carbon)
**Oracle Linux 7** / Salt 2018.3.1 (Oxygen)

State used for testing:

```
oinstall_group:
  group.present:
    - name: oinstall
    - gid: '1030'
```
