### PR TITLE
add patch support for allow vendor change option with zypper

### DIFF
--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -105,6 +105,10 @@ class _Zypper(object):
     ZYPPER_LOCK = '/var/run/zypp.pid'
     TAG_RELEASED = 'zypper/released'
     TAG_BLOCKED = 'zypper/blocked'
+    # Dist upgrade vendor change support (SLE12+)
+    dup_avc = False
+    # Install/Patch/Upgrade vendor change support (SLE15+)
+    inst_avc = False
 
     def __init__(self):
         '''
@@ -217,6 +221,22 @@ class _Zypper(object):
     @property
     def pid(self):
         return self.__call_result.get('pid', '')
+
+    def calc_zypper(self):
+        try:
+            zypp_tmp = version('zypper')
+            # zypper version 1.11.34 in SLE12 update supports vendor change for only dist upgrade
+            if version_cmp(zypp_tmp, '1.11.34') >= 0 and version_cmp(zypp_tmp, '1.14.8') == -1:
+                # zypper version supports vendor change for dist upgrade
+                self.dup_avc = True
+            # zypper version 1.14.8 in SLE15 update supports vendor change in install/patch/upgrading
+            if version_cmp(zypp_tmp, '1.14.8') >= 0:
+                self.inst_avc = True
+            else:
+                log.error("Failed to compare Zypper version")
+        except Exception as ex:
+            log.error("Unable to get Zypper version")
+            log.error(ex)
 
     def _is_error(self):
         '''
