### PR TITLE
Add sleep on exception handling on minion connection attempt to the master (bsc#1174855)

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1036,6 +1036,9 @@ class MinionManager(MinionBase):
         last = 0  # never have we signed in
         auth_wait = minion.opts['acceptance_wait_time']
         failed = False
+        retry_wait = 1
+        retry_wait_inc = 1
+        max_retry_wait = 20
         while True:
             try:
                 if minion.opts.get('beacons_before_connect', False):
@@ -1067,6 +1070,9 @@ class MinionManager(MinionBase):
                     'Unexpected error while connecting to %s',
                     minion.opts['master'], exc_info=True
                 )
+                yield salt.ext.tornado.gen.sleep(retry_wait)
+                if retry_wait < max_retry_wait:
+                    retry_wait += retry_wait_inc
 
     # Multi Master Tune In
     def tune_in(self):


### PR DESCRIPTION
### What does this PR do?
In some circumstances the flood of messages appears in the minion log. It could lead to filling whole free space on the file system, the log file placed, too fast.

### What issues does this PR fix or reference?
[1174855](https://github.com/SUSE/spacewalk/issues/13093) - salt-minion-3000-46.101.1 spams log file

### Previous Behavior
Log files messages flood.

### New Behavior
Log messages with delay after each message to prevent whole free space utilization on the file system the log file placed on.