### PR TITLE
chroot: add apply_, sls and highstate for state execution

### DIFF
--- a/salt/modules/chroot.py
+++ b/salt/modules/chroot.py
@@ -136,8 +136,6 @@ def call(root, function, *args, **kwargs):
             function
         ] + list(args) + ['{}={}'.format(k, v) for (k, v) in safe_kwargs.items()]
         ret = __salt__['cmd.run_chroot'](root, [str(x) for x in salt_argv])
-        if ret['retcode'] != EX_OK:
-            raise CommandExecutionError(ret['stderr'])
 
         # Process "real" result in stdout
         try:
@@ -146,7 +144,7 @@ def call(root, function, *args, **kwargs):
             if isinstance(local, dict) and 'retcode' in local:
                 __context__['retcode'] = local['retcode']
             return local.get('return', data)
-        except ValueError:
+        except (KeyError, ValueError):
             return {
                 'result': False,
                 'comment': "Can't parse container command output"

--- a/salt/modules/chroot.py
+++ b/salt/modules/chroot.py
@@ -1,25 +1,4 @@
 # -*- coding: utf-8 -*-
-#
-# Author: Alberto Planas <aplanas@suse.com>
-#
-# Copyright 2018 SUSE LINUX GmbH, Nuernberg, Germany.
-#
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
 
 '''
 :maintainer:    Alberto Planas <aplanas@suse.com>

--- a/salt/modules/chroot.py
+++ b/salt/modules/chroot.py
@@ -107,7 +107,14 @@ def call(root, function, *args, **kwargs):
         extra_mods=__salt__['config.option']('thin_extra_mods', ''),
         so_mods=__salt__['config.option']('thin_so_mods', '')
     )
-    stdout = __salt__['archive.tar']('xzf', thin_path, dest=thin_dest_path)
+    # Some bug in Salt is preventing us to use `archive.tar` here. A
+    # AsyncZeroMQReqChannel is not closed at the end os the salt-call,
+    # and makes the client never exit.
+    #
+    # stdout = __salt__['archive.tar']('xzf', thin_path, dest=thin_dest_path)
+    #
+    stdout = __salt__['cmd.run'](['tar', 'xzf', thin_path,
+                                  '-C', thin_dest_path])
     if stdout:
         __utils__['files.rm_rf'](thin_dest_path)
         return {'result': False, 'comment': stdout}

--- a/tests/unit/modules/test_chroot.py
+++ b/tests/unit/modules/test_chroot.py
@@ -107,7 +107,7 @@ class ChrootTestCase(TestCase, LoaderModuleMockMixin):
             'files.rm_rf': MagicMock(),
         }
         salt_mock = {
-            'archive.tar': MagicMock(return_value='Error'),
+            'cmd.run': MagicMock(return_value='Error'),
             'config.option': MagicMock(),
         }
         with patch.dict(chroot.__utils__, utils_mock), \
@@ -118,7 +118,7 @@ class ChrootTestCase(TestCase, LoaderModuleMockMixin):
             })
             utils_mock['thin.gen_thin'].assert_called_once()
             salt_mock['config.option'].assert_called()
-            salt_mock['archive.tar'].assert_called_once()
+            salt_mock['cmd.run'].assert_called_once()
             utils_mock['files.rm_rf'].assert_called_once()
 
     @patch('salt.modules.chroot.exist')
@@ -135,7 +135,7 @@ class ChrootTestCase(TestCase, LoaderModuleMockMixin):
             'files.rm_rf': MagicMock(),
         }
         salt_mock = {
-            'archive.tar': MagicMock(return_value=''),
+            'cmd.run': MagicMock(return_value=''),
             'config.option': MagicMock(),
             'cmd.run_chroot': MagicMock(return_value={
                 'retcode': 1,
@@ -148,8 +148,13 @@ class ChrootTestCase(TestCase, LoaderModuleMockMixin):
                               'test.ping')
             utils_mock['thin.gen_thin'].assert_called_once()
             salt_mock['config.option'].assert_called()
-            salt_mock['archive.tar'].assert_called_once()
-            salt_mock['cmd.run_chroot'].assert_called_once()
+            salt_mock['cmd.run'].assert_called_once()
+            salt_mock['cmd.run_chroot'].assert_called_with(
+                '/chroot',
+                ['python{}'.format(sys.version_info[0]), '/tmp01/salt-call',
+                 '--metadata', '--local',
+                 '--log-file', '/tmp01/log', '--cachedir', '/tmp01/cache',
+                 '--out', 'json', '-l', 'quiet', '--', 'test.ping'])
             utils_mock['files.rm_rf'].assert_called_once()
 
     @patch('salt.modules.chroot.exist')
@@ -167,7 +172,7 @@ class ChrootTestCase(TestCase, LoaderModuleMockMixin):
             'json.find_json': MagicMock(return_value={'return': 'result'})
         }
         salt_mock = {
-            'archive.tar': MagicMock(return_value=''),
+            'cmd.run': MagicMock(return_value=''),
             'config.option': MagicMock(),
             'cmd.run_chroot': MagicMock(return_value={
                 'retcode': 0,
@@ -179,8 +184,13 @@ class ChrootTestCase(TestCase, LoaderModuleMockMixin):
             self.assertEqual(chroot.call('/chroot', 'test.ping'), 'result')
             utils_mock['thin.gen_thin'].assert_called_once()
             salt_mock['config.option'].assert_called()
-            salt_mock['archive.tar'].assert_called_once()
-            salt_mock['cmd.run_chroot'].assert_called_once()
+            salt_mock['cmd.run'].assert_called_once()
+            salt_mock['cmd.run_chroot'].assert_called_with(
+                '/chroot',
+                ['python{}'.format(sys.version_info[0]), '/tmp01/salt-call',
+                 '--metadata', '--local',
+                 '--log-file', '/tmp01/log', '--cachedir', '/tmp01/cache',
+                 '--out', 'json', '-l', 'quiet', '--', 'test.ping'])
             utils_mock['files.rm_rf'].assert_called_once()
 
     @patch('salt.modules.chroot.exist')
@@ -198,7 +208,7 @@ class ChrootTestCase(TestCase, LoaderModuleMockMixin):
             'json.find_json': MagicMock(return_value={'return': 'result'})
         }
         salt_mock = {
-            'archive.tar': MagicMock(return_value=''),
+            'cmd.run': MagicMock(return_value=''),
             'config.option': MagicMock(),
             'cmd.run_chroot': MagicMock(return_value={
                 'retcode': 0,
@@ -211,6 +221,12 @@ class ChrootTestCase(TestCase, LoaderModuleMockMixin):
                                          user='user', key='key'), 'result')
             utils_mock['thin.gen_thin'].assert_called_once()
             salt_mock['config.option'].assert_called()
-            salt_mock['archive.tar'].assert_called_once()
-            salt_mock['cmd.run_chroot'].assert_called_once()
+            salt_mock['cmd.run'].assert_called_once()
+            salt_mock['cmd.run_chroot'].assert_called_with(
+                '/chroot',
+                ['python{}'.format(sys.version_info[0]), '/tmp01/salt-call',
+                 '--metadata', '--local',
+                 '--log-file', '/tmp01/log', '--cachedir', '/tmp01/cache',
+                 '--out', 'json', '-l', 'quiet',
+                 '--', 'ssh.set_auth_key', 'user=user', 'key=key'])
             utils_mock['files.rm_rf'].assert_called_once()

--- a/tests/unit/modules/test_chroot.py
+++ b/tests/unit/modules/test_chroot.py
@@ -91,7 +91,8 @@ class ChrootTestCase(TestCase, LoaderModuleMockMixin):
         # Basic input validation
         exist.return_value = False
         self.assertRaises(CommandExecutionError, chroot.call, '/chroot', '')
-        self.assertRaises(CommandExecutionError, chroot.call, '/chroot', 'test.ping')
+        self.assertRaises(CommandExecutionError, chroot.call, '/chroot',
+                          'test.ping')
 
     @patch('salt.modules.chroot.exist')
     @patch('tempfile.mkdtemp')
@@ -133,6 +134,7 @@ class ChrootTestCase(TestCase, LoaderModuleMockMixin):
         utils_mock = {
             'thin.gen_thin': MagicMock(return_value='/salt-thin.tgz'),
             'files.rm_rf': MagicMock(),
+            'json.find_json': MagicMock(return_value={'return': {}})
         }
         salt_mock = {
             'cmd.run': MagicMock(return_value=''),
@@ -144,8 +146,10 @@ class ChrootTestCase(TestCase, LoaderModuleMockMixin):
         }
         with patch.dict(chroot.__utils__, utils_mock), \
                 patch.dict(chroot.__salt__, salt_mock):
-            self.assertRaises(CommandExecutionError, chroot.call, '/chroot',
-                              'test.ping')
+            self.assertEqual(chroot.call('/chroot', 'test.ping'), {
+                'result': False,
+                'comment': "Can't parse container command output"
+            })
             utils_mock['thin.gen_thin'].assert_called_once()
             salt_mock['config.option'].assert_called()
             salt_mock['cmd.run'].assert_called_once()

--- a/tests/unit/modules/test_chroot.py
+++ b/tests/unit/modules/test_chroot.py
@@ -234,3 +234,47 @@ class ChrootTestCase(TestCase, LoaderModuleMockMixin):
                  '--out', 'json', '-l', 'quiet',
                  '--', 'ssh.set_auth_key', 'user=user', 'key=key'])
             utils_mock['files.rm_rf'].assert_called_once()
+
+    @patch('salt.modules.chroot._create_and_execute_salt_state')
+    @patch('salt.client.ssh.state.SSHHighState')
+    @patch('salt.fileclient.get_file_client')
+    @patch('salt.utils.state.get_sls_opts')
+    def test_sls(self, get_sls_opts, get_file_client, SSHHighState,
+                 _create_and_execute_salt_state):
+        '''
+        Test execution of Salt states in chroot.
+        '''
+        SSHHighState.return_value = SSHHighState
+        SSHHighState.render_highstate.return_value = (None, [])
+        SSHHighState.state.reconcile_extend.return_value = (None, [])
+        SSHHighState.state.requisite_in.return_value = (None, [])
+        SSHHighState.state.verify_high.return_value = []
+
+        _create_and_execute_salt_state.return_value = 'result'
+        opts_mock = {
+            'hash_type': 'md5',
+        }
+        get_sls_opts.return_value = opts_mock
+        with patch.dict(chroot.__opts__, opts_mock):
+            self.assertEqual(chroot.sls('/chroot', 'module'), 'result')
+            _create_and_execute_salt_state.assert_called_once()
+
+    @patch('salt.modules.chroot._create_and_execute_salt_state')
+    @patch('salt.client.ssh.state.SSHHighState')
+    @patch('salt.fileclient.get_file_client')
+    @patch('salt.utils.state.get_sls_opts')
+    def test_highstate(self, get_sls_opts, get_file_client, SSHHighState,
+                       _create_and_execute_salt_state):
+        '''
+        Test execution of Salt states in chroot.
+        '''
+        SSHHighState.return_value = SSHHighState
+
+        _create_and_execute_salt_state.return_value = 'result'
+        opts_mock = {
+            'hash_type': 'md5',
+        }
+        get_sls_opts.return_value = opts_mock
+        with patch.dict(chroot.__opts__, opts_mock):
+            self.assertEqual(chroot.highstate('/chroot'), 'result')
+            _create_and_execute_salt_state.assert_called_once()


### PR DESCRIPTION
### What does this PR do?

Based on the code from the SSH client wrapper, add apply_, sls and highstate for the execution of Salt states inside a chroot environment.

### Tests written?

Yes

(backport of https://github.com/saltstack/salt/pull/55345)