### PR TITLE
Regression fix of salt-ssh on processing targets

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -435,8 +435,6 @@ class SSH:
             self.opts["tgt"] = _hosts
         elif _hosts:
             self.opts["tgt"] = _hosts[0]
-        else:
-            self.opts["tgt"] = ""
 
     def get_pubkey(self):
         """


### PR DESCRIPTION
### What does this PR do?

Fixes the regression causing test fails of salt-ssh by [PR#336](https://github.com/openSUSE/salt/pull/336)

### Previous Behavior
Tests failing:
```
tests/unit/client/test_ssh.py::SSHTests::test_expand_target_dns FAILED
tests/unit/client/test_ssh.py::SSHTests::test_expand_target_ip_address FAILED
tests/unit/client/test_ssh.py::SSHTests::test_expand_target_no_user FAILED
...
tests/unit/client/test_ssh.py::SSHTests::test_update_expand_target_dns FAILED
tests/unit/client/test_ssh.py::SSHTests::test_update_targets_dns FAILED
tests/unit/client/test_ssh.py::SSHTests::test_update_targets_ip_address FAILED
tests/unit/client/test_ssh.py::SSHTests::test_update_targets_no_user FAILED
```

### New Behavior
No tests fails
