### PR TITLE
Correct python2 StringIO import in hashutil module

### DIFF
--- a/salt/modules/hashutil.py
+++ b/salt/modules/hashutil.py
@@ -17,9 +17,10 @@ import salt.utils.hashutils
 import salt.utils.stringutils
 
 if six.PY2:
-    import StringIO
+    from StringIO import StringIO
+    BytesIO = StringIO
 elif six.PY3:
-    from io import StringIO
+    from io import BytesIO, StringIO
 
 
 def digest(instr, checksum='md5'):
@@ -155,13 +156,13 @@ def base64_encodefile(fname):
 
         salt '*' hashutil.base64_encodefile /path/to/binary_file
     '''
-    encoded_f = StringIO.StringIO()
+    encoded_f = BytesIO()
 
     with salt.utils.files.fopen(fname, 'rb') as f:
         base64.encode(f, encoded_f)
 
     encoded_f.seek(0)
-    return encoded_f.read()
+    return salt.utils.stringutils.to_str(encoded_f.read())
 
 
 def base64_decodestring(instr):
@@ -192,7 +193,7 @@ def base64_decodefile(instr, outfile):
 
         salt '*' hashutil.base64_decodefile instr='Z2V0IHNhbHRlZAo=' outfile='/path/to/binary_file'
     '''
-    encoded_f = StringIO.StringIO(instr)
+    encoded_f = StringIO(instr)
 
     with salt.utils.files.fopen(outfile, 'wb') as f:
         base64.decode(encoded_f, f)


### PR DESCRIPTION
Call StringIO class directly instead of using the python2 module.class way.

### What does this PR do?

Fix `AttributeError` in the hashutil module.

### What issues does this PR fix or reference?

https://bugzilla.suse.com/show_bug.cgi?id=1107311

### Previous Behavior

`base64_encodefile` would throw an `AttributeError`.

### New Behavior

`base64_encodefile` will no longer throw an error.

### Tests written?

No

But to test it I used:

`/srv/salt/b64/init.sls`:

```yaml
/tmp/hello:
  file.managed:
    - create: True
    - contents:
      - Hello World
```

`/srv/salt/b64/hash.sls`:

```yaml
/tmp/hashed_hello:
  file.managed:
    - contents: {{ salt.hashutil.base64_encodefile('/tmp/hello') }}
```

`/srv/salt/b64/unhash.sls`:

```yaml
/tmp/unhashed_hello:
  module.run:
    - name: hashutil.base64_decodefile
    - instr: {{ salt.file.read('/tmp/hashed_hello') }}
    - outfile: /tmp/unhashed_hello
```

The then just run them in the right order:

```
salt '*' state.apply b64.init
salt '*' state.apply b64.hash
salt '*' state.apply b64.unhash
```

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
