### PR TITLE
Fix the removed six.itermitems and six.*_type*

### DIFF
--- a/salt/_compat.py
+++ b/salt/_compat.py
@@ -39,6 +39,7 @@ except Exception:  # pylint: disable=broad-except
 # True if we are running on Python 3.
 PY3 = sys.version_info.major == 3
 
+import xml.sax.saxutils as saxutils
 
 if PY3:
     import builtins

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -88,8 +88,6 @@ import string  # pylint: disable=deprecated-module
 import subprocess
 import sys
 import time
-from xml.etree import ElementTree
-from xml.sax import saxutils
 
 # Import third party libs
 import jinja2.exceptions
@@ -104,6 +102,8 @@ import salt.utils.templates
 import salt.utils.xmlutil as xmlutil
 import salt.utils.yaml
 from salt._compat import ipaddress
+from salt._compat import ElementTree
+from salt._compat import saxutils
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.ext import six
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
@@ -1521,7 +1521,7 @@ def _handle_remote_boot_params(orig_boot):
     """
     saltinst_dir = None
     new_boot = orig_boot.copy()
-    keys = orig_boot.keys()
+    keys = set(orig_boot.keys())
     cases = [
         {"efi"},
         {"kernel", "initrd", "efi"},
@@ -2548,7 +2548,7 @@ def update(
                     # Attaching device
                     if source_file:
                         ElementTree.SubElement(
-                            updated_disk, "source", attrib={"file": source_file}
+                            updated_disk, "source", file=source_file
                         )
 
             changes["disk"]["new"] = new_disks
@@ -6626,7 +6626,7 @@ def volume_infos(pool=None, volume=None, **kwargs):
             }
             for pool_obj in pools
         }
-        return {pool_name: volumes for (pool_name, volumes) in six.itermitems(vols) if volumes}
+        return {pool_name: volumes for (pool_name, volumes) in six.iteritems(vols) if volumes}
     except libvirt.libvirtError as err:
         log.debug("Silenced libvirt error: %s", six.text_type(err))
     finally:

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -105,6 +105,7 @@ import salt.utils.xmlutil as xmlutil
 import salt.utils.yaml
 from salt._compat import ipaddress
 from salt.exceptions import CommandExecutionError, SaltInvocationError
+from salt.ext import six
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 from salt.ext.six.moves.urllib.parse import urlparse, urlunparse
 from salt.utils.virt import check_remote, download_remote
@@ -657,8 +658,8 @@ def _gen_xml(
     context = {
         "hypervisor": hypervisor,
         "name": name,
-        "cpu": str(cpu),
-        "mem": str(mem),
+        "cpu": six.text_type(cpu),
+        "mem": six.text_type(mem),
     }
     if hypervisor in ["qemu", "kvm"]:
         context["controller_model"] = False
@@ -722,7 +723,7 @@ def _gen_xml(
             "target_dev": _get_disk_target(targets, len(diskp), prefix),
             "disk_bus": disk["model"],
             "format": disk.get("format", "raw"),
-            "index": str(i),
+            "index": six.text_type(i),
         }
         targets.append(disk_context["target_dev"])
         if disk.get("source_file"):
@@ -827,8 +828,8 @@ def _gen_vol_xml(
         "name": name,
         "target": {"permissions": permissions, "nocow": nocow},
         "format": format,
-        "size": str(size),
-        "allocation": str(int(allocation) * 1024),
+        "size": six.text_type(size),
+        "allocation": six.text_type(int(allocation) * 1024),
         "backingStore": backing_store,
     }
     fn_ = "libvirt_volume.jinja"
@@ -1253,7 +1254,7 @@ def _disk_profile(conn, profile, hypervisor, disks, vm_name):
         )
 
         # Transform the list to remove one level of dictionary and add the name as a property
-        disklist = [dict(d, name=name) for disk in disklist for name, d in disk.items()]
+        disklist = [dict(d, name=name) for disk in disklist for name, d in six.iteritems(disk)]
 
     # Merge with the user-provided disks definitions
     if disks:
@@ -1274,7 +1275,7 @@ def _disk_profile(conn, profile, hypervisor, disks, vm_name):
             disk["model"] = "ide"
 
         # Add the missing properties that have defaults
-        for key, val in overlay.items():
+        for key, val in six.iteritems(overlay):
             if key not in disk:
                 disk[key] = val
 
@@ -1422,7 +1423,7 @@ def _complete_nics(interfaces, hypervisor):
         """
         Apply the default overlay to attributes
         """
-        for key, value in overlays[hypervisor].items():
+        for key, value in six.iteritems(overlays[hypervisor]):
             if key not in attributes or not attributes[key]:
                 attributes[key] = value
 
@@ -1449,7 +1450,7 @@ def _nic_profile(profile_name, hypervisor):
         """
         Append dictionary profile data to interfaces list
         """
-        for interface_name, attributes in profile_dict.items():
+        for interface_name, attributes in six.iteritems(profile_dict):
             attributes["name"] = interface_name
             interfaces.append(attributes)
 
@@ -2380,8 +2381,8 @@ def update(
     # Update the cpu
     cpu_node = desc.find("vcpu")
     if cpu and int(cpu_node.text) != cpu:
-        cpu_node.text = str(cpu)
-        cpu_node.set("current", str(cpu))
+        cpu_node.text = six.text_type(cpu)
+        cpu_node.set("current", six.text_type(cpu))
         need_update = True
 
     def _set_loader(node, value):
@@ -2394,7 +2395,7 @@ def update(
         node.set("template", value)
 
     def _set_with_mib_unit(node, value):
-        node.text = str(value)
+        node.text = six.text_type(value)
         node.set("unit", "MiB")
 
     # Update the kernel boot parameters
@@ -2426,7 +2427,7 @@ def update(
         },
     ]
 
-    data = {k: v for k, v in locals().items() if bool(v)}
+    data = {k: v for k, v in six.iteritems(locals()) if bool(v)}
     if boot_dev:
         data["boot_dev"] = {i + 1: dev for i, dev in enumerate(boot_dev.split())}
     need_update = need_update or salt.utils.xmlutil.change_xml(
@@ -2609,7 +2610,7 @@ def update(
             except libvirt.libvirtError as err:
                 if "errors" not in status:
                     status["errors"] = []
-                status["errors"].append(str(err))
+                status["errors"].append(six.text_type(err))
 
     conn.close()
     return status
@@ -2823,7 +2824,7 @@ def _node_info(conn):
     info = {
         "cpucores": raw[6],
         "cpumhz": raw[3],
-        "cpumodel": str(raw[0]),
+        "cpumodel": six.text_type(raw[0]),
         "cpus": raw[2],
         "cputhreads": raw[7],
         "numanodes": raw[4],
@@ -3628,7 +3629,7 @@ def _define_vol_xml_str(conn, xml, pool=None):  # pylint: disable=redefined-oute
     poolname = (
         pool if pool else __salt__["config.get"]("virt:storagepool", default_pool)
     )
-    pool = conn.storagePoolLookupByName(str(poolname))
+    pool = conn.storagePoolLookupByName(six.text_type(poolname))
     ret = pool.createXML(xml, 0) is not None
     return ret
 
@@ -3829,7 +3830,7 @@ def seed_non_shared_migrate(disks, force=False):
 
         salt '*' virt.seed_non_shared_migrate <disks>
     """
