### PR TITLE
Adds explicit type cast for port

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1457,9 +1457,9 @@ def _netlink_tool_remote_on(port, which_end):
         local_host, local_port = chunks[3].rsplit(':', 1)
         remote_host, remote_port = chunks[4].rsplit(':', 1)
 
-        if which_end == 'remote_port' and int(remote_port) != port:
+        if which_end == 'remote_port' and int(remote_port) != int(port):
             continue
-        if which_end == 'local_port' and int(local_port) != port:
+        if which_end == 'local_port' and int(local_port) != int(port):
             continue
         remotes.add(remote_host.strip("[]"))
 


### PR DESCRIPTION
### What does this PR do?
If a port was passed as a string, the execution logic was broken
and a wrong set of remotes was returned.

The type casting to int solves this issue.

### What issues does this PR fix or reference?

### Tests written?

No. This fixes a test.

### Commits signed with GPG?

Yes