### PR TITLE
Introduce presence ping timeout parameters for sync batch

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -83,6 +83,9 @@ def batch_get_opts(
         if key not in opts:
             opts[key] = val
 
+    opts['batch_presence_ping_timeout'] = kwargs.get('batch_presence_ping_timeout', opts['timeout'])
+    opts['batch_presence_ping_gather_job_timeout'] = kwargs.get('batch_presence_ping_gather_job_timeout', opts['gather_job_timeout'])
+
     return opts
 
 
@@ -119,7 +122,7 @@ class Batch(object):
         args = [self.opts['tgt'],
                 'test.ping',
                 [],
-                self.opts['timeout'],
+                self.opts.get('batch_presence_ping_timeout', self.opts['timeout']),
                 ]
 
         selected_target_option = self.opts.get('selected_target_option', None)
@@ -130,7 +133,7 @@ class Batch(object):
 
         self.pub_kwargs['yield_pub_data'] = True
         ping_gen = self.local.cmd_iter(*args,
-                                       gather_job_timeout=self.opts['gather_job_timeout'],
+                                       gather_job_timeout=self.opts.get('batch_presence_ping_gather_job_timeout', self.opts['gather_job_timeout']),
                                        **self.pub_kwargs)
 
         # Broadcast to targets


### PR DESCRIPTION
### What does this PR do?

Introduce "batch_presence_ping_timeout" and "batch_presence_ping_gather_job_timeout" parameters for synchronous batching mode.
If this parameters are not sent, the "timeout" and "gather_job_timeout" are used as default instead.

### What issues does this PR fix or reference?

### Previous Behavior
Before, "timeout" and "gather_job_tmeout" parameters were used for the presence ping in synchronous batching mode.

### New Behavior
presence ping in synchronous batching mode uses "timeout" and "gather_job_tmeout" parameters as default values, but can be overridden in the request with "batch_presence_ping_timeout" and "batch_presence_ping_gather_job_timeout".

### Tests written?
Already existing tests still passing.

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