-    for _, data in disks.items():
+    for _, data in six.iteritems(disks):
         fn_ = data["file"]
         form = data["file format"]
         size = data["virtual size"].split()[1][1:]
@@ -4852,7 +4853,7 @@ def capabilities(**kwargs):
     try:
         caps = _capabilities(conn)
     except libvirt.libvirtError as err:
-        raise CommandExecutionError(str(err))
+        raise CommandExecutionError(six.text_type(err))
     finally:
         conn.close()
     return caps
@@ -5352,7 +5353,7 @@ def network_info(name=None, **kwargs):
             for net in nets
         }
     except libvirt.libvirtError as err:
-        log.debug("Silenced libvirt error: %s", str(err))
+        log.debug("Silenced libvirt error: %s", six.text_type(err))
     finally:
         conn.close()
     return result
@@ -6214,7 +6215,7 @@ def pool_info(name=None, **kwargs):
         ]
         result = {pool.name(): _pool_extract_infos(pool) for pool in pools}
     except libvirt.libvirtError as err:
-        log.debug("Silenced libvirt error: %s", str(err))
+        log.debug("Silenced libvirt error: %s", six.text_type(err))
     finally:
         conn.close()
     return result
@@ -6591,12 +6592,12 @@ def volume_infos(pool=None, volume=None, **kwargs):
             if vol.path():
                 as_backing_store = {
                     path
-                    for (path, all_paths) in backing_stores.items()
+                    for (path, all_paths) in six.iteritems(backing_stores)
                     if vol.path() in all_paths
                 }
                 used_by = [
                     vm_name
-                    for (vm_name, vm_disks) in disks.items()
+                    for (vm_name, vm_disks) in six.iteritems(disks)
                     if vm_disks & as_backing_store or vol.path() in vm_disks
                 ]
 
