### PR TITLE
[WIP] Notify beacon for Debian/Ubuntu systems

### DIFF
--- a/scripts/suse/apt/99aptnotify
+++ b/scripts/suse/apt/99aptnotify
@@ -1,0 +1,1 @@
+DPkg::Post-Invoke {"/usr/bin/aptnotify";};

--- a/scripts/suse/apt/aptnotify
+++ b/scripts/suse/apt/aptnotify
@@ -1,0 +1,46 @@
+#!/usr/bin/python3
+
+import os
+import hashlib
+
+CK_PATH = "/var/cache/salt/minion/rpmdb.cookie"
+DPKG_PATH = "/var/lib/dpkg/status"
+
+def _get_mtime():
+    """
+    Get the modified time of the Package Database.
+
+    Returns:
+        Unix ticks
+    """
+    return os.path.exists(DPKG_PATH) and int(os.path.getmtime(DPKG_PATH)) or 0
+
+
+def _get_checksum():
+    """
+    Get the checksum of the Package Database.
+
+    Returns:
+        hexdigest
+    """
+    digest = hashlib.sha256()
+    with open(DPKG_PATH, "rb") as rpm_db_fh:
+        while True:
+            buff = rpm_db_fh.read(0x1000)
+            if not buff:
+                break
+            digest.update(buff)
+    return digest.hexdigest()
+
+
+def dpkg_post_invoke():
+    """
+    Hook after the package installation transaction.
+    """
+    if 'SALT_RUNNING' not in os.environ:
+        with open(CK_PATH, 'w') as ck_fh:
+            ck_fh.write('{chksum} {mtime}\n'.format(chksum=_get_checksum(), mtime=_get_mtime()))
+
+
+if __name__ == "__main__":
+    dpkg_post_invoke()


### PR DESCRIPTION
### What does this PR do?

This PR implements an `aptnotify` that will trigger a "package refresh" on Uyuni when `apt-get` is used to manually install/update/remove packages (similar to the existing `zyppnotify` and `yumnotify`).

**TODO**

- [ ] Packaging: The `99aptnotify` file must be installed in `/etc/apt/apt.conf.d/99aptnotify`
- [ ] Packaging: The `aptnotify` file must be installed in `/usr/bin/aptnotify`

### What issues does this PR fix or reference?

- https://github.com/SUSE/spacewalk/issues/11561

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

No

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
