### PR TITLE
Enable passing grains to start event based on 'start_event_grains' configuration parameter

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -548,6 +548,11 @@
 #  - edit.vim
 #  - hyper
 #
+# List of grains to pass in start event when minion starts up:
+#start_event_grains:
+#  - machine_id
+#  - uuid
+#
 # Top file to execute if startup_states is 'top':
 #top_file: ''
 

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -2000,6 +2000,21 @@ List of states to run when the minion starts up if ``startup_states`` is set to 
       - edit.vim
       - hyper
 
+.. conf_minion:: start_event_grains
+
+``start_event_grains``
+----------------------
+
+Default: ``[]``
+
+List of grains to pass in start event when minion starts up.
+
+.. code-block:: yaml
+
+    start_event_grains:
+      - machine_id
+      - uuid
+
 .. conf_minion:: top_file
 
 ``top_file``

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1283,6 +1283,7 @@ DEFAULT_MINION_OPTS = {
     'state_top_saltenv': None,
     'startup_states': '',
     'sls_list': [],
+    'start_event_grains': [],
     'top_file': '',
     'thoriumenv': None,
     'thorium_top': 'top.sls',

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1456,6 +1456,11 @@ class Minion(MinionBase):
         else:
             return
 
+        if self.opts['start_event_grains']:
+            grains_to_add = dict(
+                [(k, v) for k, v in six.iteritems(self.opts.get('grains', {})) if k in self.opts['start_event_grains']])
+            load['grains'] = grains_to_add
+
         if sync:
             try:
                 self._send_req_sync(load, timeout)


### PR DESCRIPTION
### What does this PR do?
port of https://github.com/saltstack/salt/pull/54948

