### PR TITLE
Fix usermod options for SLE11 (bsc#1117017)

### DIFF
--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -414,8 +414,14 @@ def chgroups(name, groups, append=False, root=None):
 
     if __grains__['kernel'] != 'OpenBSD':
         if append and __grains__['kernel'] != 'AIX':
-            cmd.append('-a')
-        cmd.append('-G')
+            if __grains__['osfullname'] == 'SLES' and __grains__['osmajorrelease'] == 11:
+                # SLE11 doesn't support "-a" and "-G" together with the for usermod
+                # See https://bugzilla.suse.com/show_bug.cgi?id=1117017
+                cmd.append('-A')
+            else:
+                cmd.append('-a')
+        if '-A' not in cmd:
+            cmd.append('-G')
     else:
         if append:
             cmd.append('-G')

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -414,7 +414,7 @@ def chgroups(name, groups, append=False, root=None):
 
     if __grains__['kernel'] != 'OpenBSD':
         if append and __grains__['kernel'] != 'AIX':
-            if __grains__['osfullname'] == 'SLES' and __grains__['osmajorrelease'] == 11:
+            if __grains__['osfullname'] == 'SLES' and __grains__['osmajorrelease'] == '11':
                 # SLE11 doesn't support "-a" and "-G" together with the for usermod
                 # See https://bugzilla.suse.com/show_bug.cgi?id=1117017
                 cmd.append('-A')


### PR DESCRIPTION
### What does this PR do?

Bugfix.

### What issues does this PR fix or reference?

bsc#1117017

L3: salt-minion error while bootstrapping sles11sp4:
https://bugzilla.suse.com/show_bug.cgi?id=1117017

### Previous Behavior

usermod on SLE11 does not accept `-a`.

