### PR TITLE
Backport from 3000.1 - Revert changes to slspath (saltstack/salt#56341) 

### DIFF
--- a/doc/ref/states/vars.rst
+++ b/doc/ref/states/vars.rst
@@ -96,10 +96,11 @@ include option.
 slspath
 =======
 
-The `slspath` variable contains the path to the current sls file. The value
-of `slspath` in files referenced in the current sls depends on the reference
-method. For jinja includes `slspath` is the path to the current file. For
-salt includes `slspath` is the path to the included file.
+The `slspath` variable contains the path to the directory of the current sls
+file. The value of `slspath` in files referenced in the current sls depends on
+the reference method. For jinja includes `slspath` is the path to the current
+directory of the file. For salt includes `slspath` is the path to the directory
+of the included file.
 
 .. code-block:: jinja
 

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -122,6 +122,8 @@ def wrap_tmpl_func(render_str):
             slspath = context['sls'].replace('.', '/')
             if tmplpath is not None:
                 context['tplpath'] = tmplpath
+                if not tmplpath.lower().replace('\\', '/').endswith('/init.sls'):
+                    slspath = os.path.dirname(slspath)
                 template = tmplpath.replace('\\', '/')
                 i = template.rfind(slspath.replace('.', '/'))
                 if i != -1:

--- a/tests/unit/utils/test_templates.py
+++ b/tests/unit/utils/test_templates.py
@@ -5,13 +5,16 @@ Unit tests for salt.utils.templates.py
 
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
+import os
 import sys
 import logging
 
 # Import Salt libs
 import salt.utils.templates
+import salt.utils.files
 
 # Import Salt Testing Libs
+from tests.support.helpers import with_tempdir
 from tests.support.unit import TestCase, skipIf
 
 log = logging.getLogger(__name__)
@@ -181,3 +184,46 @@ class RenderTestCase(TestCase):
         ctx['var'] = 'OK'
         res = salt.utils.templates.render_cheetah_tmpl(tmpl, ctx)
         self.assertEqual(res.strip(), 'OK')
+
+
+class MockRender(object):
+    def __call__(self, tplstr, context, tmplpath=None):
+        self.tplstr = tplstr
+        self.context = context
+        self.tmplpath = tmplpath
+        return tplstr
+
+
+class WrapRenderTestCase(TestCase):
+
+    @with_tempdir()
+    def test_wrap_issue_56119_a(self, tempdir):
+        slsfile = os.path.join(tempdir, 'foo')
+        with salt.utils.files.fopen(slsfile, 'w') as fp:
+            fp.write('{{ slspath }}')
+        context = {'opts': {}, 'saltenv': 'base', 'sls': 'foo.bar'}
+        render = MockRender()
+        wrapped = salt.utils.templates.wrap_tmpl_func(render)
+        res = wrapped(
+            slsfile,
+            context=context,
+            tmplpath='/tmp/foo/bar/init.sls'
+        )
+        assert render.context['slspath'] == 'foo/bar', render.context['slspath']
+        assert render.context['tpldir'] == 'foo/bar', render.context['tpldir']
+
+    @with_tempdir()
+    def test_wrap_issue_56119_b(self, tempdir):
+        slsfile = os.path.join(tempdir, 'foo')
+        with salt.utils.files.fopen(slsfile, 'w') as fp:
+            fp.write('{{ slspath }}')
+        context = {'opts': {}, 'saltenv': 'base', 'sls': 'foo.bar.bang'}
+        render = MockRender()
+        wrapped = salt.utils.templates.wrap_tmpl_func(render)
+        res = wrapped(
+            slsfile,
+            context=context,
+            tmplpath='/tmp/foo/bar/bang.sls'
+        )
+        assert render.context['slspath'] == 'foo/bar', render.context['slspath']
+        assert render.context['tpldir'] == 'foo/bar', render.context['tpldir']


### PR DESCRIPTION
Revert changes to slspath (saltstack/salt#56341)

This was a breaking change in v3000 that was fixed in 3000.1

Fixes https://bugzilla.opensuse.org/show_bug.cgi?id=1170104

