### PR TITLE
Improvements on "ansiblegate" module

### DIFF
--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -426,7 +426,10 @@ def playbooks(
     }
     ret = __salt__["cmd.run_all"](**cmd_kwargs)
     log.debug("Ansible Playbook Return: %s", ret)
-    retdata = json.loads(ret["stdout"])
+    try:
+        retdata = json.loads(ret["stdout"])
+    except ValueError:
+        retdata = ret
     if "retcode" in ret:
         __context__["retcode"] = retdata["retcode"] = ret["retcode"]
     return retdata

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -454,16 +454,20 @@ def discover_playbooks(path, playbook_extension=None, syntax_check=False):
 
     {
         "my_ansible_playbook.yml": {
-            "fullpath": "/home/foobar/playbooks/my_ansible_playbook.yml"
+            "fullpath": "/home/foobar/playbooks/my_ansible_playbook.yml",
+            "custom_inventory": "/home/foobar/playbooks/hosts",
         },
         "another_playbook.yml": {
-            "fullpath": "/home/foobar/playbooks/another_playbook.yml"
+            "fullpath": "/home/foobar/playbooks/another_playbook.yml",
+            "custom_inventory": "/home/foobar/playbooks/hosts",
         },
         "lamp_simple/site.yml": {
-            "fullpath": "/home/foobar/playbooks/lamp_simple/site.yml"
+            "fullpath": "/home/foobar/playbooks/lamp_simple/site.yml",
+            "custom_inventory": "/home/foobar/playbooks/lamp_simple/hosts",
         },
         "lamp_proxy/site.yml": {
-            "fullpath": "/home/foobar/playbooks/lamp_proxy/site.yml"
+            "fullpath": "/home/foobar/playbooks/lamp_proxy/site.yml",
+            "custom_inventory": "/home/foobar/playbooks/lamp_proxy/hosts",
         },
     }
 
@@ -486,12 +490,18 @@ def discover_playbooks(path, playbook_extension=None, syntax_check=False):
             _path = os.path.join(path, _f)
             if os.path.isfile(_path) and _path.endswith("." + playbook_extension):
                 ret[_f] = {"fullpath": _path}
+                # Check for custom inventory "hosts" file
+                if os.path.isfile(os.path.join(path, "hosts")):
+                    ret[_f].update({"custom_inventory": os.path.join(path, "hosts")})
             elif os.path.isdir(_path):
                 # Check files in the 1st level of subdirectories
                 for _f2 in os.listdir(_path):
                     _path2 = os.path.join(_path, _f2)
                     if os.path.isfile(_path2) and _path2.endswith("." + playbook_extension):
                         ret[os.path.join(_f, _f2)] = {"fullpath": _path2}
