### PR TITLE
Add pkg.services_need_restart

### DIFF
--- a/changelog/58261.added
+++ b/changelog/58261.added
@@ -1,0 +1,1 @@
+Added ``pkg.services_need_restart`` which lists system services that should be restarted after package management operations.

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -48,7 +48,10 @@ import salt.utils.versions
 import salt.utils.yaml
 import salt.utils.environment
 from salt.exceptions import (
-    CommandExecutionError, MinionError, SaltInvocationError
+    CommandExecutionError,
+    CommandNotFoundError,
+    MinionError,
+    SaltInvocationError,
 )
 
 log = logging.getLogger(__name__)
@@ -2975,3 +2978,38 @@ def list_downloaded(root=None, **kwargs):
                 'creation_date_time': datetime.datetime.utcfromtimestamp(pkg_timestamp).isoformat(),
             }
     return ret
+
+
+def services_need_restart(**kwargs):
+    """
+    .. versionadded:: NEXT
+
+    List services that use files which have been changed by the
+    package manager. It might be needed to restart them.
+
+    Requires checkrestart from the debian-goodies package.
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' pkg.services_need_restart
+    """
+    if not salt.utils.path.which_bin(["checkrestart"]):
+        raise CommandNotFoundError(
+            "'checkrestart' is needed. It is part of the 'debian-goodies' "
+            "package which can be installed from official repositories."
+        )
+
+    cmd = ["checkrestart", "--machine"]
+    services = set()
+
+    cr_output = __salt__["cmd.run_stdout"](cmd, python_shell=False)
+    for line in cr_output.split("\n"):
+        if not line.startswith("SERVICE:"):
+            continue
+        end_of_name = line.find(",")
+        service = line[8:end_of_name]  # skip "SERVICE:"
+        services.add(service)
+
+    return list(services)

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -3359,3 +3359,42 @@ def del_repo_key(keyid, root=None, **kwargs):
 
     """
     return __salt__["lowpkg.remove_gpg_key"](keyid, root)
+
+
+def services_need_restart(**kwargs):
+    """
+    .. versionadded:: NEXT
+
+    List services that use files which have been changed by the
+    package manager. It might be needed to restart them.
+
+    Requires systemd.
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' pkg.services_need_restart
+    """
+    if _yum() != "dnf":
+        raise CommandExecutionError("dnf is required to list outdated services.")
+    if not salt.utils.systemd.booted(__context__):
+        raise CommandExecutionError("systemd is required to list outdated services.")
+
+    cmd = ["dnf", "--quiet", "needs-restarting"]
+    dnf_output = __salt__["cmd.run_stdout"](cmd, python_shell=False)
+    if not dnf_output:
+        return []
+
+    services = set()
+    for line in dnf_output.split("\n"):
+        try:
+            pid, _ = line.split(":")
+        # Skip lines that can't be parsed
+        except ValueError:
+            continue
+        service = salt.utils.systemd.pid_to_service(pid.strip())
+        if service:
+            services.add(service)
+
+    return list(services)

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -3388,13 +3388,10 @@ def services_need_restart(**kwargs):
 
     services = set()
     for line in dnf_output.split("\n"):
-        try:
-            pid, _ = line.split(":")
-        # Skip lines that can't be parsed
-        except ValueError:
-            continue
-        service = salt.utils.systemd.pid_to_service(pid.strip())
-        if service:
-            services.add(service)
+        pid, has_delim, _ = line.partition(":")
+        if has_delim:
+            service = salt.utils.systemd.pid_to_service(pid.strip())
+            if service:
+                services.add(service)
 
     return list(services)

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -2967,3 +2967,28 @@ def del_repo_key(keyid, root=None, **kwargs):
 
     """
     return __salt__["lowpkg.remove_gpg_key"](keyid, root)
+
+
+def services_need_restart(root=None, **kwargs):
+    """
+    .. versionadded:: NEXT
+
+    List services that use files which have been changed by the
+    package manager. It might be needed to restart them.
+
+    root
+        operate on a different root directory.
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' pkg.services_need_restart
+
+    """
+    cmd = ["ps", "-sss"]
+
+    zypper_output = __zypper__(root=root).nolock.call(*cmd)
+    services = zypper_output.split()
+
+    return services

--- a/salt/utils/systemd.py
+++ b/salt/utils/systemd.py
@@ -14,6 +14,12 @@ from salt.exceptions import SaltInvocationError
 import salt.utils.path
 import salt.utils.stringutils
 
+try:
+    import dbus
+except ImportError:
+    dbus = None
+
+
 log = logging.getLogger(__name__)
 
 
@@ -114,3 +120,66 @@ def has_scope(context=None):
     if _sd_version is None:
         return False
     return _sd_version >= 205
