### PR TITLE
[WIP] Hold/unhold/list_holds implementation in zypperpkg module

### DIFF
--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -2018,19 +2018,18 @@ def unhold(name=None, pkgs=None, **kwargs):
         if locks.get(pkg):
             removed.append(pkg)
             if __opts__['test']:
-                ret[pkg].update(result=None)
-                ret[pkg]['comment'] = 'Package {0} is set to be unheld.'.format(pkg)
+                ret[pkg].update(result=None, comment='Package {0} is set to be unheld.'.format(pkg))
+            else:
+                ret[pkg].update(result=True, changes={'new': '', 'old': 'hold'},
+                                comment='Package {0} is no longer held.'.format(pkg))
         else:
             ret[pkg]['comment'] = 'Package {0} unable to be unheld.'.format(pkg)
 
     if removed and not __opts__['test']:
         __zypper__(root=root).call('rl', *removed)
-
-        locks = list_locks(root=root)
-        for pkg in removed:
-            if not locks.get(pkg):
-                ret[pkg].update(result=True, changes={'new': '', 'old': 'hold'})
-                ret[pkg]['comment'] = 'Package {0} is no longer held.'.format(pkg)
+        if __zypper__.exit_code:
+            for pkg in removed:
+                ret[pkg].update(result=False, comment='Package {0} was unable to be unheld.'.format(pkg))
 
     return ret
 
@@ -2112,20 +2111,19 @@ def hold(name=None, pkgs=None, **kwargs):
         if not locks.get(pkg):
             added.append(pkg)
             if __opts__['test']:
-                ret[pkg].update(result=None)
-                ret[pkg]['comment'] = 'Package {0} is set to be held.'.format(pkg)
+                ret[pkg].update(result=None, comment='Package {0} is set to be held.'.format(pkg))
+            else:
+                ret[pkg].update(result=True, changes={'new': 'hold', 'old': ''},
+                                comment='Package {0} is now being held.'.format(pkg))
         else:
             ret[pkg]['comment'] = 'Package {0} is already set to be held.'.format(pkg)
             ret[pkg].update(result=True)
 
     if added and not __opts__['test']:
         __zypper__(root=root).call('al', *added)
-
-        locks = list_locks(root=root)
-        for pkg in added:
-            if locks.get(pkg):
-                ret[pkg].update(result=True, changes={'new': 'hold', 'old': ''})
-                ret[pkg]['comment'] = 'Package {0} is now being held.'.format(pkg)
+        if __zypper__.exit_code:
+            for pkg in added:
+                ret[pkg].update(result=False, comment='Package {0} was unable to be held.'.format(pkg))
 
     return ret
 

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -2027,7 +2027,7 @@ def unhold(name=None, pkgs=None, **kwargs):
 
     if removed and not __opts__['test']:
         __zypper__(root=root).call('rl', *removed)
-        if __zypper__.exit_code:
+        if __zypper__.exit_code != 0:
             for pkg in removed:
                 ret[pkg].update(result=False, comment='Package {0} was unable to be unheld.'.format(pkg))
 
@@ -2121,7 +2121,7 @@ def hold(name=None, pkgs=None, **kwargs):
 
     if added and not __opts__['test']:
         __zypper__(root=root).call('al', *added)
-        if __zypper__.exit_code:
+        if __zypper__.exit_code != 0:
             for pkg in added:
                 ret[pkg].update(result=False, comment='Package {0} was unable to be held.'.format(pkg))
 

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -2567,18 +2567,17 @@ def search(criteria, refresh=False, **kwargs):
     out = {}
     for solvable in solvables:
         pkg_name = solvable.getAttribute('name')
-        if pkg_name in out:
-            if not all_versions:
-                continue
-            if isinstance(out[pkg_name], dict):
-                out[pkg_name] = list([out[pkg_name]])
-            cur_pkg = dict()
-            out[pkg_name].append(cur_pkg)
+        if pkg_name in out and not all_versions:
+            continue
+        elif pkg_name not in out:
+            out[pkg_name] = list()
+        pkg = dict()
+        if all_versions:
+            out[pkg_name].append(pkg)
         else:
-            out[pkg_name] = dict()
-            cur_pkg = out[pkg_name]
+            out[pkg_name] = pkg
         for k, v in solvable.attributes.items():
-            cur_pkg[k] = v
+            pkg[k] = v
 
     return out
 


### PR DESCRIPTION
### What does this PR do?

The PR implements `hold`/`unhold` functions for `zypperpkg` module with the same result output as `yumpkg` has including `test` kwarg.
It also implements `list_holds` with the same output as `yumpkg` while the way of processing package locking is different due to different approach in `yumpkg` and `zypperpkg`.

### What issues does this PR fix or reference?
https://github.com/SUSE/spacewalk/issues/1564

