### PR TITLE
use full option name instead of undocumented abbreviation

### DIFF
--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -2494,7 +2494,7 @@ def list_products(all=False, refresh=False, root=None):
         OEM_PATH = os.path.join(root, os.path.relpath(OEM_PATH, os.path.sep))
     cmd = list()
     if not all:
-        cmd.append('--disable-repos')
+        cmd.append('--disable-repositories')
     cmd.append('products')
     if not all:
         cmd.append('-i')


### PR DESCRIPTION
### What does this PR do?

Change an option name when call zypper. We used an undocumented abbreviation which will be removed in future versions of zypper. Use the full option name instead.

Prevents:

```
"Module function pkg.list_products threw an exception. Exception: Zypper command failure: The flag --disable-repos is not known.",
```

errors.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/pull/56278