+
+
+def pid_to_service(pid):
+    """
+    Check if a PID belongs to a systemd service and return its name.
+    Return None if the PID does not belong to a service.
+
+    Uses DBUS if available.
+    """
+    if dbus:
+        return _pid_to_service_dbus(pid)
+    else:
+        return _pid_to_service_systemctl(pid)
+
+
+def _pid_to_service_systemctl(pid):
+    systemd_cmd = ["systemctl", "--output", "json", "status", str(pid)]
+    try:
+        systemd_output = subprocess.run(
+            systemd_cmd, check=True, text=True, capture_output=True
+        )
+        status_json = salt.utils.json.find_json(systemd_output.stdout)
+    except (ValueError, subprocess.CalledProcessError):
+        return None
+
+    name = status_json.get("_SYSTEMD_UNIT")
+    if name and name.endswith(".service"):
+        return _strip_suffix(name)
+    else:
+        return None
+
+
+def _pid_to_service_dbus(pid):
+    """
+    Use DBUS to check if a PID belongs to a running systemd service and return the service name if it does.
+    """
+    bus = dbus.SystemBus()
+    systemd_object = bus.get_object(
+        "org.freedesktop.systemd1", "/org/freedesktop/systemd1"
+    )
+    systemd = dbus.Interface(systemd_object, "org.freedesktop.systemd1.Manager")
+    try:
+        service_path = systemd.GetUnitByPID(pid)
+        service_object = bus.get_object("org.freedesktop.systemd1", service_path)
+        service_props = dbus.Interface(
+            service_object, "org.freedesktop.DBus.Properties"
+        )
+        service_name = service_props.Get("org.freedesktop.systemd1.Unit", "Id")
+        name = str(service_name)
+
+        if name and name.endswith(".service"):
+            return _strip_suffix(name)
+        else:
+            return None
+    except dbus.DBusException:
+        return None
+
+
+def _strip_suffix(service_name):
+    """
+    Strip ".service" suffix from a given service name.
+    """
+    return service_name[:-8]

--- a/tests/unit/modules/test_yumpkg.py
+++ b/tests/unit/modules/test_yumpkg.py
@@ -10,6 +10,7 @@ from tests.support.unit import TestCase, skipIf
 from tests.support.mock import (
     Mock,
     MagicMock,
+    call,
     mock_open,
     patch,
 )
@@ -893,3 +894,33 @@ class YumUtilsTestCase(TestCase, LoaderModuleMockMixin):
             yumpkg.__salt__['cmd.run_all'].assert_called_once_with(
                 ['fake-yum', '-y', '--do-something'], env={}, ignore_retcode=False,
                 output_loglevel='quiet', python_shell=True, username='Darth Vader')
+
+    @skipIf(not salt.utils.systemd.booted(), "Requires systemd")
+    @patch("salt.modules.yumpkg._yum", Mock(return_value="dnf"))
+    def test_services_need_restart(self):
+        """
+        Test that dnf needs-restarting output is parsed and
+        salt.utils.systemd.pid_to_service is called as expected.
+        """
+        expected = ["firewalld", "salt-minion"]
+
+        dnf_mock = Mock(
+            return_value="123 : /usr/bin/firewalld\n456 : /usr/bin/salt-minion\n"
+        )
+        systemd_mock = Mock(side_effect=["firewalld", "salt-minion"])
+        with patch.dict(yumpkg.__salt__, {"cmd.run_stdout": dnf_mock}), patch(
+            "salt.utils.systemd.pid_to_service", systemd_mock
+        ):
+            assert sorted(yumpkg.services_need_restart()) == expected
+            systemd_mock.assert_has_calls([call("123"), call("456")])
+
+    @patch("salt.modules.yumpkg._yum", Mock(return_value="dnf"))
+    def test_services_need_restart_requires_systemd(self):
+        """Test that yumpkg.services_need_restart raises an error if systemd is unavailable."""
+        with patch("salt.utils.systemd.booted", Mock(return_value=False)):
+            pytest.raises(CommandExecutionError, yumpkg.services_need_restart)
+
+    @patch("salt.modules.yumpkg._yum", Mock(return_value="yum"))
+    def test_services_need_restart_requires_dnf(self):
+        """Test that yumpkg.services_need_restart raises an error if DNF is unavailable."""
+        pytest.raises(CommandExecutionError, yumpkg.services_need_restart)

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -1766,3 +1766,17 @@ pattern() = package-c"""
         with patch.dict(zypper.__salt__, salt_mock):
             self.assertTrue(zypper.del_repo_key(keyid="keyid", root="/mnt"))
             salt_mock["lowpkg.remove_gpg_key"].assert_called_once_with("keyid", "/mnt")
+
+    def test_services_need_restart(self):
+        """
+        Test that zypper ps is used correctly to list services that need to
+        be restarted.
+        """
+        expected = ["salt-minion", "firewalld"]
+        zypper_output = "salt-minion\nfirewalld"
+        zypper_mock = Mock()
+        zypper_mock(root=None).nolock.call = Mock(return_value=zypper_output)
+
+        with patch("salt.modules.zypperpkg.__zypper__", zypper_mock):
+            assert zypper.services_need_restart() == expected
+            zypper_mock(root=None).nolock.call.assert_called_with("ps", "-sss")


### PR DESCRIPTION
### What does this PR do?
Backport of https://github.com/saltstack/salt/pull/58262. Add `pkg.services_need_restart` to gather a list out systemd services that need a restart, e.g. because the underlying program was updated. 

