### PR TITLE
Try/except undefineFlags() as this operation is not supported on bhyve

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -3189,7 +3189,10 @@ def purge(vm_, dirs=False, removables=None, **kwargs):
             shutil.rmtree(dir_)
     if getattr(libvirt, 'VIR_DOMAIN_UNDEFINE_NVRAM', False):
         # This one is only in 1.2.8+
-        dom.undefineFlags(libvirt.VIR_DOMAIN_UNDEFINE_NVRAM)
+        try:
+            dom.undefineFlags(libvirt.VIR_DOMAIN_UNDEFINE_NVRAM)
+        except Exception:
+            dom.undefine()
     else:
         dom.undefine()
     conn.close()


### PR DESCRIPTION
(cherry picked from commit 29a44aceb1a73347ac07dd241b4a64a4a38cef6e)

### What does this PR do?

It fixes virt.purge() on all non-KVM hypervisors. For instance on Xen, `virt.purge` would simply throw an exception about unsupported flag.

### What issues does this PR fix or reference?

Issue saltstack/salt#52547

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
