### PR TITLE
Adds enabled kwarg

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2353,6 +2353,8 @@ def mod_repo(repo, saltenv='base', **kwargs):
 
     if 'disabled' in kwargs:
         kwargs['disabled'] = salt.utils.data.is_true(kwargs['disabled'])
+    elif 'enabled' in kwargs:
+        kwargs['disabled'] = not salt.utils.data.is_true(kwargs['enabled'])
 
     kw_type = kwargs.get('type')
     kw_dist = kwargs.get('dist')

--- a/tests/unit/modules/test_aptpkg.py
+++ b/tests/unit/modules/test_aptpkg.py
@@ -548,6 +548,30 @@ class AptPkgTestCase(TestCase, LoaderModuleMockMixin):
             self.assert_called_once(refresh_mock)
             refresh_mock.reset_mock()
 
+    def test_mod_repo_enabled(self):
+        '''
+        Checks if a repo is enabled or disabled depending on the passed kwargs.
+        '''
+        with patch.dict(aptpkg.__salt__, {'config.option': MagicMock(), 'no_proxy': MagicMock(return_value=False)}):
+            with patch('salt.modules.aptpkg._check_apt', MagicMock(return_value=True)):
+                with patch('salt.modules.aptpkg.refresh_db', MagicMock(return_value={})):
+                    with patch('salt.utils.data.is_true', MagicMock(return_value=True)) as data_is_true:
+                        with patch('salt.modules.aptpkg.sourceslist', MagicMock(), create=True):
+                            repo = aptpkg.mod_repo('foo', enabled=False)
+                            data_is_true.assert_called_with(False)
+                            # with disabled=True; should call salt.utils.data.is_true True
+                            data_is_true.reset_mock()
+                            repo = aptpkg.mod_repo('foo', disabled=True)
+                            data_is_true.assert_called_with(True)
+                            # with enabled=True; should call salt.utils.data.is_true with False
+                            data_is_true.reset_mock()
+                            repo = aptpkg.mod_repo('foo', enabled=True)
+                            data_is_true.assert_called_with(True)
+                            # with disabled=True; should call salt.utils.data.is_true False
+                            data_is_true.reset_mock()
+                            repo = aptpkg.mod_repo('foo', disabled=False)
+                            data_is_true.assert_called_with(False)
+
     @patch('salt.utils.path.os_walk', MagicMock(return_value=[('test', 'test', 'test')]))
     @patch('os.path.getsize', MagicMock(return_value=123456))
     @patch('os.path.getctime', MagicMock(return_value=1234567890.123456))


### PR DESCRIPTION
### What does this PR do?

aptpkg is using the keyword argument 'disabled', while zypper and yum are using enabled. This change allows to also pass 'disabled' to mod_repo from the aptpkg module.


### What issues does this PR fix or reference?

https://github.com/saltstack/salt/pull/55203