### PR TITLE
Do not report patches as installed when not all the related packages are installed (bsc#1128061)

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -3166,12 +3166,18 @@ def _get_patches(installed_only=False):
     for line in salt.utils.itertools.split(ret, os.linesep):
         inst, advisory_id, sev, pkg = re.match(r'([i|\s]) ([^\s]+) +([^\s]+) +([^\s]+)',
                                                line).groups()
-        if inst != 'i' and installed_only:
-            continue
-        patches[advisory_id] = {
-            'installed': True if inst == 'i' else False,
-            'summary': pkg
-        }
+        if not advisory_id in patches:
+            patches[advisory_id] = {
+                'installed': True if inst == 'i' else False,
+                'summary': [pkg]
+            }
+        else:
+            patches[advisory_id]['summary'].append(pkg)
+            if inst != 'i':
+                patches[advisory_id]['installed'] = False
+
+    if installed_only:
+        patches = {k: v for k, v in patches.items() if v['installed']}
     return patches
 
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue on "yum" Salt module that makes the patches looks as installed even if they are not installed for all the related packages.

### What issues does this PR fix or reference?

https://github.com/SUSE/salt-board/issues/276

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
