### PR TITLE
Let salt-ssh use 'platform-python' binary in RHEL8

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -147,7 +147,7 @@ elif [ "$SUDO" ] && [ -n "$SUDO_USER" ]
 then SUDO="sudo "
 fi
 EX_PYTHON_INVALID={EX_THIN_PYTHON_INVALID}
-PYTHON_CMDS="python3 python27 python2.7 python26 python2.6 python2 python"
+PYTHON_CMDS="python3 /usr/libexec/platform-python python27 python2.7 python26 python2.6 python2 python"
 for py_cmd in $PYTHON_CMDS
 do
     if command -v "$py_cmd" >/dev/null 2>&1 && "$py_cmd" -c "import sys; sys.exit(not (sys.version_info >= (2, 6)));"


### PR DESCRIPTION
RHEL/CentOS 8 has an internal Python interpreter called 'platform-python'
included in the base setup.
    
Add this binary to the list of Python executables to look for when creating the sh shim.
### What issues does this PR fix or reference?

### Previous Behavior
In RHEL8, `salt-ssh` failed unless Python is installed from the Python module.

### New Behavior
`salt-ssh` works with the base `platform-python` binary.

### Tests written?

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