@@ -1368,6 +1388,7 @@ def install(name=None,
             no_recommends=False,
             root=None,
             inclusion_detection=False,
+            novendorchange=True,
             **kwargs):
     '''
     .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
@@ -1413,6 +1434,10 @@ def install(name=None,
 
     skip_verify
         Skip the GPG verification check (e.g., ``--no-gpg-checks``)
+
+
+    novendorchange
+        Disallow vendor change
 
     version
         Can be either a version number, or the combination of a comparison
@@ -1563,6 +1588,15 @@ def install(name=None,
     cmd_install = ['install', '--auto-agree-with-licenses']
 
     cmd_install.append(kwargs.get('resolve_capabilities') and '--capability' or '--name')
+    # Install / patching / upgrade with vendor change support is only in SLE 15+  opensuse Leap 15+
+    if not novendorchange:
+        __zypper__(root=root).calc_zypper()
+        if __zypper__(root=root).inst_avc:
+            cmd_install.append("--allow-vendor-change")
+            log.info("Enabling vendor changes")
+        else:
+            log.warning("Enabling/Disabling vendor changes is not supported on this Zypper version")
+
 
     if not refresh:
         cmd_install.insert(0, '--no-refresh')
@@ -1574,7 +1608,6 @@ def install(name=None,
         cmd_install.extend(fromrepoopt)
     if no_recommends:
         cmd_install.append('--no-recommends')
-
     errors = []
 
     # Split the targets into batches of 500 packages each, so that
@@ -1700,28 +1733,35 @@ def upgrade(refresh=True,
             cmd_update.extend(['--from' if dist_upgrade else '--repo', repo])
         log.info('Targeting repos: %s', fromrepo)
 
-    if dist_upgrade:
-        # TODO: Grains validation should be moved to Zypper class
-        if __grains__["osrelease_info"][0] > 11:
-            if novendorchange:
-                cmd_update.append("--no-allow-vendor-change")
-                log.info("Disabling vendor changes")
-            else:
+    # TODO: Grains validation should be moved to Zypper class
+    if not novendorchange:
+        __zypper__(root=root).calc_zypper()
+        if dist_upgrade:
+            if __zypper__(root=root).inst_avc or __zypper__(root=root).dup_avc:
                 cmd_update.append("--allow-vendor-change")
                 log.info("Enabling vendor changes")
+            else:
+                log.warning(
+                    "Enabling/Disabling vendor changes is not supported on this Zypper version"
+                )
         else:
-            log.warning(
-                "Enabling/Disabling vendor changes is not supported on this Zypper version"
-            )
+            # Install / patching / upgrade with vendor change support is only in SLE 15+  opensuse Leap 15+
+            if __zypper__(root=root).inst_avc:
+                cmd_update.append("--allow-vendor-change")
+                log.info("Enabling vendor changes")
+            else:
+                log.warning(
+                    "Enabling/Disabling vendor changes is not supported on this Zypper version"
+                 )
 
-        if no_recommends:
-            cmd_update.append('--no-recommends')
-            log.info('Disabling recommendations')
+    if no_recommends:
+        cmd_update.append('--no-recommends')
+        log.info('Disabling recommendations')
 
-        if dryrun:
-            # Creates a solver test case for debugging.
-            log.info('Executing debugsolver and performing a dry-run dist-upgrade')
-            __zypper__(systemd_scope=_systemd_scope(), root=root).noraise.call(*cmd_update + ['--debug-solver'])
+    if dryrun:
+        # Creates a solver test case for debugging.
+        log.info('Executing debugsolver and performing a dry-run dist-upgrade')
+        __zypper__(systemd_scope=_systemd_scope(), root=root).noraise.call(*cmd_update + ['--debug-solver'])
 
     old = list_pkgs(root=root)
 

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -543,6 +543,38 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                             "--debug-solver",
                         )
 
+                with patch(
+                    "salt.modules.zypperpkg.list_pkgs",
+                    MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.1"}])
+                ):
+                    with patch.dict(zypper.__salt__,
+                                    {'pkg_resource.version': MagicMock(return_value='1.11'),
+                                     'lowpkg.version_cmp': MagicMock(return_value=1)}):
+                        ret = zypper.upgrade(
+                            dist_upgrade=True,
+                            dryrun=True,
+                            fromrepo=["Dummy", "Dummy2"],
+                            novendorchange=False,
+                        )
+                        zypper_mock.assert_any_call(
+                            "dist-upgrade",
+                            "--auto-agree-with-licenses",
+                            "--dry-run",
+                            "--from",
+                            "Dummy",
+                            "--from",
+                            "Dummy2",
+                        )
+                        zypper_mock.assert_any_call(
+                            "dist-upgrade",
+                            "--auto-agree-with-licenses",
+                            "--dry-run",
+                            "--from",
+                            "Dummy",
+                            "--from",
+                            "Dummy2",
+                            "--debug-solver",
+                        )
 
                 with patch(
                     "salt.modules.zypperpkg.list_pkgs",

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -483,7 +483,6 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                     zypper_mock.assert_any_call(
                         "dist-upgrade",
                         "--auto-agree-with-licenses",
-                        "--no-allow-vendor-change",
                     )
 
                 with patch('salt.modules.zypperpkg.list_pkgs', MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.1"}])):
@@ -502,13 +501,11 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                         "dist-upgrade",
                         "--auto-agree-with-licenses",
                         "--dry-run",
-                        "--no-allow-vendor-change",
                     )
                     zypper_mock.assert_any_call(
                         "dist-upgrade",
                         "--auto-agree-with-licenses",
                         "--dry-run",
-                        "--no-allow-vendor-change",
                     )
 
                 with patch(
@@ -562,7 +559,6 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                         "Dummy",
                         "--from",
                         "Dummy2",
-                        "--no-allow-vendor-change",
                     )
                     zypper_mock.assert_any_call(
                         "dist-upgrade",
@@ -572,7 +568,6 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                         "Dummy",
                         "--from",
                         "Dummy2",
-                        "--no-allow-vendor-change",
                         "--debug-solver",
                     )
 
@@ -603,7 +598,7 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                     )
                     self.assertDictEqual(ret, {"vim": {"old": "1.1", "new": "1.2"}})
                     zypper_mock.assert_any_call('dist-upgrade', '--auto-agree-with-licenses', '--from', "Dummy",
-                                                '--from', 'Dummy2', '--no-allow-vendor-change')
+                                                '--from', 'Dummy2')
 
                 with patch(
                     "salt.modules.zypperpkg.list_pkgs",
@@ -682,7 +677,6 @@ Repository 'DUMMY' not found by its alias, number, or URI.
                     "--auto-agree-with-licenses",
                     "--from",
                     "DUMMY",
-                    "--no-allow-vendor-change",
                 )
 
     def test_upgrade_available(self):

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -510,35 +510,38 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
 
                 with patch(
                     "salt.modules.zypperpkg.list_pkgs",
-                    MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.1"}]),
+                    MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.1"}])
                 ):
-                    ret = zypper.upgrade(
-                        dist_upgrade=True,
-                        dryrun=True,
-                        fromrepo=["Dummy", "Dummy2"],
-                        novendorchange=False,
-                    )
-                    zypper_mock.assert_any_call(
-                        "dist-upgrade",
-                        "--auto-agree-with-licenses",
-                        "--dry-run",
-                        "--from",
-                        "Dummy",
-                        "--from",
-                        "Dummy2",
-                        "--allow-vendor-change",
-                    )
-                    zypper_mock.assert_any_call(
-                        "dist-upgrade",
-                        "--auto-agree-with-licenses",
-                        "--dry-run",
-                        "--from",
-                        "Dummy",
-                        "--from",
-                        "Dummy2",
-                        "--allow-vendor-change",
-                        "--debug-solver",
-                    )
+                    with patch.dict(zypper.__salt__,
+                                    {'pkg_resource.version': MagicMock(return_value='1.15'),
+                                     'lowpkg.version_cmp': MagicMock(return_value=1)}):
+                        ret = zypper.upgrade(
+                            dist_upgrade=True,
+                            dryrun=True,
+                            fromrepo=["Dummy", "Dummy2"],
+                            novendorchange=False,
+                        )
+                        zypper_mock.assert_any_call(
+                            "dist-upgrade",
+                            "--auto-agree-with-licenses",
+                            "--dry-run",
+                            "--from",
+                            "Dummy",
+                            "--from",
+                            "Dummy2",
+                            "--allow-vendor-change",
+                        )
+                        zypper_mock.assert_any_call(
+                            "dist-upgrade",
+                            "--auto-agree-with-licenses",
+                            "--dry-run",
+                            "--from",
+                            "Dummy",
+                            "--from",
+                            "Dummy2",
+                            "--allow-vendor-change",
+                            "--debug-solver",
+                        )
 
 
                 with patch(


### PR DESCRIPTION
### What does this PR do?
Adds patch support for vendor change
But this fixes the version support for upgrades.  

Dist upgrades support vendor change with  sle12+ 
Install/patch/upgrade support vendor change with sle15+


https://github.com/SUSE/spacewalk/pull/13370
https://github.com/openSUSE/zypp-plugin-spacewalk/pull/44

Also this can be merged without  the other's merged. 

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

Not yet

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
