### PR TITLE
Force zyppnotify to prefer Packages.db than Packages if it exists

### DIFF
--- a/scripts/suse/zypper/plugins/commit/zyppnotify
+++ b/scripts/suse/zypper/plugins/commit/zyppnotify
@@ -19,7 +19,9 @@ class DriftDetector(Plugin):
     def __init__(self):
         Plugin.__init__(self)
         self.ck_path = "/var/cache/salt/minion/rpmdb.cookie"
-        self.rpm_path = "/var/lib/rpm/Packages"
+        self.rpm_path = "/var/lib/rpm/Packages.db"
+        if not os.path.exists(self.rpm_path):
+            self.rpm_path = "/var/lib/rpm/Packages"
 
     def _get_mtime(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Some of the installed systems will use NDB backend DB instead of Berkeley DB.
For such case we should use `Packages.db` file instead of `Packages` to create cookie file.

### What issues does this PR fix or reference?
[PM-1185](https://github.com/SUSE/spacewalk/issues/13159): RPM database changing

### Previous Behavior
`zyppnotify` is creating cookie based on `Packages` file.

### New Behavior
`zyppnotify` is creating cookie based on `Packages.db` file if it exists, otherwise will use `Packages` as it was before.
