### PR TITLE
Return the expected powerpc os arch (bsc#1117995)

### DIFF
--- a/salt/utils/pkg/rpm.py
+++ b/salt/utils/pkg/rpm.py
@@ -54,8 +54,11 @@ def get_osarch():
             stderr=subprocess.PIPE).communicate()[0]
     else:
         ret = ''.join(list(filter(None, platform.uname()[-2:]))[-1:])
-
-    return salt.utils.stringutils.to_str(ret).strip() or 'unknown'
+    ret = salt.utils.stringutils.to_str(ret).strip() or 'unknown'
+    ARCH_FIXES_MAPPING = {
+        "powerpc64le": "ppc64le"
+    }
+    return ARCH_FIXES_MAPPING.get(ret, ret)
 
 
 def check_32(arch, osarch=None):


### PR DESCRIPTION
## I open this PR in order to keep track of the PTF-quick-fix and to discuss the proper solution for [bsc#1117995](https://bugzilla.suse.com/show_bug.cgi?id=1117995)


### What does this PR do?
Fixes https://bugzilla.suse.com/show_bug.cgi?id=1117995

`grains.get osarch` returns now powerpc64le which comes from `rpm --eval "%{_host_cpu}"`, before is was the same as `cpuarch` grain (ppc64le)



### What issues does this PR fix or reference?

This bug was triggered by the following changes:
  - https://github.com/SUSE/salt-board/issues/119
  - https://github.com/saltstack/salt/commit/746d2be3902fd311b34cd32259cfdeac2508d800 https://bugzilla.suse.com/show_bug.cgi?id=1114197

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
