### PR TITLE
Temporary fix pkg.info_installed retcode 1 (bsc@1125015)

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1714,7 +1714,6 @@ class Minion(MinionBase):
                 )
                 ret['return'] = 'ERROR: {0}'.format(exc)
                 ret['out'] = 'nested'
-                ret['retcode'] = salt.defaults.exitcodes.EX_GENERIC
             except SaltInvocationError as exc:
                 log.error(
                     'Problem executing \'%s\': %s',


### PR DESCRIPTION
### What does this PR do?
In 2018.3.0 `retcode` is not present in the job return. Removing it temporary to allow pkg.info_installed to continue to work for https://github.com/SUSE/salt-board/issues/251

## NOTE
This is a temporary fix. Upstream issue: https://github.com/saltstack/salt/issues/51620