### PR TITLE
Adds missing function body for win32_kill_process_tree

### DIFF
--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1626,6 +1626,27 @@ class MirrorPostHandler(tornado.web.RequestHandler):
 
 def win32_kill_process_tree(pid, sig=signal.SIGTERM, include_parent=True,
         timeout=None, on_terminate=None):
+    '''
+    Kill a process tree (including grandchildren) with signal "sig" and return
+    a (gone, still_alive) tuple.  "on_terminate", if specified, is a callabck
+    function which is called as soon as a child terminates.
+    '''
+    if pid == os.getpid():
+        raise RuntimeError("I refuse to kill myself")
+    try:
+        parent = psutil.Process(pid)
+    except psutil.NoSuchProcess:
+        log.debug("PID not found alive: %d", pid)
+        return ([], [])
+    children = parent.children(recursive=True)
+    if include_parent:
+        children.append(parent)
+    for p in children:
+        p.send_signal(sig)
+    gone, alive = psutil.wait_procs(children, timeout=timeout,
+                                    callback=on_terminate)
+    return (gone, alive)
+
 
 def this_user():
     '''


### PR DESCRIPTION
## What does this PR do?

This seems to have vanished with a previous merge conflict. Re-adding function body.
