### PR TITLE
loop: fix variable names for until_no_eval

### DIFF
--- a/salt/states/loop.py
+++ b/salt/states/loop.py
@@ -185,10 +185,10 @@ def until_no_eval(
                           ''.format(name, expected))
     if ret['comment']:
         return ret
-    if not m_args:
-        m_args = []
-    if not m_kwargs:
-        m_kwargs = {}
+    if not args:
+        args = []
+    if not kwargs:
+        kwargs = {}
 
     if init_wait:
         time.sleep(init_wait)


### PR DESCRIPTION
### What does this PR do?

Rename the until_no_eval variable names.