### PR TITLE
Add Astra Linux Common Edition to the OS Family list

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1476,6 +1476,7 @@ _OS_FAMILY_MAP = {
     'Funtoo': 'Gentoo',
     'AIX': 'AIX',
     'TurnKey': 'Debian',
+    'AstraLinuxCE': 'Debian',
 }
 
 # Matches any possible format:

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -583,6 +583,26 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         }
         self._run_os_grains_tests("ubuntu-17.10", _os_release_map, expectation)
 
+    @skipIf(not salt.utils.platform.is_linux(), 'System is not Linux')
+    def test_astralinuxce_2_os_grains(self):
+        '''
+        Test if OS grains are parsed correctly in Astra Linux CE 2.12.22 "orel"
+        '''
+        _os_release_map = {
+            'linux_distribution': ('AstraLinuxCE', '2.12.22', 'orel'),
+        }
+        expectation = {
+            'os': 'AstraLinuxCE',
+            'os_family': 'Debian',
+            'oscodename': 'orel',
+            'osfullname': 'AstraLinuxCE',
+            'osrelease': '2.12.22',
+            'osrelease_info': (2, 12, 22),
+            'osmajorrelease': 2,
+            'osfinger': 'AstraLinuxCE-2',
+        }
+        self._run_os_grains_tests("astralinuxce-2.12.22", _os_release_map, expectation)
+
     @skipIf(not salt.utils.platform.is_windows(), 'System is not Windows')
     def test_windows_platform_data(self):
         '''


### PR DESCRIPTION
**NOTE:** Upstream PR: https://github.com/saltstack/salt/pull/56125

#### What does this PR do?

It adds [Astra Linux Common Edition](https://astralinux.ru/en/products/astra-linux-common-edition/) to the OS Family list, so it's recognized by salt.

Astra Linux is a Russian distribution based on Debian, currently based on Debian 9.0:
```
$ cat /etc/debian_version 
9.0
```
```
$ cat /etc/os-release 
PRETTY_NAME="Astra Linux (Orel 2.12.22)"
NAME="Astra Linux (Orel)"
ID=astra
ID_LIKE=debian
ANSI_COLOR="1;31"
HOME_URL="http://astralinux.ru"
SUPPORT_URL="http://astralinux.ru/support"
VARIANT_ID=orel
VARIANT=Orel
VERSION_ID=2.12.22
```

### What issues does this PR fix or reference?

None. I discovered this problem because I am trying to add support for this distribution at [Uyuni](https://www.uyuni-project.org/).

### Previous Behavior

`os_family` grain value was `AstraLinuxCE`, so the distribution was not recognized as Debian derivative and things like installing packages failed:
```
# salt-call --local pkg.install htop
'pkg.install' is not available.
```
### New Behavior

`os_family` grain value is now `Debian`, so the distribution is recognized and it can be used, and salt can be used -for example- to install packages:
```
# salt-call --local pkg.install htop
local:
    ----------
    htop:
        ----------
        new:
            2.0.2-1
        old:
```

### Tests written?

Yes, one new unit test.

As far as I can see, not all distributions have tests at `tests/unit/grains/test_core.py`, but if you want me to add them anyway, please let me know.

### Commits signed with GPG?

Yes
