### PR TITLE
Fix recursion false detection in payload (bsc#1180101)

### DIFF
--- a/salt/payload.py
+++ b/salt/payload.py
@@ -197,7 +197,7 @@ class Serial(object):
             def verylong_encoder(obj, context):
                 # Make sure we catch recursion here.
                 objid = id(obj)
-                if objid in context:
+                if objid in context and isinstance(obj, (dict, list, tuple)):
                     return '<Recursion on {} with id={}>'.format(type(obj).__name__, id(obj))
                 context.add(objid)
 


### PR DESCRIPTION
openSUSE-3000: Fix recursion false detection in payload (bsc#1180101)

### What does this PR do?
Fixes recursion false detection, backport from upstream `develop` branch https://github.com/saltstack/salt/commit/a715b2c2a985f4fe9db3438cddc6efb29c87fd65

### What issues does this PR fix or reference?
Fixes https://github.com/SUSE/spacewalk/issues/13493

### Previous Behavior
In case of large output for `grains.items` could produce more than 5000 values `<Recursion on {} with id={}>` instead of real value. It leads to tracebacks in Java due to improper syntax of the return for `hardware.profileupdate` state.apply.

### New Behavior
Normal output for the grains.