### PR TITLE
Fix virt.update with cpu defined

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -2430,9 +2430,9 @@ def update(
     data = {k: v for k, v in six.iteritems(locals()) if bool(v)}
     if boot_dev:
         data["boot_dev"] = {i + 1: dev for i, dev in enumerate(boot_dev.split())}
-    need_update = need_update or salt.utils.xmlutil.change_xml(
+    need_update = salt.utils.xmlutil.change_xml(
         desc, data, params_mapping
-    )
+    ) or need_update
 
     # Update the XML definition with the new disks and diff changes
     devices_node = desc.find("devices")


### PR DESCRIPTION
In case the cpu was defined the rest of the definition wasn't completely
updated.

Note: upstream PR not yet submitted