### PR TITLE
Fix #46492: file.blockreplace throws IndexError.

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2560,7 +2560,7 @@ def blockreplace(path,
 
                         # Trim any trailing new lines to avoid unwanted
                         # additional new lines
-                        while not split_content[-1]:
+                        while split_content and not split_content[-1]:
                             split_content.pop()
 
                         # push new block content in file


### PR DESCRIPTION
This was discovered to affect SUSE CaaS Platform 3, during a test-upgrade of salt
to version 2018.3.0. The update orchestration uses this module and breaks.

### What does this PR do?

It fixes the upstream issue saltstack/salt#46492 (also fixes [bsc#1101812](https://bugzilla.suse.com/show_bug.cgi?id=1101812)).

### What issues does this PR fix or reference?

saltstack/salt#46492

### Previous Behavior

Does not verify that split_content actually has a value.

### New Behavior
Does verify that split_content actually has a value.

### Tests written?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
