### PR TITLE
[WIP] Set UUID from XEN sysfs if not set before

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2451,6 +2451,17 @@ def _hw_data(osdata):
                 grains['product'] = res.group(1).strip().replace("'", "")
                 break
 
+    # on XEN PV there is no bios, let's try to read at least the machine UUID if not set before
+    if grains.get('uuid') is None and os.path.exists('/sys/hypervisor/uuid'):
+        try:
+            with salt.utils.files.fopen('/sys/hypervisor/uuid', 'r') as fhr:
+                xen_uuid = _clean_value('uuid', salt.utils.stringutils.to_unicode(fhr.read().strip(), errors='replace'))
+                nil_id = uuid.UUID('00000000-0000-0000-0000-000000000000')
+                if uuid.UUID(xen_uuid) != nil_id:
+                    grains['uuid'] = xen_uuid
+        except (IOError, OSError, KeyError):
+            pass
+
     return grains
 
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2265,9 +2265,9 @@ def _hw_data(osdata):
             'uuid': __salt__['smbios.get']('system-uuid')
         }
         grains = dict([(key, val) for key, val in grains.items() if val is not None])
-        uuid = __salt__['smbios.get']('system-uuid')
-        if uuid is not None:
-            grains['uuid'] = uuid.lower()
+        system_uuid = __salt__['smbios.get']('system-uuid')
+        if system_uuid is not None:
+            grains['uuid'] = system_uuid.lower()
         for serial in ('system-serial-number', 'chassis-serial-number', 'baseboard-serial-number'):
             serial = __salt__['smbios.get'](serial)
             if serial is not None:


### PR DESCRIPTION
### What does this PR do?

On XEN PV guest, there is no bios and commands like dmidecode or smbios
can't be used for determining UUID of the machine. XEN exports this
value in /sys/hypervisor/uuid file, when XEN_SYS_HYPERVISOR kernel
option is enabled and this patch makes use of it.


### What issues does this PR fix or reference?

### Previous Behavior
On XEN PV guests, the uuid grain was not set.

### New Behavior
The uuid grain is set on XEN PNV guests

### Tests written?

Not **yet**

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
