### PR TITLE
Update target fix for salt-ssh and avoiding race condition on salt-ssh event processing (bsc#1179831, bsc#1182281) - 3000

### DIFF
--- a/salt/roster/__init__.py
+++ b/salt/roster/__init__.py
@@ -30,7 +30,6 @@ def get_roster_file(options):
     # from Salt API. In that case no way to define own 'roster_file', instead
     # this file needs to be chosen from already validated rosters
     # (see /etc/salt/master config).
-    skip_roster_file = False
     if options.get('__disable_custom_roster') and options.get('roster_file'):
         roster = options.get('roster_file').strip('/')
         for roster_location in options.get('rosters'):
@@ -38,10 +37,9 @@ def get_roster_file(options):
             if os.path.isfile(r_file):
                 template = r_file
                 break
-        skip_roster_file = True
 
     if not template:
-        if options.get('roster_file') and not skip_roster_file:
+        if options.get('roster_file'):
             template = options.get('roster_file')
         elif 'config_dir' in options.get('__master_opts__', {}):
             template = os.path.join(options['__master_opts__']['config_dir'],

--- a/salt/roster/__init__.py
+++ b/salt/roster/__init__.py
@@ -30,6 +30,7 @@ def get_roster_file(options):
     # from Salt API. In that case no way to define own 'roster_file', instead
     # this file needs to be chosen from already validated rosters
     # (see /etc/salt/master config).
+    skip_roster_file = False
     if options.get('__disable_custom_roster') and options.get('roster_file'):
         roster = options.get('roster_file').strip('/')
         for roster_location in options.get('rosters'):
@@ -37,10 +38,10 @@ def get_roster_file(options):
             if os.path.isfile(r_file):
                 template = r_file
                 break
-        del options['roster_file']
+        skip_roster_file = True
 
     if not template:
-        if options.get('roster_file'):
+        if options.get('roster_file') and not skip_roster_file:
             template = options.get('roster_file')
         elif 'config_dir' in options.get('__master_opts__', {}):
             template = os.path.join(options['__master_opts__']['config_dir'],


### PR DESCRIPTION
### What does this PR do?

[1179831](https://github.com/SUSE/spacewalk/issues/14002) - L3: Scheduled SSH-Push Tasks throws Exception and cause Salt-API to fail
[1182281](https://github.com/SUSE/spacewalk/issues/14002) - L3: SSH-Push/Salt-SSH "Adding minions for job xyz: [None]" cause unhandled Exception and salt-api to crash

### Previous Behavior
Traceback caused by improper processing of `tgt` parameter in case if it's a list:
```
...
File "/usr/lib/python3.6/site-packages/salt/client/ssh/__init__.py", line 233, in __init__
self._update_targets()
File "/usr/lib/python3.6/site-packages/salt/client/ssh/__init__.py", line 411, in _update_targets
if salt.utils.network.is_reachable_host(hostname):
...
```

And the traceback caused by race condition on deletion `roster_file` option during event processing for salt-ssh with large number of threads:
```
...
File "/usr/lib/python3.6/site-packages/salt/roster/__init__.py", line 40, in get_roster_file
del options['roster_file']
KeyError: 'roster_file'
...
```

### New Behavior
Normal behavior with no traceback. Additional warning message was implemented to show salt-ssh which can't be resolved.

### Tests written?
No