### PR TITLE
Fix salt-sproxy crashing because of mislead requirements in installed Salt

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 Jinja2
-msgpack>=0.5,!=0.5.5,<1.0.0
+msgpack>=0.5,!=0.5.5
 PyYAML
 MarkupSafe
 requests>=1.0.0


### PR DESCRIPTION
### What does this PR do?

Salt has  a `msgpack<1.0.0` line in _requirements/base.txt_ even if as a package runs with `msgpack>=1.0.0` requirement in the installed metadata. If a program uses the metadata to evaluate requirements, like _salt-sproxy_ does, it will crash.

### What issues does this PR fix or reference?

I am preparing _salt-sproxy_ (https://build.opensuse.org/package/show/home:dmacvicar/salt-sproxy) and found this problem.
Note that salt-sproxy also restricts msgpack, and we apply a similar fix.

See: https://twitter.com/mirceaulinic/status/1287871911255347200

### Previous Behavior

```
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 583, in _build_master
    ws.require(__requires__)
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 791, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (msgpack 1.0.0 (/usr/lib64/python3.8/site-packages), Requirement.parse('msgpack!=0.5.5,<1.0.0,>=0.5'), {'salt'})

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/salt-sproxy", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3252, in <module>
    def _initialize_master_working_set():
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3235, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3264, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 585, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 598, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/usr/lib/python3.8/site-packages/pkg_resources/__init__.py", line 786, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'msgpack!=0.5.5,<1.0.0,>=0.5' distribution was not found and is required by salt`
```

### New Behavior

```
salt-sproxy

Cannot execute command without defining a target.
```

### Tests written?

No

### Commits signed with GPG?

No
