### PR TITLE
Add AlmaLinux and Alibaba Cloud Linux to the OS Family list

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1532,6 +1532,7 @@ _OS_NAME_MAP = {
     "oracleserv": "OEL",
     "cloudserve": "CloudLinux",
     "cloudlinux": "CloudLinux",
+    "almalinux": "AlmaLinux",
     "pidora": "Fedora",
     "scientific": "ScientificLinux",
     "synology": "Synology",
@@ -1546,6 +1547,7 @@ _OS_NAME_MAP = {
     "slesexpand": "RES",
     "linuxmint": "Mint",
     "neon": "KDE neon",
+    "alibaba": "Alibaba Cloud (Aliyun)",
 }
 
 # Map the 'os' grain to the 'os_family' grain
@@ -1563,6 +1565,7 @@ _OS_FAMILY_MAP = {
     "Scientific": "RedHat",
     "Amazon": "RedHat",
     "CloudLinux": "RedHat",
+    "AlmaLinux": "RedHat",
     "OVS": "RedHat",
     "OEL": "RedHat",
     "XCP": "RedHat",
@@ -1619,6 +1622,7 @@ _OS_FAMILY_MAP = {
     "AIX": "AIX",
     "TurnKey": "Debian",
     "AstraLinuxCE": "Debian",
+    "Alibaba Cloud (Aliyun)": "RedHat",
 }
 
 # Matches any possible format:

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -678,6 +678,35 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         }
         self._run_os_grains_tests(None, _os_release_map, expectation)
 
+    @skipIf(not salt.utils.platform.is_linux(), "System is not Linux")
+    def test_almalinux_8_os_grains(self):
+        """
+        Test if OS grains are parsed correctly in AlmaLinux 8
+        """
+        _os_release_map = {
+            "os_release_file": {
+                "NAME": "AlmaLinux",
+                "VERSION_ID": "8.3",
+                "PRETTY_NAME": "AlmaLinux 8",
+                "ID": "almalinux",
+                "ANSI_COLOR": "0;31",
+                "CPE_NAME": "cpe:/o:almalinux:almalinux:8.3",
+            },
+            "_linux_distribution": ("almaLinux", "8.3", ""),
+        }
+
+        expectation = {
+            "os": "AlmaLinux",
+            "os_family": "RedHat",
+            "oscodename": "AlmaLinux 8",
+            "osfullname": "AlmaLinux",
+            "osrelease": "8.3",
+            "osrelease_info": (8, 3,),
+            "osmajorrelease": 8,
+            "osfinger": "AlmaLinux-8",
+        }
+        self._run_os_grains_tests(None, _os_release_map, expectation)
+
     def test_unicode_error(self):
         raise_unicode_mock = MagicMock(
             name="raise_unicode_error", side_effect=UnicodeError
@@ -746,6 +775,26 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
             "osfinger": "AstraLinuxCE-2",
         }
         self._run_os_grains_tests("astralinuxce-2.12.22", _os_release_map, expectation)
+
+    @skipIf(not salt.utils.platform.is_linux(), 'System is not Linux')
+    def test_aliyunlinux2_os_grains(self):
+        '''
+        Test if OS grains are parsed correctly in Alibaba Cloud Linux (Aliyun Linux) 2.1903 LTS
+        '''
+        _os_release_map = {
+            'linux_distribution': ('Alibaba Cloud Linux (Aliyun Linux)', '2.1903', 'Alibaba Cloud Linux (Aliyun Linux) 2.1903 LTS (Hunting Beagle)'),
+        }
+        expectation = {
+            'os': 'Alibaba Cloud (Aliyun)',
+            'os_family': 'RedHat',
+            'oscodename': 'Alibaba Cloud Linux (Aliyun Linux) 2.1903 LTS (Hunting Beagle)',
+            'osfullname': 'Alibaba Cloud Linux (Aliyun Linux)',
+            'osrelease': '2.1903',
+            'osrelease_info': (2, 1903),
+            'osmajorrelease': 2,
+            'osfinger': 'Alibaba Cloud Linux (Aliyun Linux)-2',
+        }
+        self._run_os_grains_tests(None, _os_release_map, expectation)
 
     @skipIf(not salt.utils.platform.is_windows(), "System is not Windows")
     def test_windows_platform_data(self):

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -762,7 +762,7 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         Test if OS grains are parsed correctly in Astra Linux CE 2.12.22 "orel"
         """
         _os_release_map = {
-            "linux_distribution": ("AstraLinuxCE", "2.12.22", "orel"),
+            "_linux_distribution": ("AstraLinuxCE", "2.12.22", "orel"),
         }
         expectation = {
             "os": "AstraLinuxCE",
@@ -782,7 +782,7 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         Test if OS grains are parsed correctly in Alibaba Cloud Linux (Aliyun Linux) 2.1903 LTS
         '''
         _os_release_map = {
-            'linux_distribution': ('Alibaba Cloud Linux (Aliyun Linux)', '2.1903', 'Alibaba Cloud Linux (Aliyun Linux) 2.1903 LTS (Hunting Beagle)'),
+            '_linux_distribution': ('Alibaba Cloud Linux (Aliyun Linux)', '2.1903', 'Alibaba Cloud Linux (Aliyun Linux) 2.1903 LTS (Hunting Beagle)'),
         }
         expectation = {
             'os': 'Alibaba Cloud (Aliyun)',


### PR DESCRIPTION
### What does this PR do?

Add AlmaLinux and Alibaba Cloud Linux to the OS Family list

Ports of https://github.com/openSUSE/salt/pull/339 and https://github.com/openSUSE/salt/pull/340

### What issues does this PR fix or reference?

### Previous Behavior

salt did not identify AlmaLinux or Alibaba Cloud Linux.

### New Behavior

salt did identifies AlmaLinux or Alibaba Cloud Linux.

### Tests written?

Yes

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
