### PR TITLE
Set passphrase for salt-ssh keys to empty string

### DIFF
--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -44,7 +44,7 @@ def gen_key(path):
     '''
     Generate a key for use with salt-ssh
     '''
-    cmd = ["ssh-keygen", "-P", '""', "-f", path, "-t", "rsa", "-q"]
+    cmd = ["ssh-keygen", "-P", "", "-f", path, "-t", "rsa", "-q"]
     if not os.path.isdir(os.path.dirname(path)):
         os.makedirs(os.path.dirname(path))
     subprocess.call(cmd)


### PR DESCRIPTION
### What does this PR do?
Fix regression in CVE fix

### Previous Behavior
ssh key passphrase was `""`

### New Behavior
ssh key passphrase is empty

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
