### PR TITLE
batch_async: avoid using fnmatch to match event

### DIFF
--- a/salt/cli/batch_async.py
+++ b/salt/cli/batch_async.py
@@ -106,7 +106,7 @@ class BatchAsync(object):
             return
         mtag, data = self.event.unpack(raw, self.event.serial)
         for (pattern, op) in self.patterns:
-            if fnmatch.fnmatch(mtag, pattern):
+            if mtag.startswith(pattern[:-1]):
                 minion = data['id']
                 if op == 'ping_return':
                     self.minions.add(minion)


### PR DESCRIPTION
### What does this PR do?

It reduces CPU load in cases where a lot of `async_batch` calls are being performed.

Behavior observed (`htop` output: before patch on top, after patch in bottom, load reduced to ~0.34x)

![salt_pr_217](https://user-images.githubusercontent.com/250541/75561485-601e5580-5a47-11ea-85b3-2344ab01caf4.png)

### Tests written?

No, already covered

### Commits signed with GPG?

Yes
