### PR TITLE
Fix virt states to not fail on VMs already stopped.

### DIFF
--- a/salt/states/virt.py
+++ b/salt/states/virt.py
@@ -145,35 +145,45 @@ def keys(name, basepath='/etc/pki', **kwargs):
     return ret
 
 
-def _virt_call(domain, function, section, comment,
+def _virt_call(domain, function, section, comment, state=None,
                connection=None, username=None, password=None, **kwargs):
     '''
     Helper to call the virt functions. Wildcards supported.
 
-    :param domain:
-    :param function:
-    :param section:
-    :param comment:
-    :return:
+    :param domain: the domain to apply the function on. Can contain wildcards.
+    :param function: virt function to call
+    :param section: key for the changed domains in the return changes dictionary
+    :param comment: comment to return
+    :param state: the expected final state of the VM. If None the VM state won't be checked.
+    :return: the salt state return
     '''
     ret = {'name': domain, 'changes': {}, 'result': True, 'comment': ''}
     targeted_domains = fnmatch.filter(__salt__['virt.list_domains'](), domain)
     changed_domains = list()
     ignored_domains = list()
+    noaction_domains = list()
     for targeted_domain in targeted_domains:
         try:
-            response = __salt__['virt.{0}'.format(function)](targeted_domain,
-                                                             connection=connection,
-                                                             username=username,
-                                                             password=password,
-                                                             **kwargs)
-            if isinstance(response, dict):
-                response = response['name']
-            changed_domains.append({'domain': targeted_domain, function: response})
+            action_needed = True
+            # If a state has been provided, use it to see if we have something to do
+            if state is not None:
+                domain_state = __salt__['virt.vm_state'](targeted_domain)
+                action_needed = domain_state.get(targeted_domain) != state
+            if action_needed:
+                response = __salt__['virt.{0}'.format(function)](targeted_domain,
+                                                                 connection=connection,
+                                                                 username=username,
+                                                                 password=password,
+                                                                 **kwargs)
+                if isinstance(response, dict):
+                    response = response['name']
+                changed_domains.append({'domain': targeted_domain, function: response})
+            else:
+                noaction_domains.append(targeted_domain)
         except libvirt.libvirtError as err:
             ignored_domains.append({'domain': targeted_domain, 'issue': six.text_type(err)})
     if not changed_domains:
-        ret['result'] = False
+        ret['result'] = not ignored_domains and bool(targeted_domains)
         ret['comment'] = 'No changes had happened'
         if ignored_domains:
             ret['changes'] = {'ignored': ignored_domains}
@@ -206,7 +216,7 @@ def stopped(name, connection=None, username=None, password=None):
           virt.stopped
     '''
 
-    return _virt_call(name, 'shutdown', 'stopped', "Machine has been shut down",
+    return _virt_call(name, 'shutdown', 'stopped', 'Machine has been shut down', state='shutdown',
                       connection=connection, username=username, password=password)
 
 
@@ -231,8 +241,7 @@ def powered_off(name, connection=None, username=None, password=None):
         domain_name:
           virt.stopped
     '''
-
-    return _virt_call(name, 'stop', 'unpowered', 'Machine has been powered off',
+    return _virt_call(name, 'stop', 'unpowered', 'Machine has been powered off', state='shutdown',
                       connection=connection, username=username, password=password)
 
 


### PR DESCRIPTION
# What does this PR do?

The virt.stopped and virt.powered_off states need to do nothing and
not fail if one of the targeted VMs is already in shutdown state.

This is a backport of a commit from PR saltstack/salt#54196 that was missing in PR 173
