### PR TITLE
virt.volume_infos needs to ignore inactive pools

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -5021,7 +5021,9 @@ def _get_all_volumes_paths(conn):
 
     :param conn: libvirt connection to use
     '''
-    volumes = [vol for l in [obj.listAllVolumes() for obj in conn.listAllStoragePools()] for vol in l]
+    volumes = [vol for l in
+                [obj.listAllVolumes() for obj in conn.listAllStoragePools()
+                    if obj.info()[0] == libvirt.VIR_STORAGE_POOL_RUNNING] for vol in l]
     return {vol.path(): [path.text for path in ElementTree.fromstring(vol.XMLDesc()).findall('.//backingStore/path')]
             for vol in volumes if _is_valid_volume(vol)}
 
@@ -5086,7 +5088,8 @@ def volume_infos(pool=None, volume=None, **kwargs):
                 'used_by': used_by,
             }
 
-        pools = [obj for obj in conn.listAllStoragePools() if pool is None or obj.name() == pool]
+        pools = [obj for obj in conn.listAllStoragePools()
+                    if (pool is None or obj.name() == pool) and obj.info()[0] == libvirt.VIR_STORAGE_POOL_RUNNING]
         vols = {pool_obj.name(): {vol.name(): _volume_extract_infos(vol)
                                   for vol in pool_obj.listAllVolumes()
                                   if (volume is None or vol.name() == volume) and _is_valid_volume(vol)}

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -2743,6 +2743,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         mock_pool_data = [
             {
                 'name': 'pool0',
+                'state': self.mock_libvirt.VIR_STORAGE_POOL_RUNNING,
                 'volumes': [
                     {
                         'key': '/key/of/vol0',
@@ -2755,6 +2756,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             },
             {
                 'name': 'pool1',
+                'state': self.mock_libvirt.VIR_STORAGE_POOL_RUNNING,
                 'volumes': [
                     {
                         'key': '/key/of/vol0bad',
@@ -2784,6 +2786,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         for pool_data in mock_pool_data:
             mock_pool = MagicMock()
             mock_pool.name.return_value = pool_data['name']  # pylint: disable=no-member
+            mock_pool.info.return_value = [pool_data['state']]
             mock_volumes = []
             for vol_data in pool_data['volumes']:
                 mock_volume = MagicMock()
@@ -2816,6 +2819,12 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                 # pylint: enable=no-member
             mock_pool.listAllVolumes.return_value = mock_volumes  # pylint: disable=no-member
             mock_pools.append(mock_pool)
+
+        inactive_pool = MagicMock()
+        inactive_pool.name.return_value = 'pool2'
+        inactive_pool.info.return_value = [self.mock_libvirt.VIR_STORAGE_POOL_INACTIVE]
+        inactive_pool.listAllVolumes.side_effect = self.mock_libvirt.libvirtError('pool is inactive')
+        mock_pools.append(inactive_pool)
 
         self.mock_conn.listAllStoragePools.return_value = mock_pools  # pylint: disable=no-member
 


### PR DESCRIPTION
# What does this PR do?

libvirt raises an error when getting the list of volumes of a pool that is not active. Rule out those pools from virt.volume_infos since we still need to give infos on the other pools' volumes.

Backport of PR saltstack/salt#54291
