### PR TITLE
Restore default behaviour of pkg list return

### DIFF
--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -1302,8 +1302,10 @@ def refresh_db(root=None):
     return ret
 
 
-def _find_types(pkgs):
+def _detect_includes(pkgs, inclusion_detection):
     '''Form a package names list, find prefixes of packages types.'''
+    if not inclusion_detection:
+        return None
     return sorted({pkg.split(':', 1)[0] for pkg in pkgs
                    if len(pkg.split(':', 1)) == 2})
 
@@ -1319,6 +1321,7 @@ def install(name=None,
             ignore_repo_failure=False,
             no_recommends=False,
             root=None,
+            inclusion_detection=False,
             **kwargs):
     '''
     .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
@@ -1433,6 +1436,9 @@ def install(name=None,
 
         .. versionadded:: 2018.3.0
 
+    inclusion_detection:
+        Detect ``includes`` based on ``sources``
+        By default packages are always included
 
     Returns a dict containing the new package names and versions::
 
@@ -1498,7 +1504,8 @@ def install(name=None,
 
     diff_attr = kwargs.get("diff_attr")
 
-    includes = _find_types(targets)
+    includes = _detect_includes(targets, inclusion_detection)
+
     old = list_pkgs(attr=diff_attr, root=root, includes=includes) if not downloadonly else list_downloaded(root)
 
     downgrades = []
@@ -1688,7 +1695,7 @@ def upgrade(refresh=True,
     return ret
 
 
-def _uninstall(name=None, pkgs=None, root=None):
+def _uninstall(inclusion_detection, name=None, pkgs=None, root=None):
     '''
     Remove and purge do identical things but with different Zypper commands,
     this function performs the common logic.
@@ -1698,7 +1705,7 @@ def _uninstall(name=None, pkgs=None, root=None):
     except MinionError as exc:
         raise CommandExecutionError(exc)
 
-    includes = _find_types(pkg_params.keys())
+    includes = _detect_includes(pkg_params.keys(), inclusion_detection)
     old = list_pkgs(root=root, includes=includes)
     targets = []
     for target in pkg_params:
@@ -1757,7 +1764,7 @@ def normalize_name(name):
     return name
 
 
-def remove(name=None, pkgs=None, root=None, **kwargs):  # pylint: disable=unused-argument
+def remove(name=None, pkgs=None, root=None, inclusion_detection=False, **kwargs):  # pylint: disable=unused-argument
     '''
     .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
@@ -1788,8 +1795,11 @@ def remove(name=None, pkgs=None, root=None, **kwargs):  # pylint: disable=unused
     root
         Operate on a different root directory.
 
-    .. versionadded:: 0.16.0
+    inclusion_detection:
+        Detect ``includes`` based on ``pkgs``
+        By default packages are always included
 
+    .. versionadded:: 0.16.0
 
     Returns a dict containing the changes.
 
@@ -1801,10 +1811,10 @@ def remove(name=None, pkgs=None, root=None, **kwargs):  # pylint: disable=unused
         salt '*' pkg.remove <package1>,<package2>,<package3>
         salt '*' pkg.remove pkgs='["foo", "bar"]'
     '''
-    return _uninstall(name=name, pkgs=pkgs, root=root)
+    return _uninstall(inclusion_detection, name=name, pkgs=pkgs, root=root)
 
 
-def purge(name=None, pkgs=None, root=None, **kwargs):  # pylint: disable=unused-argument
+def purge(name=None, pkgs=None, root=None, inclusion_detection=False, **kwargs):  # pylint: disable=unused-argument
     '''
     .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
         On minions running systemd>=205, `systemd-run(1)`_ is now used to
@@ -1836,6 +1846,10 @@ def purge(name=None, pkgs=None, root=None, **kwargs):  # pylint: disable=unused-
     root
         Operate on a different root directory.
 
+    inclusion_detection:
+        Detect ``includes`` based on ``pkgs``
+        By default packages are always included
+
     .. versionadded:: 0.16.0
 
 
@@ -1849,7 +1863,7 @@ def purge(name=None, pkgs=None, root=None, **kwargs):  # pylint: disable=unused-
         salt '*' pkg.purge <package1>,<package2>,<package3>
         salt '*' pkg.purge pkgs='["foo", "bar"]'
     '''
-    return _uninstall(name=name, pkgs=pkgs, root=root)
+    return _uninstall(inclusion_detection, name=name, pkgs=pkgs, root=root)
 
 
 def list_locks(root=None):


### PR DESCRIPTION
### What does this PR do?

The default behaviour for pkg list return was to not include patches,
even when installing patches. Only the packages where returned. There
is now parameter to also return patches if that is needed.

### What issues does this PR fix or reference?

https://github.com/SUSE/spacewalk/issues/9245

### Previous Behavior

While installing patches also patches where in the return list.

### New Behavior

Only packages are returned now.

### Tests written?

No. Simply restored default behaviour.

### Commits signed with GPG?

Yes
