### PR TITLE
transactional_update: unify with chroot.call

### DIFF
--- a/salt/modules/chroot.py
+++ b/salt/modules/chroot.py
@@ -192,10 +192,11 @@ def call(root, function, *args, **kwargs):
             if isinstance(local, dict) and 'retcode' in local:
                 __context__['retcode'] = local['retcode']
             return local.get('return', data)
-        except (KeyError, ValueError):
+        except ValueError:
             return {
                 'result': False,
-                'comment': "Can't parse container command output"
+                'retcode': ret['retcode'],
+                'comment': {'stdout': ret['stdout'], 'stderr': ret['stderr']},
             }
     finally:
         __utils__['files.rm_rf'](thin_dest_path)

--- a/salt/modules/transactional_update.py
+++ b/salt/modules/transactional_update.py
@@ -988,8 +988,8 @@ def call(function, *args, **kwargs):
             if isinstance(local, dict) and "retcode" in local:
                 __context__["retcode"] = local["retcode"]
             return local.get("return", data)
-        except (KeyError, ValueError):
-            return {"result": False, "comment": ret_stdout}
+        except ValueError:
+            return {"result": False, "retcode": 1, "comment": ret_stdout}
     finally:
         __utils__["files.rm_rf"](thin_dest_path)
 

--- a/tests/unit/modules/test_chroot.py
+++ b/tests/unit/modules/test_chroot.py
@@ -145,13 +145,14 @@ class ChrootTestCase(TestCase, LoaderModuleMockMixin):
         utils_mock = {
             'thin.gen_thin': MagicMock(return_value='/salt-thin.tgz'),
             'files.rm_rf': MagicMock(),
-            'json.find_json': MagicMock(return_value={'return': {}})
+            'json.find_json': MagicMock(side_effect=ValueError())
         }
         salt_mock = {
             'cmd.run': MagicMock(return_value=''),
             'config.option': MagicMock(),
             'cmd.run_chroot': MagicMock(return_value={
                 'retcode': 1,
+                'stdout': '',
                 'stderr': 'Error',
             }),
         }
@@ -159,7 +160,8 @@ class ChrootTestCase(TestCase, LoaderModuleMockMixin):
                 patch.dict(chroot.__salt__, salt_mock):
             self.assertEqual(chroot.call('/chroot', 'test.ping'), {
                 'result': False,
-                'comment': "Can't parse container command output"
+                'retcode': 1,
+                'comment': {'stdout': '', 'stderr': 'Error'},
             })
             utils_mock['thin.gen_thin'].assert_called_once()
             salt_mock['config.option'].assert_called()

--- a/tests/unit/modules/test_transactional_update.py
+++ b/tests/unit/modules/test_transactional_update.py
@@ -372,7 +372,11 @@ class TransactionalUpdateTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(tu.__utils__, utils_mock), patch.dict(
             tu.__opts__, opts_mock
         ), patch.dict(tu.__salt__, salt_mock):
-            assert tu.call("test.ping") == {"result": False, "comment": "Error"}
+            assert tu.call("test.ping") == {
+                "result": False,
+                "retcode": 1,
+                "comment": "Error",
+            }
 
             utils_mock["thin.gen_thin"].assert_called_once()
             salt_mock["config.option"].assert_called()
@@ -424,7 +428,11 @@ class TransactionalUpdateTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(tu.__utils__, utils_mock), patch.dict(
             tu.__opts__, opts_mock
         ), patch.dict(tu.__salt__, salt_mock):
-            assert tu.call("test.ping") == {"result": False, "comment": "Not found"}
+            assert tu.call("test.ping") == {
+                "result": False,
+                "retcode": 1,
+                "comment": "Not found",
+            }
 
             utils_mock["thin.gen_thin"].assert_called_once()
             salt_mock["config.option"].assert_called()


### PR DESCRIPTION
Return for both .call() "retcode" when fail

Upstream: https://github.com/saltstack/salt/pull/58520/commits/fd4f1a1d2fc1b9d5ecd23e30572c3ebb8fb70a51
