### PR TITLE
virt: adding kernel boot parameters to libvirt xml #55245

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -106,6 +106,8 @@ import salt.utils.templates
 import salt.utils.validate.net
 import salt.utils.versions
 import salt.utils.yaml
+
+from salt.utils.virt import check_remote, download_remote
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.ext import six
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
@@ -118,6 +120,8 @@ JINJA = jinja2.Environment(
         os.path.join(salt.utils.templates.TEMPLATE_DIRNAME, 'virt')
     )
 )
+
+CACHE_DIR = '/var/lib/libvirt/saltinst'
 
 VIRT_STATE_NAME_MAP = {0: 'running',
                        1: 'running',
@@ -1120,6 +1124,34 @@ def _get_merged_nics(hypervisor, profile, interfaces=None, dmac=None):
     return nicp
 
 
+def _handle_remote_boot_params(orig_boot):
+    """
+    Checks if the boot parameters contain a remote path. If so, it will copy
+    the parameters, download the files specified in the remote path, and return
+    a new dictionary with updated paths containing the canonical path to the
+    kernel and/or initrd
+
+    :param orig_boot: The original boot parameters passed to the init or update
+    functions.
+    """
+    saltinst_dir = None
+    new_boot = orig_boot.copy()
+
+    try:
+        for key in ['kernel', 'initrd']:
+            if check_remote(orig_boot.get(key)):
+                if saltinst_dir is None:
+                    os.makedirs(CACHE_DIR)
+                    saltinst_dir = CACHE_DIR
+
+                new_boot[key] = download_remote(orig_boot.get(key),
+                                                saltinst_dir)
+
+        return new_boot
+    except Exception as err:
+        raise err
+
+
 def init(name,
          cpu,
          mem,
@@ -1272,11 +1304,15 @@ def init(name,
     :param password: password to connect with, overriding defaults
 
                      .. versionadded:: 2019.2.0
-    :param boot: Specifies kernel for the virtual machine, as well as boot
-                 parameters for the virtual machine. This is an optionl
-                 parameter, and all of the keys are optional within the
-                 dictionary.
-         .. code-block:: python
+    :param boot:
+        Specifies kernel for the virtual machine, as well as boot parameters
+        for the virtual machine. This is an optionl parameter, and all of the
+        keys are optional within the dictionary. If a remote path is provided
+        to kernel or initrd, salt will handle the downloading of the specified
+        remote fild, and will modify the XML accordingly.
+
+        .. code-block:: python
+
             {
                 'kernel': '/root/f8-i386-vmlinuz',
                 'initrd': '/root/f8-i386-initrd',
@@ -1284,7 +1320,6 @@ def init(name,
             }
 
         .. versionadded:: neon
-    :
 
     .. _init-nic-def:
 
@@ -1532,6 +1567,9 @@ def init(name,
     if arch is None:
         arch = 'x86_64' if 'x86_64' in arches else arches[0]
 
+    if boot is not None:
+        boot = _handle_remote_boot_params(boot)
+
     vm_xml = _gen_xml(name, cpu, mem, diskp, nicp, hypervisor, os_type, arch,
                       graphics, boot, **kwargs)
     conn = __get_conn(**kwargs)
@@ -1748,12 +1786,15 @@ def update(name,
     :param username: username to connect with, overriding defaults
     :param password: password to connect with, overriding defaults
 
-    :param boot: Specifies kernel for the virtual machine, as well as boot
-                 parameters for the virtual machine. This is an optionl
-                 parameter, and all of the keys are optional within the
-                 dictionary.
+    :param boot:
+        Specifies kernel for the virtual machine, as well as boot parameters
+        for the virtual machine. This is an optionl parameter, and all of the
+        keys are optional within the dictionary. If a remote path is provided
+        to kernel or initrd, salt will handle the downloading of the specified
+        remote fild, and will modify the XML accordingly.
 
         .. code-block:: python
+
             {
                 'kernel': '/root/f8-i386-vmlinuz',
                 'initrd': '/root/f8-i386-initrd',
@@ -1802,6 +1843,10 @@ def update(name,
     # Compute the XML to get the disks, interfaces and graphics
     hypervisor = desc.get('type')
     all_disks = _disk_profile(disk_profile, hypervisor, disks, name, **kwargs)
+
+    if boot is not None:
+        boot = _handle_remote_boot_params(boot)
+
     new_desc = ElementTree.fromstring(_gen_xml(name,
                                                cpu,
                                                mem,

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -532,6 +532,7 @@ def _gen_xml(name,
              os_type,
              arch,
              graphics=None,
+             boot=None,
              **kwargs):
     '''
     Generate the XML string to define a libvirt VM
@@ -568,11 +569,15 @@ def _gen_xml(name,
     else:
         context['boot_dev'] = ['hd']
 
+    context['boot'] = boot if boot else {}
+
     if os_type == 'xen':
         # Compute the Xen PV boot method
         if __grains__['os_family'] == 'Suse':
-            context['kernel'] = '/usr/lib/grub2/x86_64-xen/grub.xen'
-            context['boot_dev'] = []
+            if not boot or not boot.get('kernel', None):
+                context['boot']['kernel'] = \
+                        '/usr/lib/grub2/x86_64-xen/grub.xen'
+                context['boot_dev'] = []
 
     if 'serial_type' in kwargs:
         context['serial_type'] = kwargs['serial_type']
@@ -1136,6 +1141,7 @@ def init(name,
          graphics=None,
          os_type=None,
          arch=None,
+         boot=None,
          **kwargs):
     '''
     Initialize a new vm
@@ -1266,6 +1272,19 @@ def init(name,
     :param password: password to connect with, overriding defaults
 
                      .. versionadded:: 2019.2.0
+    :param boot: Specifies kernel for the virtual machine, as well as boot
+                 parameters for the virtual machine. This is an optionl
+                 parameter, and all of the keys are optional within the
+                 dictionary.
+         .. code-block:: python
+            {
+                'kernel': '/root/f8-i386-vmlinuz',
+                'initrd': '/root/f8-i386-initrd',
+                'cmdline': 'console=ttyS0 ks=http://example.com/f8-i386/os/'
+            }
+
+        .. versionadded:: neon
+    :
 
     .. _init-nic-def:
 
@@ -1513,7 +1532,8 @@ def init(name,
     if arch is None:
         arch = 'x86_64' if 'x86_64' in arches else arches[0]
 
-    vm_xml = _gen_xml(name, cpu, mem, diskp, nicp, hypervisor, os_type, arch, graphics, **kwargs)
+    vm_xml = _gen_xml(name, cpu, mem, diskp, nicp, hypervisor, os_type, arch,
+                      graphics, boot, **kwargs)
     conn = __get_conn(**kwargs)
     try:
         conn.defineXML(vm_xml)
@@ -1692,6 +1712,7 @@ def update(name,
            interfaces=None,
            graphics=None,
            live=True,
+           boot=None,
            **kwargs):
     '''
     Update the definition of an existing domain.
@@ -1726,6 +1747,20 @@ def update(name,
     :param connection: libvirt connection URI, overriding defaults
     :param username: username to connect with, overriding defaults
     :param password: password to connect with, overriding defaults
+
+    :param boot: Specifies kernel for the virtual machine, as well as boot
+                 parameters for the virtual machine. This is an optionl
+                 parameter, and all of the keys are optional within the
+                 dictionary.
+
+        .. code-block:: python
+            {
+                'kernel': '/root/f8-i386-vmlinuz',
+                'initrd': '/root/f8-i386-initrd',
+                'cmdline': 'console=ttyS0 ks=http://example.com/f8-i386/os/'
+            }
+
+        .. versionadded:: neon
 
     :return:
 
@@ -1776,6 +1811,7 @@ def update(name,
                                                domain.OSType(),
                                                desc.find('.//os/type').get('arch'),
                                                graphics,
+                                               boot,
                                                **kwargs))
 
     # Update the cpu
@@ -1784,6 +1820,48 @@ def update(name,
         cpu_node.text = six.text_type(cpu)
         cpu_node.set('current', six.text_type(cpu))
         need_update = True
+
+    # Update the kernel boot parameters
+    boot_tags = ['kernel', 'initrd', 'cmdline']
+    parent_tag = desc.find('os')
+
+    # We need to search for each possible subelement, and update it.
+    for tag in boot_tags:
+        # The Existing Tag...
+        found_tag = desc.find(tag)
+
+        # The new value
+        boot_tag_value = boot.get(tag, None) if boot else None
+
+        # Existing tag is found and values don't match
+        if found_tag and found_tag.text != boot_tag_value:
+
+            # If the existing tag is found, but the new value is None
+            # remove it. If the existing tag is found, and the new value
+            # doesn't match update it. In either case, mark for update.
+            if boot_tag_value is None \
+               and boot is not None   \
+               and parent_tag is not None:
+                ElementTree.remove(parent_tag, tag)
+            else:
+                found_tag.text = boot_tag_value
+
+            need_update = True
+
+        # Existing tag is not found, but value is not None
+        elif found_tag is None and boot_tag_value is not None:
+
+            # Need to check for parent tag, and add it if it does not exist.
+            # Add a subelement and set the value to the new value, and then
+            # mark for update.
+            if parent_tag is not None:
+                child_tag = ElementTree.SubElement(parent_tag, tag)
+            else:
+                new_parent_tag = ElementTree.Element('os')
+                child_tag = ElementTree.SubElement(new_parent_tag, tag)
+
+            child_tag.text = boot_tag_value
+            need_update = True
 
     # Update the memory, note that libvirt outputs all memory sizes in KiB
     for mem_node_name in ['memory', 'currentMemory']:

--- a/salt/states/virt.py
+++ b/salt/states/virt.py
@@ -350,11 +350,15 @@ def running(name,
 
         .. versionadded:: Neon
 
-    :param boot: Specifies kernel for the virtual machine, as well as boot
-                 parameters for the virtual machine. This is an optionl
-                 parameter, and all of the keys are optional within the
-                 dictionary.
+    :param boot:
+        Specifies kernel for the virtual machine, as well as boot parameters
+        for the virtual machine. This is an optionl parameter, and all of the
+        keys are optional within the dictionary. If a remote path is provided
+        to kernel or initrd, salt will handle the downloading of the specified
+        remote fild, and will modify the XML accordingly.
+
         .. code-block:: python
+
             {
                 'kernel': '/root/f8-i386-vmlinuz',
                 'initrd': '/root/f8-i386-initrd',

--- a/salt/states/virt.py
+++ b/salt/states/virt.py
@@ -264,7 +264,8 @@ def running(name,
             username=None,
             password=None,
             os_type=None,
-            arch=None):
+            arch=None,
+            boot=None):
     '''
     Starts an existing guest, or defines and starts a new VM with specified arguments.
 
@@ -349,6 +350,19 @@ def running(name,
 
         .. versionadded:: Neon
 
+    :param boot: Specifies kernel for the virtual machine, as well as boot
+                 parameters for the virtual machine. This is an optionl
+                 parameter, and all of the keys are optional within the
+                 dictionary.
+        .. code-block:: python
+            {
+                'kernel': '/root/f8-i386-vmlinuz',
+                'initrd': '/root/f8-i386-initrd',
+                'cmdline': 'console=ttyS0 ks=http://example.com/f8-i386/os/'
+            }
+
+        .. versionadded:: neon
+
     .. rubric:: Example States
 
     Make sure an already-defined virtual machine called ``domain_name`` is running:
@@ -413,7 +427,8 @@ def running(name,
                                                      live=False,
                                                      connection=connection,
                                                      username=username,
-                                                     password=password)
+                                                     password=password,
+                                                     boot=boot)
                     if status['definition']:
                         action_msg = 'updated and started'
                 __salt__['virt.start'](name)
@@ -431,7 +446,8 @@ def running(name,
                                                      graphics=graphics,
                                                      connection=connection,
                                                      username=username,
-                                                     password=password)
+                                                     password=password,
+                                                     boot=boot)
                     ret['changes'][name] = status
                     if status.get('errors', None):
                         ret['comment'] = 'Domain {0} updated, but some live update(s) failed'.format(name)
@@ -466,7 +482,8 @@ def running(name,
                                   priv_key=priv_key,
                                   connection=connection,
                                   username=username,
-                                  password=password)
+                                  password=password,
+                                  boot=boot)
             ret['changes'][name] = 'Domain defined and started'
             ret['comment'] = 'Domain {0} defined and started'.format(name)
     except libvirt.libvirtError as err:

--- a/salt/templates/virt/libvirt_domain.jinja
+++ b/salt/templates/virt/libvirt_domain.jinja
@@ -5,7 +5,17 @@
         <currentMemory unit='KiB'>{{ mem }}</currentMemory>
         <os>
                 <type arch='{{ arch }}'>{{ os_type }}</type>
-                {% if kernel %}<kernel>{{ kernel }}</kernel>{% endif %}
+                {% if boot %}
+                  {% if 'kernel' in boot %}
+                    <kernel>{{ boot.kernel }}</kernel>
+                  {% endif %}
+                  {% if 'initrd' in boot %}
+                    <initrd>{{ boot.initrd }}</initrd>
+                  {% endif %}
+                  {% if 'cmdline' in boot %}
+                    <cmdline>{{ boot.cmdline }}</cmdline>
+                  {% endif %}
+                {% endif %}
                 {% for dev in boot_dev %}
                 <boot dev='{{ dev }}' />
                 {% endfor %}

--- a/tests/unit/states/test_virt.py
+++ b/tests/unit/states/test_virt.py
@@ -249,7 +249,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                                               mem=2048,
                                               image='/path/to/img.qcow2'), ret)
             init_mock.assert_called_with('myvm', cpu=2, mem=2048, image='/path/to/img.qcow2',
-                                         os_type=None, arch=None,
+                                         os_type=None, arch=None, boot=None,
                                          disk=None, disks=None, nic=None, interfaces=None,
                                          graphics=None, hypervisor=None,
                                          seed=True, install=True, pub_key=None, priv_key=None,
@@ -314,6 +314,7 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                                          graphics=graphics,
                                          hypervisor='qemu',
                                          seed=False,
+                                         boot=None,
                                          install=False,
                                          pub_key='/path/to/key.pub',
                                          priv_key='/path/to/key',
@@ -337,6 +338,23 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
                         'result': True,
                         'comment': 'Domain myvm updated, restart to fully apply the changes'})
             self.assertDictEqual(virt.running('myvm', update=True, cpu=2), ret)
+
+        # Working update case when running with boot params
+        boot = {
+            'kernel': '/root/f8-i386-vmlinuz',
+            'initrd': '/root/f8-i386-initrd',
+            'cmdline': 'console=ttyS0 ks=http://example.com/f8-i386/os/'
+        }
+
+        with patch.dict(virt.__salt__, {  # pylint: disable=no-member
+                    'virt.vm_state': MagicMock(return_value='running'),
+                    'virt.update': MagicMock(return_value={'definition': True, 'cpu': True})
+                }):
+            ret.update({'changes': {'myvm': {'definition': True, 'cpu': True}},
+                        'result': True,
+                        'comment': 'Domain myvm updated, restart to fully apply the changes'})
+            self.assertDictEqual(virt.running('myvm', update=True, boot=boot), ret)
+
 
         # Working update case when stopped
         with patch.dict(virt.__salt__, {  # pylint: disable=no-member

--- a/tests/unit/states/test_virt.py
+++ b/tests/unit/states/test_virt.py
@@ -347,14 +347,13 @@ class LibvirtTestCase(TestCase, LoaderModuleMockMixin):
         }
 
         with patch.dict(virt.__salt__, {  # pylint: disable=no-member
-                    'virt.vm_state': MagicMock(return_value='running'),
+                    'virt.vm_state': MagicMock(return_value={'myvm': 'running'}),
                     'virt.update': MagicMock(return_value={'definition': True, 'cpu': True})
                 }):
             ret.update({'changes': {'myvm': {'definition': True, 'cpu': True}},
                         'result': True,
                         'comment': 'Domain myvm updated, restart to fully apply the changes'})
             self.assertDictEqual(virt.running('myvm', update=True, boot=boot), ret)
-
 
         # Working update case when stopped
         with patch.dict(virt.__salt__, {  # pylint: disable=no-member


### PR DESCRIPTION
### What does this PR do?

This PR adds the kernel path, initrd path, and kernel boot command line parameters to libvirt xml for use with SUSE's autoyast and Red Hat's kickstart.

### What issues does this PR fix or reference?

N/A

### New Behavior

Adds an additional parameter 'boot=None' to a number of functions, allowing the kernel path, the initrd path, and the kernel boot command line string to be parse and added to the xml.

### Tests written?

Yes

### Commits signed with GPG?

Yes

Backport of PR [saltstack/salt#55245](https://github.com/saltstack/salt/pull/55245)