+                        # Check for custom inventory "hosts" file
+                        if os.path.isfile(os.path.join(_path, "hosts")):
+                            ret[os.path.join(_f, _f2)].update({"custom_inventory": os.path.join(_path, "hosts")})
     except Exception as exc:
         raise CommandExecutionError("There was an exception while discovering playbooks: {}".format(exc))
 

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -430,3 +430,11 @@ def playbooks(
     if "retcode" in ret:
         __context__["retcode"] = retdata["retcode"] = ret["retcode"]
     return retdata
+
+
+def targets(**kwargs):
+    """
+    Return the targets from the ansible inventory_file
+    Default: /etc/salt/roster
+    """
+    return __utils__["ansible.targets"](**kwargs)

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -443,9 +443,13 @@ def targets(**kwargs):
     return __utils__["ansible.targets"](**kwargs)
 
 
-def discover_playbooks(path, playbook_extension=None, syntax_check=False):
+def discover_playbooks(path=None,
+                       locations=None,
+                       playbook_extension=None,
+                       hosts_filename=None,
+                       syntax_check=False):
     """
-    Discover Ansible playbooks stored under the given path.
+    Discover Ansible playbooks stored under the given path or from multiple paths (locations)
 
     This will search for files matching with the playbook file extension under the given
     root path and will also look for files inside the first level of directories in this path.
@@ -453,55 +457,92 @@ def discover_playbooks(path, playbook_extension=None, syntax_check=False):
     The return of this function would be a dict like this:
 
     {
-        "my_ansible_playbook.yml": {
-            "fullpath": "/home/foobar/playbooks/my_ansible_playbook.yml",
-            "custom_inventory": "/home/foobar/playbooks/hosts",
+        "/home/foobar/": {
+            "my_ansible_playbook.yml": {
+                "fullpath": "/home/foobar/playbooks/my_ansible_playbook.yml",
+                "custom_inventory": "/home/foobar/playbooks/hosts",
+            },
+            "another_playbook.yml": {
+                "fullpath": "/home/foobar/playbooks/another_playbook.yml",
+                "custom_inventory": "/home/foobar/playbooks/hosts",
+            },
+            "lamp_simple/site.yml": {
+                "fullpath": "/home/foobar/playbooks/lamp_simple/site.yml",
+                "custom_inventory": "/home/foobar/playbooks/lamp_simple/hosts",
+            },
+            "lamp_proxy/site.yml": {
+                "fullpath": "/home/foobar/playbooks/lamp_proxy/site.yml",
+                "custom_inventory": "/home/foobar/playbooks/lamp_proxy/hosts",
+            },
         },
-        "another_playbook.yml": {
-            "fullpath": "/home/foobar/playbooks/another_playbook.yml",
-            "custom_inventory": "/home/foobar/playbooks/hosts",
-        },
-        "lamp_simple/site.yml": {
-            "fullpath": "/home/foobar/playbooks/lamp_simple/site.yml",
-            "custom_inventory": "/home/foobar/playbooks/lamp_simple/hosts",
-        },
-        "lamp_proxy/site.yml": {
-            "fullpath": "/home/foobar/playbooks/lamp_proxy/site.yml",
-            "custom_inventory": "/home/foobar/playbooks/lamp_proxy/hosts",
-        },
+        "/srv/playbooks/": {
+            "example_playbook/example.yml": {
+                "fullpath": "/srv/playbooks/example_playbook/example.yml",
+                "custom_inventory": "/srv/playbooks/example_playbook/hosts",
+            },
+        }
     }
 
     :param path: Path to discover playbooks from.
+    :param locations: List of paths to discover playbooks from.
     :param playbook_extension: File extension of playbooks file to search for. Default: "yml"
+    :param hosts_filename: Filename of custom playbook inventory to search for. Default: "hosts"
     :param syntax_check: Skip playbooks that do not pass "ansible-playbook --syntax-check" validation. Default: False
     """
 
+    if not path and not locations:
+        raise CommandExecutionError("You have to specify either 'path' or 'locations' arguments")
+
+    if path and locations:
+        raise CommandExecutionError("You cannot specify 'path' and 'locations' at the same time")
+
     if not playbook_extension:
        playbook_extension = "yml"
-    if not os.path.isabs(path):
-        raise CommandExecutionError("The given path is not an absolute path: {}".format(path))
-    if not os.path.isdir(path):
-        raise CommandExecutionError("The given path is not a directory: {}".format(path))
+    if not hosts_filename:
+       hosts_filename = "hosts"
 
+    if path:
+        if not os.path.isabs(path):
+            raise CommandExecutionError("The given path is not an absolute path: {}".format(path))
+        if not os.path.isdir(path):
+            raise CommandExecutionError("The given path is not a directory: {}".format(path))
+        return {path: _explore_path(path, playbook_extension, hosts_filename, syntax_check)}
+
+    if locations:
+        all_ret = {}
+        for location in locations:
+            all_ret[location] = _explore_path(location, playbook_extension, hosts_filename, syntax_check)
+        return all_ret
+
+
+def _explore_path(path, playbook_extension, hosts_filename, syntax_check):
     ret = {}
+
+    if not os.path.isabs(path):
+        log.error("The given path is not an absolute path: {}".format(path))
+        return ret
+    if not os.path.isdir(path):
+        log.error("The given path is not a directory: {}".format(path))
+        return ret
+
     try:
         # Check files in the given path
         for _f in os.listdir(path):
             _path = os.path.join(path, _f)
             if os.path.isfile(_path) and _path.endswith("." + playbook_extension):
                 ret[_f] = {"fullpath": _path}
-                # Check for custom inventory "hosts" file
-                if os.path.isfile(os.path.join(path, "hosts")):
-                    ret[_f].update({"custom_inventory": os.path.join(path, "hosts")})
+                # Check for custom inventory file
+                if os.path.isfile(os.path.join(path, hosts_filename)):
+                    ret[_f].update({"custom_inventory": os.path.join(path, hosts_filename)})
             elif os.path.isdir(_path):
                 # Check files in the 1st level of subdirectories
                 for _f2 in os.listdir(_path):
                     _path2 = os.path.join(_path, _f2)
                     if os.path.isfile(_path2) and _path2.endswith("." + playbook_extension):
                         ret[os.path.join(_f, _f2)] = {"fullpath": _path2}
-                        # Check for custom inventory "hosts" file
-                        if os.path.isfile(os.path.join(_path, "hosts")):
-                            ret[os.path.join(_f, _f2)].update({"custom_inventory": os.path.join(_path, "hosts")})
+                        # Check for custom inventory file
+                        if os.path.isfile(os.path.join(_path, hosts_filename)):
+                            ret[os.path.join(_f, _f2)].update({"custom_inventory": os.path.join(_path, hosts_filename)})
     except Exception as exc:
         raise CommandExecutionError("There was an exception while discovering playbooks: {}".format(exc))
 

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -441,3 +441,67 @@ def targets(**kwargs):
     Default: /etc/salt/roster
     """
     return __utils__["ansible.targets"](**kwargs)
+
+
+def discover_playbooks(path, playbook_extension=None, syntax_check=False):
+    """
+    Discover Ansible playbooks stored under the given path.
+
+    This will search for files matching with the playbook file extension under the given
+    root path and will also look for files inside the first level of directories in this path.
+
+    The return of this function would be a dict like this:
+
+    {
+        "my_ansible_playbook.yml": {
+            "fullpath": "/home/foobar/playbooks/my_ansible_playbook.yml"
+        },
+        "another_playbook.yml": {
+            "fullpath": "/home/foobar/playbooks/another_playbook.yml"
+        },
+        "lamp_simple/site.yml": {
+            "fullpath": "/home/foobar/playbooks/lamp_simple/site.yml"
+        },
+        "lamp_proxy/site.yml": {
+            "fullpath": "/home/foobar/playbooks/lamp_proxy/site.yml"
+        },
+    }
+
+    :param path: Path to discover playbooks from.
+    :param playbook_extension: File extension of playbooks file to search for. Default: "yml"
+    :param syntax_check: Skip playbooks that do not pass "ansible-playbook --syntax-check" validation. Default: False
+    """
+
+    if not playbook_extension:
+       playbook_extension = "yml"
+    if not os.path.isabs(path):
+        raise CommandExecutionError("The given path is not an absolute path: {}".format(path))
+    if not os.path.isdir(path):
+        raise CommandExecutionError("The given path is not a directory: {}".format(path))
+
+    ret = {}
+    try:
+        # Check files in the given path
+        for _f in os.listdir(path):
+            _path = os.path.join(path, _f)
+            if os.path.isfile(_path) and _path.endswith("." + playbook_extension):
+                ret[_f] = {"fullpath": _path}
+            elif os.path.isdir(_path):
+                # Check files in the 1st level of subdirectories
+                for _f2 in os.listdir(_path):
+                    _path2 = os.path.join(_path, _f2)
+                    if os.path.isfile(_path2) and _path2.endswith("." + playbook_extension):
+                        ret[os.path.join(_f, _f2)] = {"fullpath": _path2}
+    except Exception as exc:
+        raise CommandExecutionError("There was an exception while discovering playbooks: {}".format(exc))
+
+    # Run syntax check validation
+    if syntax_check:
+        check_command = ["ansible-playbook", "--syntax-check"]
+        try:
+            for pb in list(ret):
+               if __salt__["cmd.retcode"](check_command + [ret[pb]]):
+                   del ret[pb]
+        except Exception as exc:
+            raise CommandExecutionError("There was an exception while checking syntax of playbooks: {}".format(exc))
+    return ret

--- a/salt/roster/ansible.py
+++ b/salt/roster/ansible.py
@@ -89,7 +89,6 @@ Any of the [groups] or direct hostnames will return.  The 'all' is special, and 
 """
 # Import Python libs
 from __future__ import absolute_import, print_function, unicode_literals
-
 import copy
 import fnmatch
 
@@ -121,11 +120,8 @@ def targets(tgt, tgt_type="glob", **kwargs):
     Return the targets from the ansible inventory_file
     Default: /etc/salt/roster
     """
-    inventory = __runner__["salt.cmd"](
-        "cmd.run", "ansible-inventory -i {0} --list".format(get_roster_file(__opts__))
-    )
-    __context__["inventory"] = __utils__["json.loads"](
-        __utils__["stringutils.to_str"](inventory)
+    __context__["inventory"] = __utils__["ansible.targets"](
+        inventory=get_roster_file(__opts__), **kwargs
     )
 
     if tgt_type == "glob":
@@ -141,7 +137,8 @@ def _get_hosts_from_group(group):
     inventory = __context__["inventory"]
     hosts = [host for host in inventory[group].get("hosts", [])]
     for child in inventory[group].get("children", []):
-        if child != "ungrouped":
+        child_info = _get_hosts_from_group(child)
+        if child_info not in hosts:
             hosts.extend(_get_hosts_from_group(child))
     return hosts
 

--- a/salt/utils/ansible.py
+++ b/salt/utils/ansible.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+# Import Python libs
+from __future__ import absolute_import, print_function, unicode_literals
+import logging
+import os
+
+# Import Salt libs
+import salt.utils.json
+import salt.utils.path
+import salt.utils.stringutils
+from salt.exceptions import CommandExecutionError
+
+CONVERSION = {
+    "ansible_ssh_host": "host",
+    "ansible_ssh_port": "port",
+    "ansible_ssh_user": "user",
+    "ansible_ssh_pass": "passwd",
+    "ansible_sudo_pass": "sudo",
+    "ansible_ssh_private_key_file": "priv",
+}
+
+__virtualname__ = "ansible"
+
+log = logging.getLogger(__name__)
+
+# Load the __salt__ dunder if not already loaded (when called from utils-module)
+__salt__ = None
+
+
+def __virtual__():  # pylint: disable=expected-2-blank-lines-found-0
+    try:
+        global __salt__  # pylint: disable=global-statement
+        if not __salt__:
+            __salt__ = salt.loader.minion_mods(__opts__)
+            return (
+                salt.utils.path.which("ansible-inventory") and __virtualname__,
+                "Install `ansible` to use inventory",
+            )
+    except Exception as e:  # pylint: disable=broad-except
+        log.error("Could not load __salt__: %s", e)
+        return False
+
+
+def targets(inventory="/etc/ansible/hosts", **kwargs):
+    """
+    Return the targets from the ansible inventory_file
+    Default: /etc/salt/roster
+    """
+    if not os.path.isfile(inventory):
+        raise CommandExecutionError("Inventory file not found: {}".format(inventory))
+
+    extra_cmd = ""
+    if kwargs.get("export", False):
+        extra_cmd += "--export "
+    if kwargs.get("yaml", False):
+        extra_cmd += "--yaml "
+    inv = __salt__["cmd.run"](
+        "ansible-inventory -i {} --list {}".format(inventory, extra_cmd)
+    )
+    if kwargs.get("yaml", False):
+        return salt.utils.stringutils.to_str(inv)
+    else:
+        return salt.utils.json.loads(salt.utils.stringutils.to_str(inv))

--- a/salt/utils/ansible.py
+++ b/salt/utils/ansible.py
@@ -40,13 +40,13 @@ def targets(inventory="/etc/ansible/hosts", **kwargs):
     if not os.path.isfile(inventory):
         raise CommandExecutionError("Inventory file not found: {}".format(inventory))
 
-    extra_cmd = ""
-    if kwargs.get("export", False):
-        extra_cmd += "--export "
-    if kwargs.get("yaml", False):
-        extra_cmd += "--yaml "
+    extra_cmd = []
+    if "export" in kwargs:
+        extra_cmd.append("--export")
+    if "yaml" in kwargs:
+        extra_cmd.append("--yaml")
     inv = __salt__["cmd.run"](
-        "ansible-inventory -i {} --list {}".format(inventory, extra_cmd)
+        "ansible-inventory -i {} --list {}".format(inventory, " ".join(extra_cmd))
     )
     if kwargs.get("yaml", False):
         return salt.utils.stringutils.to_str(inv)

--- a/salt/utils/ansible.py
+++ b/salt/utils/ansible.py
@@ -10,15 +10,6 @@ import salt.utils.path
 import salt.utils.stringutils
 from salt.exceptions import CommandExecutionError
 
-CONVERSION = {
-    "ansible_ssh_host": "host",
-    "ansible_ssh_port": "port",
-    "ansible_ssh_user": "user",
-    "ansible_ssh_pass": "passwd",
-    "ansible_sudo_pass": "sudo",
-    "ansible_ssh_private_key_file": "priv",
-}
-
 __virtualname__ = "ansible"
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
### What does this PR do?
This PR adds some improvements to the Ansiblegate module of Salt:

- Move Ansible inventory collector from "AnsibleRoster" to Salt utils to reuse it
- Add `ansible.targets` method to gather Ansible inventory
- Add `ansible.discover_playbooks` method to help collecting playbooks.
- Fix crash when running Ansible playbooks if `ansible-playbook` CLI output is not the expected JSON.

NOTE: I want to push this PR also upstream, but tests are still needed. I want to get an initial review here and then will proceed pushing this to upstream.

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

No

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
