### PR TITLE
Adds the possibility to also use downloadonly in kwargs

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1054,8 +1054,9 @@ def upgrade(refresh=True, dist_upgrade=False, **kwargs):
         Skip refreshing the package database if refresh has already occurred within
         <value> seconds
 
-    download_only
-        Only download the packages, don't unpack or install them
+    download_only (or downloadonly)
+        Only download the packages, don't unpack or install them. Use
+        downloadonly to be in line with yum and zypper module.
 
         .. versionadded:: 2018.3.0
 
@@ -1086,7 +1087,7 @@ def upgrade(refresh=True, dist_upgrade=False, **kwargs):
         cmd.append('--force-yes')
     if kwargs.get('skip_verify', False):
         cmd.append('--allow-unauthenticated')
-    if kwargs.get('download_only', False):
+    if kwargs.get('download_only', False) or kwargs.get('downloadonly', False):
         cmd.append('--download-only')
 
     cmd.append('dist-upgrade' if dist_upgrade else 'upgrade')

--- a/tests/unit/modules/test_aptpkg.py
+++ b/tests/unit/modules/test_aptpkg.py
@@ -393,6 +393,36 @@ class AptPkgTestCase(TestCase, LoaderModuleMockMixin):
                 with patch.multiple(aptpkg, **patch_kwargs):
                     self.assertEqual(aptpkg.upgrade(), dict())
 
+    def test_upgrade_downloadonly(self):
+        '''
+        Tests the download-only options for upgrade.
+        '''
+        with patch('salt.utils.pkg.clear_rtag', MagicMock()):
+            with patch('salt.modules.aptpkg.list_pkgs',
+                       MagicMock(return_value=UNINSTALL)):
+                mock_cmd = MagicMock(return_value={
+                    'retcode': 0,
+                    'stdout': UPGRADE
+                })
+                patch_kwargs = {
+                    '__salt__': {
+                        'config.get': MagicMock(return_value=True),
+                        'cmd.run_all': mock_cmd
+                    },
+                }
+                with patch.multiple(aptpkg, **patch_kwargs):
+                    aptpkg.upgrade()
+                    args_matching = [True for args in patch_kwargs['__salt__']['cmd.run_all'].call_args.args if "--download-only" in args]
+                    self.assertFalse(any(args_matching))
+
+                    aptpkg.upgrade(downloadonly=True)
+                    args_matching = [True for args in patch_kwargs['__salt__']['cmd.run_all'].call_args.args if "--download-only" in args]
+                    self.assertTrue(any(args_matching))
+
+                    aptpkg.upgrade(download_only=True)
+                    args_matching = [True for args in patch_kwargs['__salt__']['cmd.run_all'].call_args.args if "--download-only" in args]
+                    self.assertTrue(any(args_matching))
+
     def test_show(self):
         '''
         Test that the pkg.show function properly parses apt-cache show output.


### PR DESCRIPTION
### What does this PR do?

The download_only parameter in the apt module is not in line with
the yum and zypper modules. Both of them use downloadonly without
the underline.

With this change apt now additionally supports the downloadonly
parameter.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/pull/54793

### Tests written?

Yes

### Commits signed with GPG?

Yes