### PR TITLE
Add Alibaba Cloud Linux 2 to Salt 3002.2 branch

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1547,7 +1547,7 @@ _OS_NAME_MAP = {
     "slesexpand": "RES",
     "linuxmint": "Mint",
     "neon": "KDE neon",
-    "alibaba": "Alibaba Cloud (Aliyun)",
+    "alibabaclo": "Alinux",
 }
 
 # Map the 'os' grain to the 'os_family' grain
@@ -1622,7 +1622,7 @@ _OS_FAMILY_MAP = {
     "AIX": "AIX",
     "TurnKey": "Debian",
     "AstraLinuxCE": "Debian",
-    "Alibaba Cloud (Aliyun)": "RedHat",
+    "Alinux": "RedHat",
 }
 
 # Matches any possible format:

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -782,17 +782,25 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         Test if OS grains are parsed correctly in Alibaba Cloud Linux (Aliyun Linux) 2.1903 LTS
         '''
         _os_release_map = {
-            '_linux_distribution': ('Alibaba Cloud Linux (Aliyun Linux)', '2.1903', 'Alibaba Cloud Linux (Aliyun Linux) 2.1903 LTS (Hunting Beagle)'),
+            "os_release_file": {
+                "NAME": "Alibaba Cloud Linux (Aliyun Linux)",
+                "VERSION": "2.1903 LTS (Hunting Beagle)",
+                "VERSION_ID": "2.1903",
+                "PRETTY_NAME": "Alibaba Cloud Linux (Aliyun Linux) 2.1903 LTS (Hunting Beagle)",
+                "ID": "alinux",
+                "ANSI_COLOR": "0;31",
+            },
+            "_linux_distribution": ("alinux", "2.1903", "LTS"),
         }
         expectation = {
-            'os': 'Alibaba Cloud (Aliyun)',
-            'os_family': 'RedHat',
-            'oscodename': 'Alibaba Cloud Linux (Aliyun Linux) 2.1903 LTS (Hunting Beagle)',
-            'osfullname': 'Alibaba Cloud Linux (Aliyun Linux)',
-            'osrelease': '2.1903',
-            'osrelease_info': (2, 1903),
-            'osmajorrelease': 2,
-            'osfinger': 'Alibaba Cloud Linux (Aliyun Linux)-2',
+            "os": "Alinux",
+            "os_family": "RedHat",
+            "oscodename": "Alibaba Cloud Linux (Aliyun Linux) 2.1903 LTS (Hunting Beagle)",
+            "osfullname": "Alibaba Cloud Linux (Aliyun Linux)",
+            "osrelease": "2.1903",
+            "osrelease_info": (2, 1903),
+            "osmajorrelease": 2,
+            "osfinger": "Alibaba Cloud Linux (Aliyun Linux)-2",
         }
         self._run_os_grains_tests(None, _os_release_map, expectation)
 


### PR DESCRIPTION
### What does this PR do?

Adds Alibaba Cloud Linux to Salt 3002.2 branch

### What issues does this PR fix or reference?

Backport of https://github.com/saltstack/salt/pull/59687

### Previous Behavior

I had implemented my own grain while implementing support for Alibaba Cloud Linux 2 in Uyuni, but only a few days ago, an official grain coming from Alibaba was merged upstream.

### New Behavior

Same as upstream.

### Tests written?

Yes (unit test)

### Commits signed with GPG?

No