### PR TITLE
Open suse 2016.11.10 port optimization order

### DIFF
--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -264,6 +264,9 @@ VALID_OPTS = {
     # The type of hashing algorithm to use when doing file comparisons
     'hash_type': str,
 
+    # Order of preference for optimized .pyc files (PY3 only)
+    'optimization_order': list,
+
     # Refuse to load these modules
     'disable_modules': list,
 
@@ -1090,6 +1093,7 @@ DEFAULT_MINION_OPTS = {
     'gitfs_ssl_verify': True,
     'gitfs_saltenv': [],
     'hash_type': 'sha256',
+    'optimization_order': [0, 1, 2],
     'disable_modules': [],
     'disable_returners': [],
     'whitelist_modules': [],
@@ -1360,6 +1364,7 @@ DEFAULT_MASTER_OPTS = {
     'fileserver_limit_traversal': False,
     'max_open_files': 100000,
     'hash_type': 'sha256',
+    'optimization_order': [0, 1, 2],
     'conf_file': os.path.join(salt.syspaths.CONFIG_DIR, 'master'),
     'open_mode': False,
     'auto_accept': False,


### PR DESCRIPTION
### What does this PR do?
Fixes the missing `optimization_order` issue:

the test.opts_pkg returns the options from the sles11sp4(salt-2016.11.10 in the salt-ssh thin) but does not have 'optimization_order' parameter (the default [0, 1, 2]) - this causes the empty lazyloader.file_mapping issue which causes the 'state.apply' KeyError issue on the master https://github.com/openSUSE/salt/blob/openSUSE-2019.2.0/salt/client/ssh/__init__.py#L1159

### What issues does this PR fix or reference?
Porting https://github.com/saltstack/salt/commit/6fc8da5bab37d4e250e01bc220d6153be2018076
