### PR TITLE
Read repo info without using interpolation (bsc#1135656)

### DIFF
--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -1043,7 +1043,7 @@ def _get_repo_info(alias, repos_cfg=None, root=None):
     Get one repo meta-data.
     '''
     try:
-        meta = dict((repos_cfg or _get_configured_repos(root=root)).items(alias))
+        meta = dict((repos_cfg or _get_configured_repos(root=root)).items(alias, raw=True))
         meta['alias'] = alias
         for key, val in six.iteritems(meta):
             if val in ['0', '1']:


### PR DESCRIPTION
### What does this PR do?

Fixes issue https://github.com/SUSE/spacewalk/issues/9242
https://bugzilla.suse.com/show_bug.cgi?id=1135656

I have reduced the reproducer to running the following script with python3:

```python
import tempfile
from salt.ext.six.moves import configparser


if __name__ == "__main__":
    repos_cfg = configparser.ConfigParser()
    with tempfile.NamedTemporaryFile() as _f: 
      _f.write(b"[test]\n")
      _f.write(b"baseurl=ftp://10.160.0.100/%2Finstall/SLP/SLE-15-Installer-LATEST/s390x/DVD1")
      _f.flush()
      repos_cfg.read([_f.name])
      repos_cfg.items("test")
```

The fix was to replace ```repos_cfg.items("test")``` with ```repos_cfg.items("test", raw=True)```

It can also be fixed by doing:
```python
     repos_cfg = configparser.ConfigParser(interpolation=None)
```

The default interpolation is: https://docs.python.org/3/library/configparser.html#configparser.BasicInterpolation

I think the more prudent way of fixing is: ```repos_cfg.items("test", raw=True)```

The `raw` param is described here: https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.get

> All the '%' interpolations are expanded in the return values, unless the raw argument is true. Values for interpolation keys are looked up in the same manner as the option.

I'm going to fix it by using `raw=True`

### Tests written?

No

### Commits signed with GPG?
No