### PR TITLE
Ensure virt.update stop_on_reboot is updated with its default value

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -2742,6 +2742,7 @@ def update(
     ]
 
     data = {k: v for k, v in six.iteritems(locals()) if bool(v)}
+    data["stop_on_reboot"] = stop_on_reboot
     if boot_dev:
         data["boot_dev"] = {i + 1: dev for i, dev in enumerate(boot_dev.split())}
     need_update = salt.utils.xmlutil.change_xml(

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -1778,6 +1778,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
               <memory unit='KiB'>1048576</memory>
               <currentMemory unit='KiB'>1048576</currentMemory>
               <vcpu placement='auto'>1</vcpu>
+              <on_reboot>restart</on_reboot>
               <os>
                 <type arch='x86_64' machine='pc-i440fx-2.6'>hvm</type>
                 <boot dev="hd"/>
@@ -2350,6 +2351,7 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
               <memory unit='KiB'>1048576</memory>
               <currentMemory unit='KiB'>1048576</currentMemory>
               <vcpu placement='auto'>1</vcpu>
+              <on_reboot>restart</on_reboot>
               <os>
                 <type arch='x86_64' machine='pc-i440fx-2.6'>hvm</type>
               </os>


### PR DESCRIPTION
### What does this PR do?

While all virt.update properties default values should not be used when
updating the XML definition, the stop_on_reboot default value (False)
needs to be passed still or the user will never be able to update with
this value.

Will be submitted upstream within the original PR.
