### PR TITLE
Catch NameError in IPCClient.close()

### DIFF
--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -361,8 +361,11 @@ class IPCClient(object):
 
         self._closing = True
 
-        log.debug('Closing %s instance', self.__class__.__name__)
-
+        try:
+            log.debug('Closing %s instance', self.__class__.__name__)
+        except NameError:
+            # Possible race condition: name '__salt_system_encoding__' is not defined
+            pass
         if self.stream is not None and not self.stream.closed():
             self.stream.close()
 


### PR DESCRIPTION
### What does this PR do?
IPCClient's destructor calls close(), which tries to log a debug statement. Logging might hit a race condition, it sometimes raises:

    NameError: name '__salt_system_encoding__' is not defined

Logging not being available should not stop `__del__()` or `close()` from cleaning up.

### What issues does this PR fix or reference?
Related issue: https://github.com/SUSE/spacewalk/issues/11018

### Previous Behavior

    NameError: name '__salt_system_encoding__' is not defined

### New Behavior

Exception is caught

### Tests written?

No

### Commits signed with GPG?

Yes
