### PR TITLE
Strip trailing "/" from repo.uri when comparing repos in apktpkg.mod_repo

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2462,7 +2462,7 @@ def mod_repo(repo, saltenv='base', **kwargs):
         # and the resulting source line.  The idea here is to ensure
         # we are not returning bogus data because the source line
         # has already been modified on a previous run.
-        repo_matches = source.type == repo_type and source.uri == repo_uri and source.dist == repo_dist
+        repo_matches = source.type == repo_type and source.uri.rstrip('/') == repo_uri.rstrip('/') and source.dist == repo_dist
         kw_matches = source.dist == kw_dist and source.type == kw_type
 
         if repo_matches or kw_matches:


### PR DESCRIPTION
### What does this PR do?

Port of upstream https://github.com/saltstack/salt/pull/51654

### Tests written?

No

### Commits signed with GPG?

No
