### PR TITLE
fixes #56144 to enable hotadd profile support (3002.2)

### DIFF
--- a/doc/topics/cloud/vmware.rst
+++ b/doc/topics/cloud/vmware.rst
@@ -457,6 +457,14 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or
     Specifies whether the new virtual machine should be powered on or not. If
     ``template: True`` is set, this field is ignored. Default is ``power_on: True``.
 
+``cpu_hot_add``
+    Boolean value that enables hot-add support for modifying CPU resources while
+    the guest is powered on.
+
+``mem_hot_add``
+    Boolean value that enables hot-add support for modifying memory resources while
+    the guest is powered on.
+
 ``extra_config``
     Specifies the additional configuration information for the virtual machine. This
     describes a set of modifications to the additional options. If the key is already

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -2824,6 +2824,12 @@ def create(vm_):
     win_run_once = config.get_cloud_config_value(
         "win_run_once", vm_, __opts__, search_global=False, default=None
     )
+    cpu_hot_add = config.get_cloud_config_value(
+        'cpu_hot_add', vm_, __opts__, search_global=False, default=None
+    )
+    mem_hot_add = config.get_cloud_config_value(
+        'mem_hot_add', vm_, __opts__, search_global=False, default=None
+    )
 
     # Get service instance object
     si = _get_si()
@@ -3041,6 +3047,12 @@ def create(vm_):
             devices, vm=object_ref, container_ref=container_ref, new_vm_name=vm_name
         )
         config_spec.deviceChange = specs["device_specs"]
+
+    if cpu_hot_add and hasattr(config_spec, 'cpuHotAddEnabled'):
+        config_spec.cpuHotAddEnabled = bool(cpu_hot_add)
+
+    if mem_hot_add and hasattr(config_spec, 'memoryHotAddEnabled'):
+        config_spec.memoryHotAddEnabled = bool(mem_hot_add)
 
     if extra_config:
         for key, value in six.iteritems(extra_config):


### PR DESCRIPTION
### What does this PR do?

Allows for the VMware provider to handle CPU and memory hot-add in newer versions of the software.

### What issues does this PR fix or reference?

saltstack/salt#56173

