### PR TITLE
Fix aptpkg systemd call (bsc#1143301)

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -165,7 +165,7 @@ def _call_apt(args, scope=True, **kwargs):
     '''
     cmd = []
     if scope and salt.utils.systemd.has_scope(__context__) and __salt__['config.get']('systemd.scope', True):
-        cmd.extend(['systemd-run', '--scope'])
+        cmd.extend(['systemd-run', '--scope', '--description "{0}"'.format(__name__)])
     cmd.extend(args)
 
     params = {'output_loglevel': 'trace',

--- a/tests/unit/modules/test_aptpkg.py
+++ b/tests/unit/modules/test_aptpkg.py
@@ -544,7 +544,7 @@ class AptUtilsTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(aptpkg.__salt__, {'cmd.run_all': MagicMock(), 'config.get': MagicMock(return_value=True)}):
             aptpkg._call_apt(['apt-get', 'purge', 'vim'])  # pylint: disable=W0106
             aptpkg.__salt__['cmd.run_all'].assert_called_once_with(
-                ['systemd-run', '--scope', 'apt-get', 'purge', 'vim'], env={},
+                ['systemd-run', '--scope', '--description "salt.modules.aptpkg"', 'apt-get', 'purge', 'vim'], env={},
                 output_loglevel='trace', python_shell=False)
 
     def test_call_apt_with_kwargs(self):


### PR DESCRIPTION
### What does this PR do?
Sets a `--description` for the systemd-run command called by aptpkg to avoid long description strings that would cause crashes.

### What issues does this PR fix or reference?
Fixes:  [1143301 - aptpkg module causes systemd to crash in Ubuntu 18.04](https://bugzilla.suse.com/show_bug.cgi?id=1143301")

### Previous Behavior
See bug.

### New Behavior
Sets the description to `salt.modules.aptpkg`

### Tests written?

Yes

PR Upstream: https://github.com/saltstack/salt/pull/54077