### PR TITLE
fix azurearm deps bsc#1107333

### DIFF
--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -74,7 +74,6 @@ import salt.utils.cloud
 import salt.utils.data
 import salt.utils.files
 import salt.utils.yaml
-from salt.utils.versions import LooseVersion
 from salt.ext import six
 import salt.version
 from salt.exceptions import (

--- a/salt/cloud/clouds/azurearm.py
+++ b/salt/cloud/clouds/azurearm.py
@@ -67,6 +67,7 @@ import logging
 import pprint
 import base64
 import collections
+import pkgutil
 import salt.cache
 import salt.config as config
 import salt.utils.cloud
@@ -124,9 +125,12 @@ try:
     from azure.mgmt.storage import StorageManagementClient
     from azure.mgmt.web import WebSiteManagementClient
     from msrestazure.azure_exceptions import CloudError
-    from azure.multiapi.storage.v2016_05_31 import CloudStorageAccount
-    from azure.cli import core
-    HAS_LIBS = LooseVersion(core.__version__) >= LooseVersion("2.0.12")
+    if pkgutil.find_loader('azure.multiapi'):
+        # use multiapi version if available
+        from azure.multiapi.storage.v2016_05_31 import CloudStorageAccount
+    else:
+        from azure.storage import CloudStorageAccount
+    HAS_LIBS = True
 except ImportError:
     pass
 # pylint: enable=wrong-import-position,wrong-import-order
@@ -159,8 +163,7 @@ def __virtual__():
             False,
             'The following dependencies are required to use the AzureARM driver: '
             'Microsoft Azure SDK for Python >= 2.0rc5, '
-            'Microsoft Azure Storage SDK for Python >= 0.32, '
-            'Microsoft Azure CLI >= 2.0.12'
+            'Microsoft Azure Storage SDK for Python >= 0.32'
         )
 
     global cache  # pylint: disable=global-statement,invalid-name


### PR DESCRIPTION
### What does this PR do?
This PR removes the dependecy of the azurearm driver on azure-cli (which is not used) and allows using the official azure-storage-sdk in case the multiapi package is not available (as it is the case on SLES 12 currently). The changes were merged upstream (https://github.com/saltstack/salt/pull/49696) and cherry-picked from there.

### What issues does this PR fix or reference?
https://bugzilla.suse.com/show_bug.cgi?id=1107333
