### PR TITLE
Run github actions once

### DIFF
--- a/.github/workflows/integration-opensuse-leap-15-1.yml
+++ b/.github/workflows/integration-opensuse-leap-15-1.yml
@@ -1,5 +1,5 @@
 name: integration-opensuse-leap-15-1
-on: [push, pull_request]
+on: pull_request
 jobs:
   integration-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-opensuse-leap-15-1.yml
+++ b/.github/workflows/unit-opensuse-leap-15-1.yml
@@ -1,5 +1,5 @@
 name: unit-opensuse-leap-15-1
-on: [push, pull_request]
+on: pull_request
 jobs:
   unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What does this PR do?

GH actions were running twice on every Pull Request because we have it
running on pull requests and push actions. We only need the pull request
even, give when there is a push to the pull request branch, the pull
request even is triggered.

On the branch were the pr is merged, we already have the jenkins jobs,
so no need to run it there.

### What issues does this PR fix or reference?

### Previous Behavior

Github actions were run twice on every Pull Request

### New Behavior

Github actions are run only once

### Tests written?
N/A

### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
