### PR TITLE
grains: master can read grains

### DIFF
--- a/salt/grains/extra.py
+++ b/salt/grains/extra.py
@@ -94,8 +94,14 @@ def __secure_boot():
     enabled = False
     sboot = glob.glob("/sys/firmware/efi/vars/SecureBoot-*/data")
     if len(sboot) == 1:
-        with salt.utils.files.fopen(sboot[0], "rb") as fd:
-            enabled = fd.read()[-1:] == b"\x01"
+        # The minion is usually running as a privileged user, but is
+        # not the case for the master.  Seems that the master can also
+        # pick the grains, and this file can only be readed by "root"
+        try:
+            with salt.utils.files.fopen(sboot[0], "rb") as fd:
+                enabled = fd.read()[-1:] == b"\x01"
+        except PermissionError:
+            pass
     return enabled
 
 


### PR DESCRIPTION
### What does this PR do?

Seems that the master can read grains too, and the secure boot grain is only for root.

upstream: https://github.com/saltstack/salt/pull/58520