### PR TITLE
Apply patch from upstream to support Python 3.8

### DIFF
--- a/pkg/suse/salt.spec
+++ b/pkg/suse/salt.spec
@@ -62,6 +62,7 @@ BuildRequires:  python-psutil
 BuildRequires:  python-requests >= 1.0.0
 BuildRequires:  python-tornado >= 4.2.1
 BuildRequires:  python-yaml
+BuildRequires:  python-distro
 # requirements/opt.txt (not all)
 # BuildRequires:  python-MySQL-python
 # BuildRequires:  python-timelib
@@ -112,6 +113,7 @@ Requires:       python-psutil
 Requires:       python-requests >= 1.0.0
 Requires:       python-tornado >= 4.2.1
 Requires:       python-yaml
+Requires:       python-distro
 %if 0%{?suse_version}
 # requirements/opt.txt (not all)
 Recommends:     python-MySQL-python

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -3276,7 +3276,9 @@ def apply_cloud_providers_config(overrides, defaults=None):
         # Merge provided extends
         keep_looping = False
         for alias, entries in six.iteritems(providers.copy()):
-            for driver, details in six.iteritems(entries):
+            for driver in list(six.iterkeys(entries)):
+                # Don't use iteritems, because the values of the dictionary will be changed
+                details = entries[driver]
 
                 if 'extends' not in details:
                     # Extends resolved or non existing, continue!

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -40,20 +40,20 @@ except ImportError:
 __proxyenabled__ = ['*']
 __FQDN__ = None
 
-# Extend the default list of supported distros. This will be used for the
-# /etc/DISTRO-release checking that is part of linux_distribution()
-from platform import _supported_dists
-_supported_dists += ('arch', 'mageia', 'meego', 'vmware', 'bluewhite64',
-                     'slamd64', 'ovs', 'system', 'mint', 'oracle', 'void')
-
 # linux_distribution deprecated in py3.7
 try:
     from platform import linux_distribution as _deprecated_linux_distribution
 
+    # Extend the default list of supported distros. This will be used for the
+    # /etc/DISTRO-release checking that is part of linux_distribution()
+    from platform import _supported_dists
+    _supported_dists += ('arch', 'mageia', 'meego', 'vmware', 'bluewhite64',
+                         'slamd64', 'ovs', 'system', 'mint', 'oracle', 'void')
+
     def linux_distribution(**kwargs):
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            return _deprecated_linux_distribution(**kwargs)
+            return _deprecated_linux_distribution(supported_dists=_supported_dists, **kwargs)
 except ImportError:
     from distro import linux_distribution
 
@@ -1961,7 +1961,7 @@ def os_data():
         )
         (osname, osrelease, oscodename) = \
             [x.strip('"').strip("'") for x in
-             linux_distribution(supported_dists=_supported_dists)]
+             linux_distribution()]
         # Try to assign these three names based on the lsb info, they tend to
         # be more accurate than what python gets from /etc/DISTRO-release.
         # It's worth noting that Ubuntu has patched their Python distribution

--- a/salt/renderers/stateconf.py
+++ b/salt/renderers/stateconf.py
@@ -224,10 +224,10 @@ def render(input, saltenv='base', sls='', argline='', **kws):
             tmplctx = STATE_CONF.copy()
             if tmplctx:
                 prefix = sls + '::'
-                for k in six.iterkeys(tmplctx):  # iterate over a copy of keys
-                    if k.startswith(prefix):
-                        tmplctx[k[len(prefix):]] = tmplctx[k]
-                        del tmplctx[k]
+                tmplctx = {
+                    k[len(prefix):] if k.startswith(prefix) else k: v
+                    for k, v in six.iteritems(tmplctx)
+                }
         else:
             tmplctx = {}
 

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -1256,7 +1256,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
                   <alias name='net1'/>
                   <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x1'/>
                 </interface>
-                <graphics type='spice' port='5900' autoport='yes' listen='127.0.0.1'>
+                <graphics type='spice' listen='127.0.0.1' autoport='yes'>
                   <listen type='address' address='127.0.0.1'/>
                 </graphics>
                 <video>


### PR DESCRIPTION
### What does this PR do?

Apply saltstack/salt#56031 to support Python 3.8, which removed a
deprecated module and changed some behaviour. Add a {Build,}Requires on
python-distro, since it is now required.

### What issues does this PR fix or reference?

Adds support for Python 3.8, so Tumbleweed can move forward with using it rather than 3.7.

### Tests written?

Yes -- inasmuch if the tests pass under Python 3.8, it's all good

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
