### PR TITLE
make sure not to send invalid information

### DIFF
--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -87,7 +87,7 @@ def _localectl_status():
                         ret[ctl_key] = {}
                     ret[ctl_key][loc_set[0]] = loc_set[1]
             else:
-                ret[ctl_key] = ctl_data
+                ret[ctl_key] = {'data': None if ctl_data == 'n/a' else ctl_data}
     if not ret:
         log.debug("Unable to find any locale information inside the following data:\n%s", locale_ctl_out)
         raise CommandExecutionError('Unable to parse result of "localectl"')
@@ -102,7 +102,7 @@ def _localectl_set(locale=''):
     '''
     locale_params = _parse_dbus_locale() if dbus is not None else _localectl_status().get('system_locale', {})
     locale_params['LANG'] = six.text_type(locale)
-    args = ' '.join(['{0}="{1}"'.format(k, v) for k, v in six.iteritems(locale_params)])
+    args = ' '.join(['{0}="{1}"'.format(k, v) for k, v in six.iteritems(locale_params) if v is not None])
     return not __salt__['cmd.retcode']('localectl set-locale {0}'.format(args), python_shell=False)
 
 

--- a/tests/unit/modules/test_localemod.py
+++ b/tests/unit/modules/test_localemod.py
@@ -79,9 +79,36 @@ class LocalemodTestCase(TestCase, LoaderModuleMockMixin):
         assert 'LANG' in out['system_locale']
         assert 'LANGUAGE' in out['system_locale']
         assert out['system_locale']['LANG'] == out['system_locale']['LANGUAGE'] == 'de_DE.utf8'
-        assert out['vc_keymap'] == 'n/a'
-        assert out['x11_layout'] == 'us'
-        assert out['x11_model'] == 'pc105'
+        assert isinstance(out['vc_keymap'], dict)
+        assert 'data' in out['vc_keymap']
+        assert out['vc_keymap']['data'] is None
+        assert isinstance(out['x11_layout'], dict)
+        assert 'data' in out['x11_layout']
+        assert out['x11_layout']['data'] == 'us'
+        assert isinstance(out['x11_model'], dict)
+        assert 'data' in out['x11_model']
+        assert out['x11_model']['data'] == 'pc105'
+
+    @patch('salt.utils.path.which', MagicMock(return_value="/usr/bin/localctl"))
+    @patch('salt.modules.localemod.__salt__', {'cmd.run': MagicMock(return_value=locale_ctl_notset)})
+    def test_localectl_status_parser_notset(self):
+        '''
+        Test localectl status parser.
+        :return:
+        '''
+        out = localemod._localectl_status()
+        assert isinstance(out, dict)
+        for key in ['system_locale', 'vc_keymap', 'x11_layout']:
+            assert key in out
+        assert isinstance(out['system_locale'], dict)
+        assert 'data' in out['system_locale']
+        assert out['system_locale']['data'] is None
+        assert isinstance(out['vc_keymap'], dict)
+        assert 'data' in out['vc_keymap']
+        assert out['vc_keymap']['data'] is None
+        assert isinstance(out['x11_layout'], dict)
+        assert 'data' in out['x11_layout']
+        assert out['x11_layout']['data'] is None
 
     @patch('salt.modules.localemod.dbus', MagicMock())
     def test_dbus_locale_parser_matches(self):


### PR DESCRIPTION
### What does this PR do?

Upsteam PR can be found here: https://github.com/saltstack/salt/pull/47280

Localectl outputs n/a sometimes when stuff is not set, instead of just not
outputting anything.  Actually put None in the variable when parsing it, and do
not add it to the localectl set command.

update localemod tests


### What issues does this PR fix or reference?

bsc#1128974

### Previous Behavior

locale module was not working

### New Behavior

locale module should be working again