### PR TITLE
Async batch implementation fix for 3002.2

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -534,12 +534,6 @@ class LocalClient:
             {'dave': {...}}
             {'stewart': {...}}
         """
-        # We need to re-import salt.utils.args here
-        # even though it has already been imported.
-        # when cmd_batch is called via the NetAPI
-        # the module is unavailable.
-        import salt.utils.args
-
         # Late import - not used anywhere else in this file
         import salt.cli.batch
 
@@ -557,38 +551,6 @@ class LocalClient:
 
         eauth = salt.cli.batch.batch_get_eauth(kwargs)
 
-        arg = salt.utils.args.condition_input(arg, kwarg)
-        opts = {
-            "tgt": tgt,
-            "fun": fun,
-            "arg": arg,
-            "tgt_type": tgt_type,
-            "ret": ret,
-            "batch": batch,
-            "failhard": kwargs.get("failhard", self.opts.get("failhard", False)),
-            "raw": kwargs.get("raw", False),
-        }
-
-        if "timeout" in kwargs:
-            opts["timeout"] = kwargs["timeout"]
-        if "gather_job_timeout" in kwargs:
-            opts["gather_job_timeout"] = kwargs["gather_job_timeout"]
-        if "batch_wait" in kwargs:
-            opts["batch_wait"] = int(kwargs["batch_wait"])
-
-        eauth = {}
-        if "eauth" in kwargs:
-            eauth["eauth"] = kwargs.pop("eauth")
-        if "username" in kwargs:
-            eauth["username"] = kwargs.pop("username")
-        if "password" in kwargs:
-            eauth["password"] = kwargs.pop("password")
-        if "token" in kwargs:
-            eauth["token"] = kwargs.pop("token")
-
-        for key, val in self.opts.items():
-            if key not in opts:
-                opts[key] = val
         batch = salt.cli.batch.Batch(opts, eauth=eauth, quiet=True)
         for ret in batch.run():
             yield ret


### PR DESCRIPTION
### What does this PR do?

[1182203](https://github.com/SUSE/spacewalk/issues/13990) - Salt presence ping mechanism seems broken

### Previous Behavior
`eauth`, `timeout`, `gather_job_timeout` and some other parameters were wiped out from the request initiated from `salt-api` with async batch.
All the events were processed with `salt` user instead of specified in the request, any user and password accepted as valid.

### New Behavior
Normal expected behavior.

### Tests written?
No

### Root cause
Incomplete https://github.com/openSUSE/salt/commit/78faccbd063b8635550935057b8630262958f669