### PR TITLE
[WIP] batch.py: avoid exception when minion does not respond (bsc#1135507)

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -315,6 +315,11 @@ class Batch(object):
                     if self.opts.get('failhard') and data['ret']['retcode'] > 0:
                         failhard = True
 
+                # avoid an exception if the minion does not respond.
+                if data.get("failed") is True:
+                    log.debug('Minion %s failed to respond: data=%s', minion, data)
+                    data = {'ret': 'Minion did not return. [Failed]', 'retcode': salt.defaults.exitcodes.EX_GENERIC}
+
                 if self.opts.get('raw'):
                     ret[minion] = data
                     yield data


### PR DESCRIPTION
Porting: https://github.com/saltstack/salt/pull/53159
---

We have several issues reporting that salt is throwing exception when
the minion does not respond. This change avoid the exception adding a
default data to the minion when it fails to respond. This patch based
on the patch suggested by @roskens.

Issues #46876 #48509 #50238
bsc#1135507

Signed-off-by: José Guilherme Vanz <jguilhermevanz@suse.com>