@@ -6625,9 +6626,9 @@ def volume_infos(pool=None, volume=None, **kwargs):
             }
             for pool_obj in pools
         }
-        return {pool_name: volumes for (pool_name, volumes) in vols.items() if volumes}
+        return {pool_name: volumes for (pool_name, volumes) in six.itermitems(vols) if volumes}
     except libvirt.libvirtError as err:
-        log.debug("Silenced libvirt error: %s", str(err))
+        log.debug("Silenced libvirt error: %s", six.text_type(err))
     finally:
         conn.close()
     return result

--- a/salt/states/virt.py
+++ b/salt/states/virt.py
@@ -23,6 +23,7 @@ import salt.utils.files
 import salt.utils.stringutils
 import salt.utils.versions
 from salt.exceptions import CommandExecutionError, SaltInvocationError
+from salt.ext import six
 
 try:
     import libvirt  # pylint: disable=import-error
@@ -97,7 +98,7 @@ def keys(name, basepath="/etc/pki", **kwargs):
     # rename them to something hopefully unique to avoid
     # overriding anything existing
     pillar_kwargs = {}
-    for key, value in kwargs.items():
+    for key, value in six.iteritems(kwargs):
         pillar_kwargs["ext_pillar_virt.{}".format(key)] = value
 
     pillar = __salt__["pillar.ext"]({"libvirt": "_"}, pillar_kwargs)
