### PR TITLE
Fix grains.test_core unit test (openSUSE-3000.3)

### DIFF
--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -69,10 +69,11 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
     def test_parse_etc_os_release(self, path_isfile_mock):
         path_isfile_mock.side_effect = lambda x: x == "/usr/lib/os-release"
         with salt.utils.files.fopen(os.path.join(OS_RELEASE_DIR, "ubuntu-17.10")) as os_release_file:
-            os_release_content = os_release_file.readlines()
-        with patch("salt.utils.files.fopen", mock_open()) as os_release_file:
-            os_release_file.return_value.__iter__.return_value = os_release_content
-            os_release = core._parse_os_release(["/etc/os-release", "/usr/lib/os-release"])
+            os_release_content = os_release_file.read()
+        with patch("salt.utils.files.fopen", mock_open(read_data=os_release_content)):
+            os_release = core._parse_os_release(
+                "/etc/os-release", "/usr/lib/os-release"
+            )
         self.assertEqual(os_release, {
             "NAME": "Ubuntu",
             "VERSION": "17.10 (Artful Aardvark)",
@@ -134,7 +135,9 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
 
     def test_missing_os_release(self):
         with patch('salt.utils.files.fopen', mock_open(read_data={})):
-            os_release = core._parse_os_release(['/etc/os-release', '/usr/lib/os-release'])
+            os_release = core._parse_os_release(
+                "/etc/os-release", "/usr/lib/os-release"
+            )
         self.assertEqual(os_release, {})
 
     @skipIf(not salt.utils.platform.is_windows(), 'System is not Windows')


### PR DESCRIPTION
## What does this PR do?
This reverts 63b94ae and fixes the grains test_core unit test. The changes are aligned with the [upstream code](https://github.com/saltstack/salt/blob/f2d07c9d6df9a5de9e4d29e9edab8e5536a51d00/tests/unit/grains/test_core.py#L62-L66).

### What issues does this PR fix or reference?
https://github.com/SUSE/spacewalk/issues/12270#issuecomment-697304488
### Previous Behavior
Failed `unit.grains.test_core` unit test. 

```bash
$ python3 tests/runtests.py -n unit.grains.test_core
ERROR: test_parse_etc_os_release (unit.grains.test_core.CoreGrainsTestCase)
[CPU:14.0%|MEM:42.6%]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/mock/mock.py", line 1369, in patched
    return func(*newargs, **newkeywargs)
  File "/salt/src/salt-3000-suse/tests/unit/grains/test_core.py", line 74, in test_parse_etc_os_release
    os_release_file.return_value.__iter__.return_value = os_release_content
AttributeError: 'MockOpen' object has no attribute 'return_value'
```

### New Behavior
The unit test will succeed.

### Tests written?
No

### Commits signed with GPG?

Yes