### PR TITLE
virt.volume_infos: silence libvirt error message

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -5008,8 +5008,14 @@ def _is_valid_volume(vol):
     the last pool refresh.
     '''
     try:
-        # Getting info on an invalid volume raises error
+        # Getting info on an invalid volume raises error and libvirt logs an error
+        def discarder(ctxt, error):  # pylint: disable=unused-argument
+            log.debug("Ignore libvirt error: %s", error[2])
+        # Disable the libvirt error logging
+        libvirt.registerErrorHandler(discarder, None)
         vol.info()
+        # Reenable the libvirt error logging
+        libvirt.registerErrorHandler(None, None)
         return True
     except libvirt.libvirtError as err:
         return False


### PR DESCRIPTION
### What does this PR do?

Even though the volume_infos handles the libvirt exception when a volume
is missing, libvirt was still outputting the error message in the log.
Since this can add noise to the log only record the libvirt error
message in debug level.

Backport of saltstack/salt#53867
