### PR TITLE
info_installed works without status attr now

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2867,6 +2867,15 @@ def info_installed(*names, **kwargs):
     failhard = kwargs.pop('failhard', True)
     kwargs.pop('errors', None)                # Only for compatibility with RPM
     attr = kwargs.pop('attr', None)           # Package attributes to return
+
+    # status is needed to see if a package is installed. So we have to add it,
+    # even if it's excluded via attr parameter. Otherwise all packages are
+    # returned.
+    if attr:
+        attr_list = set(attr.split(','))
+        attr_list.add('status')
+        attr = ','.join(attr_list)
+
     all_versions = kwargs.pop('all_versions', False)  # This is for backward compatible structure only
 
     if kwargs:

--- a/tests/unit/modules/test_aptpkg.py
+++ b/tests/unit/modules/test_aptpkg.py
@@ -257,6 +257,23 @@ class AptPkgTestCase(TestCase, LoaderModuleMockMixin):
         self.assertEqual(aptpkg.info_installed('wget'), installed)
         self.assertEqual(len(aptpkg.info_installed()), 1)
 
+    def test_info_installed_attr_without_status(self):
+        '''
+        Test info_installed 'attr' for inclusion of 'status' attribute.
+
+        Since info_installed should only return installed packages, we need to
+        call __salt__['lowpkg.info'] with the 'status' attribute even if the user
+        is not asking for it in 'attr'. Otherwise info_installed would not be able
+        to check if the package is installed and would return everything.
+
+        :return:
+        '''
+        with patch('salt.modules.aptpkg.__salt__', {'lowpkg.info': MagicMock(return_value=LOWPKG_INFO)}) as wget_lowpkg:
+            ret = aptpkg.info_installed('wget', attr='version')
+            calls = wget_lowpkg['lowpkg.info'].call_args_list.pop()
+            self.assertIn('status', calls.kwargs['attr'])
+            self.assertIn('version', calls.kwargs['attr'])
+
     @patch('salt.modules.aptpkg.__salt__', {'lowpkg.info': MagicMock(return_value=LOWPKG_INFO)})
     def test_info_installed_attr(self):
         '''


### PR DESCRIPTION
### What does this PR do?

If 'status' was excluded via attr, info_installed was no longer able to detect if a package was installed or not. Now info_installed adds the 'status' for the 'lowpkg.info' request again.

### What issues does this PR fix or reference?

Upstream PR: https://github.com/saltstack/salt/pull/57779

### Previous Behavior

Uninstalled packages with config (status==rc) where shown as installed.

### New Behavior

Uninstalled packages are no longer shown.

### Tests written?

Yes

### Commits signed with GPG?

Yes