### PR TITLE
Fix virt.get_hypervisor()

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -3307,7 +3307,7 @@ def get_hypervisor():
     # To add a new 'foo' hypervisor, add the _is_foo_hyper function,
     # add 'foo' to the list below and add it to the docstring with a .. versionadded::
     hypervisors = ['kvm', 'xen']
-    result = [hyper for hyper in hypervisors if getattr(sys.modules[__name__], '_is_{}_hyper').format(hyper)()]
+    result = [hyper for hyper in hypervisors if getattr(sys.modules[__name__], '_is_{}_hyper'.format(hyper))()]
     return result[0] if result else None
 
 

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -3023,3 +3023,17 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
         # Shouldn't be called with another parameter so far since those are not implemented
         # and thus throwing exceptions.
         mock_pool.delete.assert_called_once_with(self.mock_libvirt.VIR_STORAGE_POOL_DELETE_NORMAL)
+
+    @patch('salt.modules.virt._is_kvm_hyper', return_value=True)
+    @patch('salt.modules.virt._is_xen_hyper', return_value=False)
+    def test_get_hypervisor(self, isxen_mock, iskvm_mock):
+        '''
+        test the virt.get_hypervisor() function
+        '''
+        self.assertEqual('kvm', virt.get_hypervisor())
+
+        iskvm_mock.return_value = False
+        self.assertIsNone(virt.get_hypervisor())
+
+        isxen_mock.return_value = True
+        self.assertEqual('xen', virt.get_hypervisor())


### PR DESCRIPTION
### What does this PR do?

virt.get_hypervisor resulted in:

  AttributeError: module 'salt.loader.dev-srv.tf.local.int.module.virt' has no attribute '_is_{}_hyper'

This was due to missplaced parenthese.

### What issues does this PR fix or reference?

Backport of saltstack/salt#55351

### Tests written?

Yes
### Commits signed with GPG?

Yes