### PR TITLE
path: replace functools.wraps with six.wraps (bsc#1177867)

### DIFF
--- a/salt/utils/decorators/path.py
+++ b/salt/utils/decorators/path.py
@@ -4,11 +4,10 @@ Decorators for salt.utils.path
 '''
 from __future__ import absolute_import, print_function, unicode_literals
 
-import functools
-
 # Import Salt libs
 import salt.utils.path
 from salt.exceptions import CommandNotFoundError
+import salt.ext.six
 
 
 def which(exe):
@@ -16,7 +15,7 @@ def which(exe):
     Decorator wrapper for salt.utils.path.which
     '''
     def wrapper(function):
-        @functools.wraps(function)
+        @salt.ext.six.wraps(function)
         def wrapped(*args, **kwargs):
             if salt.utils.path.which(exe) is None:
                 raise CommandNotFoundError(
@@ -34,7 +33,7 @@ def which_bin(exes):
     Decorator wrapper for salt.utils.path.which_bin
     '''
     def wrapper(function):
-        @functools.wraps(function)
+        @salt.ext.six.wraps(function)
         def wrapped(*args, **kwargs):
             if salt.utils.path.which_bin(exes) is None:
                 raise CommandNotFoundError(


### PR DESCRIPTION
Python 2.7 functools.wraps decorator do not add the `__wrapped__`
attribute to decorated functions, that is used by Salt to access the
original function and deduce the parameters from the signature.

This patch uses six.wraps, that add this extra attribute.

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
