### PR TITLE
Add Alibaba Cloud Linux 2 to Salt 3000 branch

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1468,6 +1468,7 @@ _OS_NAME_MAP = {
     'slesexpand': 'RES',
     'linuxmint': 'Mint',
     'neon': 'KDE neon',
+    'alibabaclo': 'Alinux',
 }
 
 # Map the 'os' grain to the 'os_family' grain
@@ -1542,6 +1543,7 @@ _OS_FAMILY_MAP = {
     'AIX': 'AIX',
     'TurnKey': 'Debian',
     'AstraLinuxCE': 'Debian',
+    'Alinux': 'RedHat',
 }
 
 # Matches any possible format:

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -663,7 +663,7 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
                 "ID": "alinux",
                 "ANSI_COLOR": "0;31",
             },
-            "_linux_distribution": ("alinux", "2.1903", "LTS"),
+            "linux_distribution": ("alinux", "2.1903", "LTS"),
         }
 
         expectation = {

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -649,6 +649,35 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         }
         self._run_os_grains_tests("astralinuxce-2.12.22", _os_release_map, expectation)
 
+    @skipIf(not salt.utils.platform.is_linux(), 'System is not Linux')
+    def test_alinux2_os_grains(self):
+        """
+        Test if OS grains are parsed correctly in Alibaba Cloud Linux
+        """
+        _os_release_map = {
+            "os_release_file": {
+                "NAME": "Alibaba Cloud Linux (Aliyun Linux)",
+                "VERSION": "2.1903 LTS (Hunting Beagle)",
+                "VERSION_ID": "2.1903",
+                "PRETTY_NAME": "Alibaba Cloud Linux (Aliyun Linux) 2.1903 LTS (Hunting Beagle)",
+                "ID": "alinux",
+                "ANSI_COLOR": "0;31",
+            },
+            "_linux_distribution": ("alinux", "2.1903", "LTS"),
+        }
+
+        expectation = {
+            "os": "Alinux",
+            "os_family": "RedHat",
+            "oscodename": "Alibaba Cloud Linux (Aliyun Linux) 2.1903 LTS (Hunting Beagle)",
+            "osfullname": "Alibaba Cloud Linux (Aliyun Linux)",
+            "osrelease": "2.1903",
+            "osrelease_info": (2, 1903),
+            "osmajorrelease": 2,
+            "osfinger": "Alibaba Cloud Linux (Aliyun Linux)-2",
+        }
+        self._run_os_grains_tests(None, _os_release_map, expectation)
+
     @skipIf(not salt.utils.platform.is_windows(), 'System is not Windows')
     def test_windows_platform_data(self):
         '''


### PR DESCRIPTION
### What does this PR do?

Adds Alibaba Cloud Linux to Salt 3000.0 branch

### What issues does this PR fix or reference?

Backport of https://github.com/saltstack/salt/pull/59687

### Previous Behavior

I had implemented my own grain while implementing support for Alibaba Cloud Linux 2 in Uyuni, but only a few days ago, an official grain coming from Alibaba was merged upstream.

### New Behavior

Same as upstream.

### Tests written?

Yes (unit test)

### Commits signed with GPG?

No
