### PR TITLE
Fix regression in dynamic pillarenv (bsc#1124277)

### DIFF
--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -2952,7 +2952,12 @@ class GitPillar(GitBase):
             cachedir = self.do_checkout(repo)
             if cachedir is not None:
                 # Figure out which environment this remote should be assigned
-                if repo.env:
+                if repo.branch == '__env__':
+                    env = self.opts.get('pillarenv') \
+                        or self.opts.get('saltenv') \
+                        or self.opts['{0}_base'.format(self.role)] \
+                        or 'base'
+                elif repo.env:
                     env = repo.env
                 else:
                     base_branch = self.opts['{0}_base'.format(self.role)]

--- a/tests/integration/pillar/test_git_pillar.py
+++ b/tests/integration/pillar/test_git_pillar.py
@@ -1448,6 +1448,27 @@ class TestPygit2HTTP(GitPillarHTTPTestBase):
             ''')
         self.assertEqual(ret, expected)
 
+    def test__env___with_pillarenv_base(self):
+        ret = self.get_pillar('''\
+            file_ignore_regex: []
+            file_ignore_glob: []
+            git_pillar_provider: pygit2
+            cachedir: {cachedir}
+            extension_modules: {extmods}
+            pillarenv: base
+            ext_pillar:
+              - git:
+                - __env__ {url}
+            ''')
+        self.assertEqual(
+            ret,
+            {'branch': 'master',
+             'mylist': ['master'],
+             'mydict': {'master': True,
+                        'nested_list': ['master'],
+                        'nested_dict': {'master': True}}}
+        )
+
     def test_includes_enabled(self):
         '''
         Test with git_pillar_includes enabled. The top_only branch references


### PR DESCRIPTION
Proposed patch for https://bugzilla.novell.com/show_bug.cgi?id=1124277

Upstream code is different (probably because of other backportings): https://github.com/saltstack/salt/blob/2018.3/salt/utils/gitfs.py#L2992-L3019

Just using the upstream implementation of that function doesn't work because it needs some changes to code outside the function. Since it is hard to establish what exactly needs to be ported from upstream, I have decided to produce a patch that fixes the problem we have even though it's not exactly as upstream.

I hope to unify with upstream at a later time.