### PR TITLE
Workaround for #48020

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -239,12 +239,12 @@ class CkMinions(object):
         Retreive complete minion list from PKI dir.
         Respects cache if configured
         '''
-        if self.opts.get('__role') == 'master' and self.opts.get('__cli') == 'salt-run':
-            # Compiling pillar directly on the master, just return the master's
-            # ID as that is the only one that is available.
-            return [self.opts['id']]
         minions = []
         pki_cache_fn = os.path.join(self.opts['pki_dir'], self.acc, '.key_cache')
+        try:
+            os.makedirs(os.path.dirname(pki_cache_fn))
+        except OSError:
+            pass
         try:
             if self.opts['key_cache'] and os.path.exists(pki_cache_fn):
                 log.debug('Returning cached minion list')


### PR DESCRIPTION
This issue affects SUSE CaaS Platform and was discovered when testing an upgrade
to salt-2018. It breaks the orchestrate runner that makes use of the mine on the
master.

What does this PR do?
Implements a workaround for saltstack/salt#48020 (also bnc#1100142).

It restores the previous behavior (2016-salt) version for CaaS Platform, where mine.get could be used on the master.

What issues does this PR fix or reference?
saltstack/salt#48020

Previous Behavior
mine.get would return no nodes when run on the master.

New Behavior
mine.get returns the correct nodes when run on the master.

Tests written?
No

Please review Salt's Contributing Guide for best practices.

Replaces https://github.com/openSUSE/salt/pull/102 - backports https://github.com/saltstack/salt/pull/48765 from upstream.