@@ -187,7 +188,7 @@ def _virt_call(
             else:
                 noaction_domains.append(targeted_domain)
         except libvirt.libvirtError as err:
-            ignored_domains.append({"domain": targeted_domain, "issue": str(err)})
+            ignored_domains.append({"domain": targeted_domain, "issue": six.text_type(err)})
     if not changed_domains:
         ret["result"] = not ignored_domains and bool(targeted_domains)
         ret["comment"] = "No changes had happened"
@@ -461,7 +462,7 @@ def defined(
             ret["comment"] = "Domain {} defined".format(name)
     except libvirt.libvirtError as err:
         # Something bad happened when defining / updating the VM, report it
-        ret["comment"] = str(err)
+        ret["comment"] = six.text_type(err)
         ret["result"] = False
 
     return ret
@@ -704,7 +705,7 @@ def running(
 
         except libvirt.libvirtError as err:
             # Something bad happened when starting / updating the VM, report it
-            ret["comment"] = str(err)
+            ret["comment"] = six.text_type(err)
             ret["result"] = False
 
     return ret
@@ -867,7 +868,7 @@ def reverted(
                     }
                 except CommandExecutionError as err:
                     if len(domains) > 1:
-                        ignored_domains.append({"domain": domain, "issue": str(err)})
+                        ignored_domains.append({"domain": domain, "issue": six.text_type(err)})
                 if len(domains) > 1:
                     if result:
                         ret["changes"]["reverted"].append(result)
@@ -885,9 +886,9 @@ def reverted(
             if not ret["changes"]["reverted"]:
                 ret["changes"].pop("reverted")
     except libvirt.libvirtError as err:
-        ret["comment"] = str(err)
+        ret["comment"] = six.text_type(err)
     except CommandExecutionError as err:
-        ret["comment"] = str(err)
+        ret["comment"] = six.text_type(err)
 
     return ret
 

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -4,6 +4,7 @@ Functions for manipulating, inspecting, or otherwise working with data types
 and data structures.
 """
 
+from __future__ import absolute_import, print_function, unicode_literals
 
 # Import Python libs
 import copy
@@ -145,7 +146,7 @@ def compare_dicts(old=None, new=None):
     dict describing the changes that were made.
     """
     ret = {}
-    for key in set(new or {}).union(old or {}):
+    for key in set((new or {})).union((old or {})):
         if key not in old:
             # New key
             ret[key] = {"old": "", "new": new[key]}

--- a/salt/utils/data.py
+++ b/salt/utils/data.py
@@ -71,7 +71,7 @@ class CaseInsensitiveDict(MutableMapping):
         return self._data[to_lowercase(key)][1]
 
     def __iter__(self):
-        return (item[0] for item in self._data.values())
+        return (item[0] for item in six.itervalues(self._data))
 
     def __eq__(self, rval):
         if not isinstance(rval, Mapping):
@@ -80,20 +80,20 @@ class CaseInsensitiveDict(MutableMapping):
         return dict(self.items_lower()) == dict(CaseInsensitiveDict(rval).items_lower())
 
     def __repr__(self):
-        return repr(dict(self.items()))
+        return repr(dict(six.iteritems(self)))
 
     def items_lower(self):
         """
         Returns a generator iterating over keys and values, with the keys all
         being lowercase.
         """
-        return ((key, val[1]) for key, val in self._data.items())
+        return ((key, val[1]) for key, val in six.iteritems(self._data))
 
     def copy(self):
         """
         Returns a copy of the object
         """
-        return CaseInsensitiveDict(self._data.items())
+        return CaseInsensitiveDict(six.iteritems(self._data))
 
 
 def __change_case(data, attr, preserve_dict_class=False):
@@ -115,7 +115,7 @@ def __change_case(data, attr, preserve_dict_class=False):
                 __change_case(key, attr, preserve_dict_class),
                 __change_case(val, attr, preserve_dict_class),
             )
-            for key, val in data.items()
+            for key, val in six.iteritems(data) 
         )
     if isinstance(data, Sequence):
         return data_type(
@@ -205,7 +205,7 @@ def _remove_circular_refs(ob, _seen=None):
     if isinstance(ob, dict):
         res = {
             _remove_circular_refs(k, _seen): _remove_circular_refs(v, _seen)
-            for k, v in ob.items()
+            for k, v in six.iteritems(ob)
         }
     elif isinstance(ob, (list, tuple, set, frozenset)):
         res = type(ob)(_remove_circular_refs(v, _seen) for v in ob)
@@ -336,7 +336,7 @@ def decode_dict(
     )
     # Make sure we preserve OrderedDicts
     ret = data.__class__() if preserve_dict_class else {}
-    for key, value in data.items():
+    for key, value in six.iteritems(data):
         if isinstance(key, tuple):
             key = (
                 decode_tuple(
@@ -592,7 +592,7 @@ def encode_dict(
     # Clean data object before encoding to avoid circular references
     data = _remove_circular_refs(data)
     ret = data.__class__() if preserve_dict_class else {}
-    for key, value in data.items():
+    for key, value in six.iteritems(data):
         if isinstance(key, tuple):
             key = (
                 encode_tuple(key, encoding, errors, keep, preserve_dict_class)
@@ -734,8 +734,8 @@ def filter_by(lookup_dict, lookup, traverse, merge=None, default="default", base
     # lookup_dict keys
     for each in val if isinstance(val, list) else [val]:
         for key in lookup_dict:
-            test_key = key if isinstance(key, str) else str(key)
-            test_each = each if isinstance(each, str) else str(each)
+            test_key = key if isinstance(key, six.string_types) else six.text_type(key)
+            test_each = each if isinstance(each, six.string_types) else six.text_type(each)
             if fnmatch.fnmatchcase(test_each, test_key):
                 ret = lookup_dict[key]
                 break
@@ -851,11 +851,11 @@ def subdict_match(
         # begin with is that (by design) to_unicode will raise a TypeError if a
         # non-string/bytestring/bytearray value is passed.
         try:
-            target = str(target).lower()
+            target = six.text_type(target).lower()
         except UnicodeDecodeError:
             target = salt.utils.stringutils.to_unicode(target).lower()
         try:
-            pattern = str(pattern).lower()
+            pattern = six.text_type(pattern).lower()
         except UnicodeDecodeError:
             pattern = salt.utils.stringutils.to_unicode(pattern).lower()
 
@@ -997,7 +997,7 @@ def repack_dictlist(data, strict=False, recurse=False, key_cb=None, val_cb=None)
     Takes a list of one-element dicts (as found in many SLS schemas) and
     repacks into a single dictionary.
     """
-    if isinstance(data, str):
+    if isinstance(data, six.string_types):
         try:
             data = salt.utils.yaml.safe_load(data)
         except salt.utils.yaml.parser.ParserError as err:
@@ -1009,7 +1009,7 @@ def repack_dictlist(data, strict=False, recurse=False, key_cb=None, val_cb=None)
     if val_cb is None:
         val_cb = lambda x, y: y
 
-    valid_non_dict = ((str,), (int,), float)
+    valid_non_dict = (six.string_types, six.integer_types, float)
     if isinstance(data, list):
         for element in data:
             if isinstance(element, valid_non_dict):
@@ -1067,7 +1067,7 @@ def is_list(value):
 
 
 @jinja_filter("is_iter")
-def is_iter(thing, ignore=(str,)):
+def is_iter(thing, ignore=six.string_types):
     """
     Test if an object is iterable, but not a string type.
 
@@ -1124,10 +1124,10 @@ def is_true(value=None):
         pass
 
     # Now check for truthiness
-    if isinstance(value, ((int,), float)):
+    if isinstance(value, (six.integer_types, float)):
         return value > 0
-    if isinstance(value, str):
-        return str(value).lower() == "true"
+    if isinstance(value, six.string_types):
+        return six.text_type(value).lower() == "true"
     return bool(value)
 
 
@@ -1167,7 +1167,7 @@ def simple_types_filter(data):
     if data is None:
         return data
 
-    simpletypes_keys = ((str,), str, (int,), float, bool)
+    simpletypes_keys = (six.string_types, six.text_type, six.integer_types, float, bool)
     simpletypes_values = tuple(list(simpletypes_keys) + [list, tuple])
 
     if isinstance(data, (list, tuple)):
@@ -1183,7 +1183,7 @@ def simple_types_filter(data):
 
     if isinstance(data, dict):
         simpledict = {}
-        for key, value in data.items():
+        for key, value in six.iteritems(data):
             if key is not None and not isinstance(key, simpletypes_keys):
                 key = repr(key)
             if value is not None and isinstance(value, (dict, list, tuple)):
@@ -1205,8 +1205,8 @@ def stringify(data):
     for item in data:
         if six.PY2 and isinstance(item, str):
             item = salt.utils.stringutils.to_unicode(item)
-        elif not isinstance(item, str):
-            item = str(item)
+        elif not isinstance(item, six.string_types):
+            item = six.text_type(item)
         ret.append(item)
     return ret
 
@@ -1282,7 +1282,7 @@ def filter_falsey(data, recurse_depth=None, ignore_types=()):
 
     if isinstance(data, dict):
         processed_elements = [
-            (key, filter_element(value)) for key, value in data.items()
+            (key, filter_element(value)) for key, value in six.iteritems(data)
         ]
         return type(data)(
             [
@@ -1472,7 +1472,7 @@ def get_value(obj, path, default=None):
             if obj is None:
                 return res
             if isinstance(obj, dict):
-                items = obj.items()
+                items = six.iteritems(obj)
             elif isinstance(obj, list):
                 items = enumerate(obj)
 

--- a/salt/utils/xmlutil.py
+++ b/salt/utils/xmlutil.py
@@ -9,6 +9,7 @@ from xml.etree import ElementTree
 
 # Import salt libs
 import salt.utils.data
+from salt.ext import six
 
 
 def _conv_name(x):
@@ -147,7 +148,7 @@ def set_node_text(node, value):
     :param node: the node to set the text to
     :param value: the value to set
     """
-    node.text = str(value)
+    node.text = six.text_type(value)
 
 
 def clean_node(parent_map, node, ignored=None):

--- a/salt/utils/xmlutil.py
+++ b/salt/utils/xmlutil.py
@@ -163,7 +163,7 @@ def clean_node(parent_map, node, ignored=None):
     has_text = node.text is not None and node.text.strip()
     parent = parent_map.get(node)
     if (
-        len(node.attrib.keys() - (ignored or [])) == 0
+        len(set(node.attrib.keys()) - set(ignored or [])) == 0
         and not list(node)
         and not has_text
     ):

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -48,7 +48,7 @@ class LibvirtMock(MagicMock):  # pylint: disable=too-many-ancestors
         """
 
         def __init__(self, msg):
-            super().__init__(msg)
+            super(Exception, self).__init__(msg)
             self.msg = msg
 
         def get_error_message(self):

--- a/tests/unit/utils/test_data.py
+++ b/tests/unit/utils/test_data.py
@@ -1,14 +1,17 @@
+# -*- coding: utf-8 -*-
 """
 Tests for salt.utils.data
 """
 
 # Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
 
 import logging
 
 # Import Salt libs
 import salt.utils.data
 import salt.utils.stringutils
+from salt.ext import six
 
 # Import 3rd party libs
 from salt.ext.six.moves import (  # pylint: disable=import-error,redefined-builtin
@@ -414,18 +417,19 @@ class DataTestCase(TestCase):
         )
         self.assertEqual(ret, expected)
 
-        # The binary data in the data structure should fail to decode, even
-        # using the fallback, and raise an exception.
-        self.assertRaises(
-            UnicodeDecodeError,
-            salt.utils.data.decode,
-            self.test_data,
-            keep=False,
-            normalize=True,
-            preserve_dict_class=True,
-            preserve_tuples=True,
-            to_str=True,
-        )
+        if six.PY3:
+            # The binary data in the data structure should fail to decode, even
+            # using the fallback, and raise an exception.
+            self.assertRaises(
+                UnicodeDecodeError,
+                salt.utils.data.decode,
+                self.test_data,
+                keep=False,
+                normalize=True,
+                preserve_dict_class=True,
+                preserve_tuples=True,
+                to_str=True,
+            )
 
         # Now munge the expected data so that we get what we would expect if we
         # disable preservation of dict class and tuples
@@ -469,9 +473,14 @@ class DataTestCase(TestCase):
 
         # Test binary blob
         self.assertEqual(salt.utils.data.decode(BYTES, keep=True, to_str=True), BYTES)
-        self.assertRaises(
-            UnicodeDecodeError, salt.utils.data.decode, BYTES, keep=False, to_str=True,
-        )
+        if six.PY3:
+            self.assertRaises(
+                UnicodeDecodeError,
+                salt.utils.data.decode,
+                BYTES,
+                keep=False,
+                to_str=True,
+            )
 
     def test_decode_fallback(self):
         """
@@ -666,7 +675,7 @@ class DataTestCase(TestCase):
         self.assertRaises(TypeError, salt.utils.data.stringify, 9)
         self.assertEqual(
             salt.utils.data.stringify(
-                ["one", "two", "three", 4, 5]
+                ["one", "two", str("three"), 4, 5]
             ),  # future lint: disable=blacklisted-function
             ["one", "two", "three", "4", "5"],
         )
@@ -720,7 +729,7 @@ class FilterFalseyTestCase(TestCase):
         # Check returned type equality
         self.assertIs(type(old_list), type(new_list))
         # Test with set
-        old_set = {"foo", "bar"}
+        old_set = set(["foo", "bar"])
         new_set = salt.utils.data.filter_falsey(old_set)
         self.assertEqual(old_set, new_set)
         # Check returned type equality
@@ -839,9 +848,9 @@ class FilterFalseyTestCase(TestCase):
         Test filtering a set without recursing.
         Note that a set cannot contain unhashable types, so recursion is not possible.
         """
-        old_set = {"foo", None, 0, ""}
+        old_set = set(["foo", None, 0, ""])
         new_set = salt.utils.data.filter_falsey(old_set)
-        expect_set = {"foo"}
+        expect_set = set(["foo"])
         self.assertEqual(expect_set, new_set)
         self.assertIs(type(expect_set), type(new_set))
 
@@ -1053,13 +1062,13 @@ class FilterRecursiveDiff(TestCase):
         """
         Test cases where equal sets are compared.
         """
-        test_set = {0, 1, 2, 3, "foo"}
+        test_set = set([0, 1, 2, 3, "foo"])
         self.assertEqual({}, salt.utils.data.recursive_diff(test_set, test_set))
 
         # This is a bit of an oddity, as python seems to sort the sets in memory
         # so both sets end up with the same ordering (0..3).
-        set_one = {0, 1, 2, 3}
-        set_two = {3, 2, 1, 0}
+        set_one = set([0, 1, 2, 3])
+        set_two = set([3, 2, 1, 0])
         self.assertEqual({}, salt.utils.data.recursive_diff(set_one, set_two))
 
     def test_tuple_equality(self):
@@ -1149,13 +1158,13 @@ class FilterRecursiveDiff(TestCase):
         Tricky as the sets are compared zipped, so shuffled sets of equal values
         are considered different.
         """
-        set_one = {0, 1, 2, 4}
-        set_two = {0, 1, 3, 4}
-        expected_result = {"old": {2}, "new": {3}}
+        set_one = set([0, 1, 2, 4])
+        set_two = set([0, 1, 3, 4])
+        expected_result = {"old": set([2]), "new": set([3])}
         self.assertEqual(
             expected_result, salt.utils.data.recursive_diff(set_one, set_two)
         )
-        expected_result = {"new": {2}, "old": {3}}
+        expected_result = {"new": set([2]), "old": set([3])}
         self.assertEqual(
             expected_result, salt.utils.data.recursive_diff(set_two, set_one)
         )
@@ -1164,8 +1173,8 @@ class FilterRecursiveDiff(TestCase):
         # Python 2.7 seems to sort it (i.e. set_one below becomes {0, 1, 'foo', 'bar'}
         # However Python 3.6.8 stores it differently each run.
         # So just test for "not equal" here.
-        set_one = {0, "foo", 1, "bar"}
-        set_two = {"foo", 1, "bar", 2}
+        set_one = set([0, "foo", 1, "bar"])
+        set_two = set(["foo", 1, "bar", 2])
         expected_result = {}
         self.assertNotEqual(
             expected_result, salt.utils.data.recursive_diff(set_one, set_two)
@@ -1203,18 +1212,18 @@ class FilterRecursiveDiff(TestCase):
             expected_result, salt.utils.data.recursive_diff(list_two, list_one)
         )
 
-        mixed_one = {"foo": {0, 1, 2}, "bar": [0, 1, 2]}
-        mixed_two = {"foo": {1, 2, 3}, "bar": [1, 2, 3]}
+        mixed_one = {"foo": set([0, 1, 2]), "bar": [0, 1, 2]}
+        mixed_two = {"foo": set([1, 2, 3]), "bar": [1, 2, 3]}
         expected_result = {
-            "old": {"foo": {0}, "bar": [0, 1, 2]},
-            "new": {"foo": {3}, "bar": [1, 2, 3]},
+            "old": {"foo": set([0]), "bar": [0, 1, 2]},
+            "new": {"foo": set([3]), "bar": [1, 2, 3]},
         }
         self.assertEqual(
             expected_result, salt.utils.data.recursive_diff(mixed_one, mixed_two)
         )
         expected_result = {
-            "new": {"foo": {0}, "bar": [0, 1, 2]},
-            "old": {"foo": {3}, "bar": [1, 2, 3]},
+            "new": {"foo": set([0]), "bar": [0, 1, 2]},
+            "old": {"foo": set([3]), "bar": [1, 2, 3]},
         }
         self.assertEqual(
             expected_result, salt.utils.data.recursive_diff(mixed_two, mixed_one)
@@ -1236,7 +1245,7 @@ class FilterRecursiveDiff(TestCase):
         Test case comparing a list with a set, will be compared unordered.
         """
         mixed_one = [1, 2, 3]
-        mixed_two = {3, 2, 1}
+        mixed_two = set([3, 2, 1])
         expected_result = {}
         self.assertEqual(
             expected_result, salt.utils.data.recursive_diff(mixed_one, mixed_two)
@@ -1351,9 +1360,9 @@ class FilterRecursiveDiff(TestCase):
         Test case comparing two sets of unequal length.
         This does not do anything special, as it is unordered.
         """
-        set_one = {1, 2, 3}
-        set_two = {4, 3, 2, 1}
-        expected_result = {"old": set(), "new": {4}}
+        set_one = set([1, 2, 3])
+        set_two = set([4, 3, 2, 1])
+        expected_result = {"old": set([]), "new": set([4])}
         self.assertEqual(
             expected_result, salt.utils.data.recursive_diff(set_one, set_two)
         )


### PR DESCRIPTION
Upstream py2 to py3 cleanup tool removes a bunch of six calls that we
still need when backporting since our Salt minion might still be running
on python 2.7.