### Previous Behavior
`hold`/`unhold` produces traceback on call with any parameters:
```
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  File "/usr/lib/python3.6/site-packages/salt/scripts.py", line 445, in salt_call
    client.run()
  File "/usr/lib/python3.6/site-packages/salt/cli/call.py", line 57, in run
    caller.run()
  File "/usr/lib/python3.6/site-packages/salt/cli/caller.py", line 119, in run
    ret = self.call()
  File "/usr/lib/python3.6/site-packages/salt/cli/caller.py", line 218, in call
    ret['return'] = self.minion.executors[fname](self.opts, data, func, args, kwargs)
  File "/usr/lib/python3.6/site-packages/salt/executors/direct_call.py", line 12, in execute
    return func(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/salt/modules/zypperpkg.py", line 1991, in unhold
    pkgs = list(__salt__['pkg_resource.parse_targets'](pkgs)[0].keys())
  File "/usr/lib/python3.6/site-packages/salt/modules/pkg_resource.py", line 170, in parse_targets
    packed = dict([(_normalize_name(x), version) for x in name.split(',')])
AttributeError: 'list' object has no attribute 'split'
```

### New Behavior
`hold`/`unhold` work the same way as `add_lock`/`remove_lock`, but return the same result format as `yumpkg`.(`hold`|`unhold`).


### `list_holds` description
There is different approach of managing the locks implemented in `yum` and `zypper`:
- `zypper` saves wildcard or plain package name as specified during `zypper addlock` and doesn't check the package on time of appending the lock
- `yum` resolves all the installed packages using wildcard specified on lock appending and saves all of the resulting packages as distinct locks
Examples:
`yum versionlock add 'gcc*'`:
```
Adding versionlock on: 0:gcc-4.8.5-39.el7
Adding versionlock on: 0:gcc-c++-4.8.5-39.el7
Adding versionlock on: 0:gcc-gfortran-4.8.5-39.el7
Adding versionlock on: 0:gcc-gnat-4.8.5-39.el7
Adding versionlock on: 0:gcc-go-4.8.5-39.el7
Adding versionlock on: 0:gcc-objc++-4.8.5-39.el7
Adding versionlock on: 0:gcc-objc-4.8.5-39.el7
Adding versionlock on: 0:gcc-plugin-devel-4.8.5-39.el7
```

`zypper al 'kernel*'`
`zypper ll -s`:`
```
Loading repository data...
Reading installed packages...

# | Name           | Matches | Type    | Repository
--+----------------+---------+---------+-----------
1 | kernel*        | 33      | package | (any)
    Keep installed : [3]
        kernel-default-5.3.18-24.24.1.x86_64 (@System)
        kernel-default-5.3.18-24.15.1.x86_64 (@System)
        kernel-default-5.3.18-22.2.x86_64 (@System)
...
```
The best way to align the functionality of `list_holds` between `zypperpkg` and `yumpkg`
is to keep `zypperpkg.list_locks` as is to return the current locks exact the same way as stored in `/etc/zypp/locks` while make `zypperpkg.list_holds`
returning actual list of packages being held.


## Example output:
YUM system:
`salt-call --local pkg.list_holds`:
```
    - 0:kernel-3.10.0-1127.el7.*
    - 0:gcc-4.8.5-39.el7.*
    - 0:gcc-c++-4.8.5-39.el7.*
    - 0:gcc-gfortran-4.8.5-39.el7.*
    - 0:gcc-gnat-4.8.5-39.el7.*
    - 0:gcc-go-4.8.5-39.el7.*
    - 0:gcc-objc++-4.8.5-39.el7.*
    - 0:gcc-objc-4.8.5-39.el7.*
    - 0:gcc-plugin-devel-4.8.5-39.el7.*
```

Zypper system:
`salt-call --local pkg.list_holds`:
```
local:
    - 0:kernel-default-5.3.18-24.24.1.*
    - 0:kernel-default-5.3.18-24.15.1.*
    - 0:kernel-default-5.3.18-22.2.*
    - 0:systemd-234-24.49.2.*
    - 1:wpa_supplicant-1:2.6-12.el7.*
    - 0:yast2-4.2.87-3.8.1.*
    - 0:yast2-core-4.1.0-5.18.*
    - 0:yast2-hardware-detection-4.1.1-1.68.*
    - 0:yast2-logs-4.2.87-3.8.1.*
    - 0:yast2-perl-bindings-4.1.0-1.18.*
    - 0:yast2-pkg-bindings-4.2.8-3.3.4.*
    - 0:yast2-ruby-bindings-4.2.8-1.38.*
    - 0:yast2-support-4.2.3-1.94.*
    - 0:yast2-xml-4.1.1-1.33.*
    - 0:yast2-ycp-ui-bindings-4.2.9-1.39.*
```
`salt-call --local pkg.list_holds`:
```
local:
    ----------
    kernel*:
        ----------
        case_sensitive:
            on
        match_type:
            glob
        type:
            package
    systemd:
        ----------
        case_sensitive:
            on
        match_type:
            glob
        type:
            package
    wpa_supplicant:
        ----------
        case_sensitive:
            on
        match_type:
            glob
        type:
            package
    yast2*:
        ----------
        case_sensitive:
            on
        match_type:
            glob
        type:
            package
```

### Additional changes
- Documentation part of the functions fixed. (removed wrong function calls examples: `salt '*' pkg.(add|remove)_lock pkgs='["foo", "bar"]'`)
- `all_versions` kwarg implemented for `zypperpkg.search` as it not returning multiple installed versions of the package (required for `zypperpkg.list_holds`)
