### PR TITLE
Add sleep on exception handling on minion connection attempt to the master (bsc#1174855)

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -534,12 +534,6 @@ class LocalClient:
             {'dave': {...}}
             {'stewart': {...}}
         """
-        # We need to re-import salt.utils.args here
-        # even though it has already been imported.
-        # when cmd_batch is called via the NetAPI
-        # the module is unavailable.
-        import salt.utils.args
-
         # Late import - not used anywhere else in this file
         import salt.cli.batch
 
@@ -557,38 +551,6 @@ class LocalClient:
 
         eauth = salt.cli.batch.batch_get_eauth(kwargs)
 
-        arg = salt.utils.args.condition_input(arg, kwarg)
-        opts = {
-            "tgt": tgt,
-            "fun": fun,
-            "arg": arg,
-            "tgt_type": tgt_type,
-            "ret": ret,
-            "batch": batch,
-            "failhard": kwargs.get("failhard", self.opts.get("failhard", False)),
-            "raw": kwargs.get("raw", False),
-        }
-
-        if "timeout" in kwargs:
-            opts["timeout"] = kwargs["timeout"]
-        if "gather_job_timeout" in kwargs:
-            opts["gather_job_timeout"] = kwargs["gather_job_timeout"]
-        if "batch_wait" in kwargs:
-            opts["batch_wait"] = int(kwargs["batch_wait"])
-
-        eauth = {}
-        if "eauth" in kwargs:
-            eauth["eauth"] = kwargs.pop("eauth")
-        if "username" in kwargs:
-            eauth["username"] = kwargs.pop("username")
-        if "password" in kwargs:
-            eauth["password"] = kwargs.pop("password")
-        if "token" in kwargs:
-            eauth["token"] = kwargs.pop("token")
-
-        for key, val in self.opts.items():
-            if key not in opts:
-                opts[key] = val
         batch = salt.cli.batch.Batch(opts, eauth=eauth, quiet=True)
         for ret in batch.run():
             yield ret

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1123,6 +1123,9 @@ class MinionManager(MinionBase):
         last = 0  # never have we signed in
         auth_wait = minion.opts["acceptance_wait_time"]
         failed = False
+        retry_wait = 1
+        retry_wait_inc = 1
+        max_retry_wait = 20
         while True:
             try:
                 if minion.opts.get("beacons_before_connect", False):
@@ -1158,6 +1161,9 @@ class MinionManager(MinionBase):
                     minion.opts["master"],
                     exc_info=True,
                 )
+                yield salt.ext.tornado.gen.sleep(retry_wait)
+                if retry_wait < max_retry_wait:
+                    retry_wait += retry_wait_inc
 
     # Multi Master Tune In
     def tune_in(self):


### PR DESCRIPTION
### What does this PR do?
In some circumstances the flood of messages appears in the minion log. It could lead to filling whole free space on the file system, the log file placed, too fast.

### What issues does this PR fix or reference?
[1174855](https://github.com/SUSE/spacewalk/issues/13093) - salt-minion-3000-46.101.1 spams log file

### Previous Behavior
Log files messages flood.

### New Behavior
Log messages with delay after each message to prevent whole free space utilization on the file system the log file placed on.