### PR TITLE
Move vendor change logic to zypper class

### DIFF
--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -1463,7 +1463,8 @@ def install(name=None,
         DEPRECATED(use allowvendorchange): If set to True, do not allow vendor changes. Default: True
 
     allowvendorchange
-        If set to True, allow vendor changes. Default: False
+        If set to True, vendor change is allowed. Default: False
+        If both allowvendorchange and novendorchange are passed, only allowvendorchange is used.
 
     version
         Can be either a version number, or the combination of a comparison
@@ -1713,6 +1714,7 @@ def upgrade(refresh=True,
 
     allowvendorchange
         If set to True, vendor change is allowed. Default: False
+        If both allowvendorchange and novendorchange are passed, only allowvendorchange is used.
 
     skip_verify
         Skip the GPG verification check (e.g., ``--no-gpg-checks``)

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -355,10 +355,15 @@ class _Zypper(object):
             if self.__systemd_scope:
                 cmd.extend(['systemd-run', '--scope'])
             cmd.extend(self.__cmd)
+
             if self.avc:
                 for i in ["install", "upgrade", "dist-upgrade"]:
                     if i in cmd:
-                        cmd.insert(cmd(index) + 1, "--allow-vendor-change")
+                        if i == "install" and self.inst_avc:
+                           cmd.insert(cmd.index(i) + 1, "--allow-vendor-change")
+                        elif i in ["upgrade", "dist-upgrade"] and self.dup_avc:
+                           cmd.insert(cmd.index(i) + 1, "--allow-vendor-change")
+
             log.debug("Calling Zypper: %s", ' '.join(cmd))
             self.__call_result = __salt__['cmd.run_all'](cmd, **kwargs)
             if self._check_result():

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -355,8 +355,6 @@ class _Zypper(object):
             if self.__systemd_scope:
                 cmd.extend(['systemd-run', '--scope'])
             cmd.extend(self.__cmd)
-            log.error("j**************************8")
-            log.error(cmd)
             if self.avc:
                 for i in ["install", "upgrade", "dist-upgrade"]:
                     if i in cmd:

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -1460,7 +1460,7 @@ def install(name=None,
         Skip the GPG verification check (e.g., ``--no-gpg-checks``)
 
     novendorchange
-        Disallow vendor change
+        DEPRECATED(use allowvendorchange): If set to True, do not allow vendor changes. Default: True
 
     allowvendorchange
         If set to True, allow vendor changes. Default: False
@@ -1709,10 +1709,10 @@ def upgrade(refresh=True,
         Specify a list of package repositories to upgrade from. Default: None
 
     novendorchange
-        If set to True, no allow vendor changes. Default: False
+        DEPRECATED(use allowvendorchange): If set to True, do not allow vendor changes. Default: True
 
     allowvendorchange
-        If set to True, allow vendor changes. Default: False
+        If set to True, vendor change is allowed. Default: False
 
     skip_verify
         Skip the GPG verification check (e.g., ``--no-gpg-checks``)

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -105,10 +105,6 @@ class _Zypper(object):
     ZYPPER_LOCK = '/var/run/zypp.pid'
     TAG_RELEASED = 'zypper/released'
     TAG_BLOCKED = 'zypper/blocked'
-    # Dist upgrade vendor change support (SLE12+)
-    dup_avc = False
-    # Install/Patch/Upgrade vendor change support (SLE15+)
-    inst_avc = False
 
     def __init__(self):
         '''
@@ -137,6 +133,13 @@ class _Zypper(object):
         self.__ignore_not_found = False
         self.__systemd_scope = False
         self.__root = None
+
+        # Dist upgrade vendor change support (SLE12+)
+        self.dup_avc = False
+        # Install/Patch/Upgrade vendor change support (SLE15+)
+        self.inst_avc = False
+        # Flag if allow vendor change should be allowed
+        self.avc = False
 
         # Call status
         self.__called = False
@@ -182,6 +185,8 @@ class _Zypper(object):
             self.__no_raise = True
         elif item == 'refreshable':
             self.__refresh = True
+        elif item == 'allow_vendor_change':
+            return self.__allow_vendor_change
         elif item == 'call':
             return self.__call
         else:
@@ -221,6 +226,16 @@ class _Zypper(object):
     @property
     def pid(self):
         return self.__call_result.get('pid', '')
+
+    def __allow_vendor_change(self, allowvendorchange, novendorchange, dist_upgrade=False):
+        if allowvendorchange or not novendorchange:
+            self.refresh_zypper_flags()
+            if self.dup_avc or self.inst_avc:
+                log.info("Enabling vendor change")
+                self.avc = True
+            else:
+                log.warning("Enabling/Disabling vendor changes is not supported on this Zypper version")
+        return self
 
     def refresh_zypper_flags(self):
         try:
@@ -340,6 +355,10 @@ class _Zypper(object):
             if self.__systemd_scope:
                 cmd.extend(['systemd-run', '--scope'])
             cmd.extend(self.__cmd)
+            if self.avc:
+                for i in ["install", "upgrade", "dist-upgrade"]:
+                    if cmd.index(i):
+                        cmd.insert(cmd(index) + 1, "--allow-vendor-change")
             log.debug("Calling Zypper: %s", ' '.join(cmd))
             self.__call_result = __salt__['cmd.run_all'](cmd, **kwargs)
             if self._check_result():
@@ -1388,6 +1407,7 @@ def install(name=None,
             root=None,
             inclusion_detection=False,
             novendorchange=True,
+            allowvendorchange=False,
             **kwargs):
     '''
     .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
@@ -1436,6 +1456,9 @@ def install(name=None,
 
     novendorchange
         Disallow vendor change
+
+    allowvendorchange
+        If set to True, allow vendor changes. Default: False
 
     version
         Can be either a version number, or the combination of a comparison
@@ -1587,13 +1610,6 @@ def install(name=None,
 
     cmd_install.append(kwargs.get('resolve_capabilities') and '--capability' or '--name')
     # Install / patching / upgrade with vendor change support is only in SLE 15+  opensuse Leap 15+
-    if not novendorchange:
-        __zypper__(root=root).refresh_zypper_flags()
-        if __zypper__(root=root).inst_avc:
-            cmd_install.append("--allow-vendor-change")
-            log.info("Enabling vendor changes")
-        else:
-            log.warning("Enabling/Disabling vendor changes is not supported on this Zypper version")
 
 
     if not refresh:
@@ -1615,7 +1631,7 @@ def install(name=None,
     while targets:
         cmd = cmd_install + targets[:500]
         targets = targets[500:]
-        for line in __zypper__(no_repo_failure=ignore_repo_failure, systemd_scope=systemd_scope, root=root).call(*cmd).splitlines():
+        for line in __zypper__(no_repo_failure=ignore_repo_failure, systemd_scope=systemd_scope, root=root).allow_vendor_change(allowvendorchange, novendorchange).call(*cmd).splitlines():
             match = re.match(r"^The selected package '([^']+)'.+has lower version", line)
             if match:
                 downgrades.append(match.group(1))
@@ -1623,7 +1639,7 @@ def install(name=None,
     while downgrades:
         cmd = cmd_install + ['--force'] + downgrades[:500]
         downgrades = downgrades[500:]
-        __zypper__(no_repo_failure=ignore_repo_failure, root=root).call(*cmd)
+        __zypper__(no_repo_failure=ignore_repo_failure, root=root).allow_vendor_change(allowvendorchange, novendorchange).call(*cmd)
 
     _clean_cache()
     new = list_pkgs(attr=diff_attr, root=root, includes=includes) if not downloadonly else list_downloaded(root)
@@ -1650,6 +1666,7 @@ def upgrade(refresh=True,
             dist_upgrade=False,
             fromrepo=None,
             novendorchange=True,
+            allowvendorchange=False,
             skip_verify=False,
             no_recommends=False,
             root=None,
@@ -1688,6 +1705,9 @@ def upgrade(refresh=True,
 
     novendorchange
         If set to True, no allow vendor changes. Default: False
+
+    allowvendorchange
+        If set to True, allow vendor changes. Default: False
 
     skip_verify
         Skip the GPG verification check (e.g., ``--no-gpg-checks``)
@@ -1732,26 +1752,6 @@ def upgrade(refresh=True,
             cmd_update.extend(['--from' if dist_upgrade else '--repo', repo])
         log.info('Targeting repos: %s', fromrepo)
 
-    if not novendorchange:
-        __zypper__(root=root).refresh_zypper_flags()
-        if dist_upgrade:
-            if __zypper__(root=root).dup_avc:
-                cmd_update.append("--allow-vendor-change")
-                log.info("Enabling vendor changes")
-            else:
-                log.warning(
-                    "Enabling/Disabling vendor changes is not supported on this Zypper version"
-                )
-        else:
-            # Install / patching / upgrade with vendor change support is only in SLE 15+  opensuse Leap 15+
-            if __zypper__(root=root).inst_avc:
-                cmd_update.append("--allow-vendor-change")
-                log.info("Enabling vendor changes")
-            else:
-                log.warning(
-                    "Enabling/Disabling vendor changes is not supported on this Zypper version"
-                 )
-
     if no_recommends:
         cmd_update.append('--no-recommends')
         log.info('Disabling recommendations')
@@ -1759,11 +1759,10 @@ def upgrade(refresh=True,
     if dryrun:
         # Creates a solver test case for debugging.
         log.info('Executing debugsolver and performing a dry-run dist-upgrade')
-        __zypper__(systemd_scope=_systemd_scope(), root=root).noraise.call(*cmd_update + ['--debug-solver'])
+        __zypper__(systemd_scope=_systemd_scope(), root=root).allow_vendor_change(allowvendorchange, novendorchange, dist_upgrade).noraise.call(*cmd_update + ['--debug-solver'])
 
     old = list_pkgs(root=root)
-
-    __zypper__(systemd_scope=_systemd_scope(), root=root).noraise.call(*cmd_update)
+    __zypper__(systemd_scope=_systemd_scope(), root=root).allow_vendor_change(allowvendorchange, novendorchange, dist_upgrade).noraise.call(*cmd_update)
     _clean_cache()
     new = list_pkgs(root=root)
     ret = salt.utils.data.compare_dicts(old, new)

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -355,9 +355,11 @@ class _Zypper(object):
             if self.__systemd_scope:
                 cmd.extend(['systemd-run', '--scope'])
             cmd.extend(self.__cmd)
+            log.error("j**************************8")
+            log.error(cmd)
             if self.avc:
                 for i in ["install", "upgrade", "dist-upgrade"]:
-                    if cmd.index(i):
+                    if i in cmd:
                         cmd.insert(cmd(index) + 1, "--allow-vendor-change")
             log.debug("Calling Zypper: %s", ' '.join(cmd))
             self.__call_result = __salt__['cmd.run_all'](cmd, **kwargs)

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -227,7 +227,7 @@ class _Zypper(object):
     def pid(self):
         return self.__call_result.get('pid', '')
 
-    def __allow_vendor_change(self, allowvendorchange, novendorchange, dist_upgrade=False):
+    def __allow_vendor_change(self, allowvendorchange, novendorchange):
         if allowvendorchange or not novendorchange:
             self.refresh_zypper_flags()
             if self.dup_avc or self.inst_avc:
@@ -1759,10 +1759,10 @@ def upgrade(refresh=True,
     if dryrun:
         # Creates a solver test case for debugging.
         log.info('Executing debugsolver and performing a dry-run dist-upgrade')
-        __zypper__(systemd_scope=_systemd_scope(), root=root).allow_vendor_change(allowvendorchange, novendorchange, dist_upgrade).noraise.call(*cmd_update + ['--debug-solver'])
+        __zypper__(systemd_scope=_systemd_scope(), root=root).allow_vendor_change(allowvendorchange, novendorchange).noraise.call(*cmd_update + ['--debug-solver'])
 
     old = list_pkgs(root=root)
-    __zypper__(systemd_scope=_systemd_scope(), root=root).allow_vendor_change(allowvendorchange, novendorchange, dist_upgrade).noraise.call(*cmd_update)
+    __zypper__(systemd_scope=_systemd_scope(), root=root).allow_vendor_change(allowvendorchange, novendorchange).noraise.call(*cmd_update)
     _clean_cache()
     new = list_pkgs(root=root)
     ret = salt.utils.data.compare_dicts(old, new)

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -621,7 +621,8 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
             patch('salt.modules.zypperpkg.__zypper__.refresh_zypper_flags', MagicMock()), \
                 patch('salt.modules.zypperpkg.__zypper__._reset', MagicMock()):
                     zypper.__zypper__.inst_avc = False
-                    zypper.__zypper__.avc = False
+                    zypper.__zypper__.dup_avc = True
+                    zypper.__zypper__.avc = True
                     zypper.__zypper__.call("install")
                     cmd_run_mock.assert_any_call(
                         [
@@ -675,9 +676,6 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                                 fromrepo=["Dummy", "Dummy2"],
                                 novendorchange=False,
                             )
-                            # Since the "call" method is completely mocked away, we need to
-                            # assert on the vendor_change_mock, because the logic of the vendor-change
-                            # flag insertion is in thes __call method.
                             assert zypper.__zypper__.avc == True
 
 
@@ -706,9 +704,6 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                                 fromrepo=["Dummy", "Dummy2"],
                                 allowvendorchange=True,
                             )
-                            # Since the "call" method is completely mocked away, we need to
-                            # assert on the vendor_change_mock, because the logic of the vendor-change
-                            # flag insertion is in thes __call method.
                             assert zypper.__zypper__.avc == True
 
     def test_upgrade_with_allowvendorchange_false(self):
@@ -736,9 +731,6 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                                 fromrepo=["Dummy", "Dummy2"],
                                 allowvendorchange=False,
                             )
-                            # Since the "call" method is completely mocked away, we need to
-                            # assert on the vendor_change_mock, because the logic of the vendor-change
-                            # flag insertion is in thes __call method.
                             assert zypper.__zypper__.avc == False
 
     def test_upgrade_old_zypper(self):

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -470,16 +470,21 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                     )
 
 
+    #def test_refresh_zypper.....
+      #mocking version_cmp() 
+
+
     def test_upgrade_with_novendorchange(self):
         '''
         Dist-upgrade without vendor change option.
         '''
-        with patch.dict(zypper.__grains__, {'osrelease_info': [12, 1]}), \
-                patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
+        with patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
+                patch('salt.modules.zypperpkg.__zypper__.refresh_zypper_flags', MagicMock()) as refresh_flags_mock, \
                 patch('salt.modules.zypperpkg._systemd_scope', MagicMock(return_value=False)):
             with patch('salt.modules.zypperpkg.__zypper__.noraise.call', MagicMock()) as zypper_mock:
                 with patch('salt.modules.zypperpkg.list_pkgs', MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.2"}])):
                     ret = zypper.upgrade(dist_upgrade=True, novendorchange=True)
+                    refresh_flags_mock.assert_not_called()
                     zypper_mock.assert_any_call(
                         "dist-upgrade",
                         "--auto-agree-with-licenses",
@@ -489,15 +494,16 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Perform dist-upgrade with novendorchange set to False.
         '''
-        with patch.dict(zypper.__grains__, {'osrelease_info': [12, 1]}), \
-                patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
+        with patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
+                patch('salt.modules.zypperpkg.__zypper__.refresh_zypper_flags', MagicMock()), \
                 patch('salt.modules.zypperpkg._systemd_scope', MagicMock(return_value=False)):
             with patch('salt.modules.zypperpkg.__zypper__.noraise.call', MagicMock()) as zypper_mock:
-                with patch('salt.modules.zypperpkg.__zypper__.allow_vendor_change', MagicMock()) as vendor_change_mock:
                     with patch(
                         "salt.modules.zypperpkg.list_pkgs",
                         MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.1"}])
                     ):
+                        zypper.__zypper__.inst_avc = True
+                        zypper.__zypper__.dup_avc = True
                         with patch.dict(zypper.__salt__,
                                         {'pkg_resource.version': MagicMock(return_value='1.15'),
                                         'lowpkg.version_cmp': MagicMock(return_value=1)}):
@@ -511,19 +517,16 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                             # assert on the vendor_change_mock, because the logic of the vendor-change
                             # flag insertion is in thes __call method.
                             assert zypper.__zypper__.avc == True
-                            vendor_change_mock.assert_any_call(False, False, True)
 
 
     def test_upgrade_with_allowvendorchange(self):
         '''
         Perform dist-upgrade with allowvendorchange set to True.
         '''
-        with patch.dict(zypper.__grains__, {'osrelease_info': [12, 1]}), \
-                patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
+        with patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
+                patch('salt.modules.zypperpkg.__zypper__.refresh_zypper_flags', MagicMock()), \
                 patch('salt.modules.zypperpkg._systemd_scope', MagicMock(return_value=False)):
             with patch('salt.modules.zypperpkg.__zypper__.noraise.call', MagicMock()) as zypper_mock:
-                with patch('salt.modules.zypperpkg.__zypper__.allow_vendor_change', MagicMock()) as vendor_change_mock:
-
                     with patch(
                         "salt.modules.zypperpkg.list_pkgs",
                         MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.1"}])
@@ -531,6 +534,9 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                         with patch.dict(zypper.__salt__,
                                         {'pkg_resource.version': MagicMock(return_value='1.15'),
                                         'lowpkg.version_cmp': MagicMock(return_value=1)}):
+
+                            zypper.__zypper__.inst_avc = True
+                            zypper.__zypper__.dup_avc = True
                             ret = zypper.upgrade(
                                 dist_upgrade=True,
                                 dryrun=True,
@@ -541,11 +547,10 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                             # assert on the vendor_change_mock, because the logic of the vendor-change
                             # flag insertion is in thes __call method.
                             assert zypper.__zypper__.avc == True
-                            vendor_change_mock.assert_any_call(True, True, True)
 
     def test_upgrade_old_zypper(self):
-        with patch.dict(zypper.__grains__, {'osrelease_info': [12, 1]}), \
-                patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
+         with patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
+                patch('salt.modules.zypperpkg.__zypper__.refresh_zypper_flags', MagicMock()) as refresh_flags_mock, \
                 patch('salt.modules.zypperpkg._systemd_scope', MagicMock(return_value=False)):
             with patch('salt.modules.zypperpkg.__zypper__.noraise.call', MagicMock()) as zypper_mock:
                 with patch(
@@ -555,13 +560,14 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                     with patch.dict(zypper.__salt__,
                                     {'pkg_resource.version': MagicMock(return_value='1.11'),
                                     'lowpkg.version_cmp': MagicMock(return_value=-1)}):
+                        refresh_flags_mock.assert_not_called()
                         ret = zypper.upgrade(
                             dist_upgrade=True,
                             dryrun=True,
                             fromrepo=["Dummy", "Dummy2"],
                             novendorchange=False,
                         )
-                        assert zypper.__zypper__.avc == False
+
 
     def test_upgrade_success(self):
         '''

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -569,7 +569,7 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                             "Dummy",
                             "--from",
                             "Dummy2",
-                        
+                        )
 
     def test_upgrade_success(self):
         '''

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -452,6 +452,125 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
             self.assertEqual(zypper.latest_version('vim'), '7.4.326-2.62')
             self.assertDictEqual(zypper.latest_version('vim', 'fakepkg'), {'vim': '7.4.326-2.62', 'fakepkg': ''})
 
+
+    def test_upgrade_without_vendor_change(self):
+        '''
+        Dist-upgrade without vendor change option.
+        '''
+        with patch.dict(zypper.__grains__, {'osrelease_info': [12, 1]}), \
+                patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
+                patch('salt.modules.zypperpkg._systemd_scope', MagicMock(return_value=False)):
+            with patch('salt.modules.zypperpkg.__zypper__.noraise.call', MagicMock()) as zypper_mock:
+                with patch('salt.modules.zypperpkg.list_pkgs', MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.2"}])):
+                    ret = zypper.upgrade(dist_upgrade=True)
+                    self.assertDictEqual(ret, {"vim": {"old": "1.1", "new": "1.2"}})
+                    zypper_mock.assert_any_call(
+                        "dist-upgrade",
+                        "--auto-agree-with-licenses",
+                    )
+
+
+    def test_upgrade_with_novendorchange(self):
+        '''
+        Dist-upgrade without vendor change option.
+        '''
+        with patch.dict(zypper.__grains__, {'osrelease_info': [12, 1]}), \
+                patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
+                patch('salt.modules.zypperpkg._systemd_scope', MagicMock(return_value=False)):
+            with patch('salt.modules.zypperpkg.__zypper__.noraise.call', MagicMock()) as zypper_mock:
+                with patch('salt.modules.zypperpkg.list_pkgs', MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.2"}])):
+                    ret = zypper.upgrade(dist_upgrade=True, novendorchange=True)
+                    zypper_mock.assert_any_call(
+                        "dist-upgrade",
+                        "--auto-agree-with-licenses",
+                    )
+
+    def test_upgrade_with_vendorchange(self):
+        '''
+        Perform dist-upgrade with novendorchange set to False.
+        '''
+        with patch.dict(zypper.__grains__, {'osrelease_info': [12, 1]}), \
+                patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
+                patch('salt.modules.zypperpkg._systemd_scope', MagicMock(return_value=False)):
+            with patch('salt.modules.zypperpkg.__zypper__.noraise.call', MagicMock()) as zypper_mock:
+                with patch('salt.modules.zypperpkg.__zypper__.allow_vendor_change', MagicMock()) as vendor_change_mock:
+                    with patch(
+                        "salt.modules.zypperpkg.list_pkgs",
+                        MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.1"}])
+                    ):
+                        with patch.dict(zypper.__salt__,
+                                        {'pkg_resource.version': MagicMock(return_value='1.15'),
+                                        'lowpkg.version_cmp': MagicMock(return_value=1)}):
+                            ret = zypper.upgrade(
+                                dist_upgrade=True,
+                                dryrun=True,
+                                fromrepo=["Dummy", "Dummy2"],
+                                novendorchange=False,
+                            )
+                            # Since the "call" method is completely mocked away, we need to
+                            # assert on the vendor_change_mock, because the logic of the vendor-change
+                            # flag insertion is in thes __call method.
+                            vendor_change_mock.assert_any_call(False, False, True)
+
+
+    def test_upgrade_with_allowvendorchange(self):
+        '''
+        Perform dist-upgrade with allowvendorchange set to True.
+        '''
+        with patch.dict(zypper.__grains__, {'osrelease_info': [12, 1]}), \
+                patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
+                patch('salt.modules.zypperpkg._systemd_scope', MagicMock(return_value=False)):
+            with patch('salt.modules.zypperpkg.__zypper__.noraise.call', MagicMock()) as zypper_mock:
+                with patch('salt.modules.zypperpkg.__zypper__.allow_vendor_change', MagicMock()) as vendor_change_mock:
+
+                    with patch(
+                        "salt.modules.zypperpkg.list_pkgs",
+                        MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.1"}])
+                    ):
+                        with patch.dict(zypper.__salt__,
+                                        {'pkg_resource.version': MagicMock(return_value='1.15'),
+                                        'lowpkg.version_cmp': MagicMock(return_value=1)}):
+                            ret = zypper.upgrade(
+                                dist_upgrade=True,
+                                dryrun=True,
+                                fromrepo=["Dummy", "Dummy2"],
+                                allowvendorchange=True,
+                            )
+                            # Since the "call" method is completely mocked away, we need to
+                            # assert on the vendor_change_mock, because the logic of the vendor-change
+                            # flag insertion is in thes __call method.
+                            vendor_change_mock.assert_any_call(True, True, True)
+
+    def test_upgrade_old_zypper(self):
+        # FIXME: This test is a false negative!!!!!!g
+        with patch.dict(zypper.__grains__, {'osrelease_info': [12, 1]}), \
+                patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
+                patch('salt.modules.zypperpkg._systemd_scope', MagicMock(return_value=False)):
+            with patch('salt.modules.zypperpkg.__zypper__.noraise.call', MagicMock()) as zypper_mock:
+                with patch(
+                    "salt.modules.zypperpkg.list_pkgs",
+                    MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.1"}])
+                ):
+                    with patch.dict(zypper.__salt__,
+                                    {'pkg_resource.version': MagicMock(return_value='1.11'),
+                                    'lowpkg.version_cmp': MagicMock(return_value=1)}):
+                        ret = zypper.upgrade(
+                            dist_upgrade=True,
+                            dryrun=True,
+                            fromrepo=["Dummy", "Dummy2"],
+                            novendorchange=False,
+                        )
+                        # zypper version is too old, so no 
+                        zypper_mock.assert_any_call(
+                            "dist-upgrade",
+                            "--auto-agree-with-licenses",
+                            "--dry-run",
+                            "--from",
+                            "Dummy",
+                            "--from",
+                            "Dummy2",
+                        
+
     def test_upgrade_success(self):
         '''
         Test system upgrade and dist-upgrade success.
@@ -479,13 +598,6 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                     self.assertDictEqual(ret, {"vim": {"old": "1.1", "new": "1.1,1.2"}})
                     zypper_mock.assert_any_call('update', '--auto-agree-with-licenses')
 
-                with patch('salt.modules.zypperpkg.list_pkgs', MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.2"}])):
-                    ret = zypper.upgrade(dist_upgrade=True)
-                    self.assertDictEqual(ret, {"vim": {"old": "1.1", "new": "1.2"}})
-                    zypper_mock.assert_any_call(
-                        "dist-upgrade",
-                        "--auto-agree-with-licenses",
-                    )
 
                 with patch('salt.modules.zypperpkg.list_pkgs', MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.1"}])):
                     ret = zypper.upgrade(dist_upgrade=True, dryrun=True)
@@ -497,119 +609,6 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                     ret = zypper.upgrade(dist_upgrade=False, fromrepo=["Dummy", "Dummy2"], dryrun=False)
                     zypper_mock.assert_any_call('update', '--auto-agree-with-licenses', '--repo', "Dummy", '--repo', 'Dummy2')
 
-                with patch('salt.modules.zypperpkg.list_pkgs', MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.2"}])):
-                    ret = zypper.upgrade(dist_upgrade=True, fromrepo=["Dummy", "Dummy2"], novendorchange=True)
-                    zypper_mock.assert_any_call(
-                        "dist-upgrade",
-                        "--auto-agree-with-licenses",
-                        "--dry-run",
-                    )
-                    zypper_mock.assert_any_call(
-                        "dist-upgrade",
-                        "--auto-agree-with-licenses",
-                        "--dry-run",
-                    )
-
-                with patch(
-                    "salt.modules.zypperpkg.list_pkgs",
-                    MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.1"}])
-                ):
-                    with patch.dict(zypper.__salt__,
-                                    {'pkg_resource.version': MagicMock(return_value='1.15'),
-                                     'lowpkg.version_cmp': MagicMock(return_value=1)}):
-                        ret = zypper.upgrade(
-                            dist_upgrade=True,
-                            dryrun=True,
-                            fromrepo=["Dummy", "Dummy2"],
-                            novendorchange=False,
-                        )
-                        assert "--allow-vendor-change" in zypper.__zypper__._Zypper__cmd 
-                        zypper_mock.assert_any_call(
-                            "dist-upgrade",
-                            "--auto-agree-with-licenses",
-                            "--dry-run",
-                            "--from",
-                            "Dummy",
-                            "--from",
-                            "Dummy2",
-                        )
-                        zypper_mock.assert_any_call(
-                            "dist-upgrade",
-                            "--auto-agree-with-licenses",
-                            "--dry-run",
-                            "--from",
-                            "Dummy",
-                            "--from",
-                            "Dummy2",
-                            "--debug-solver",
-                        )
-
-                with patch(
-                    "salt.modules.zypperpkg.list_pkgs",
-                    MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.1"}])
-                ):
-                    with patch.dict(zypper.__salt__,
-                                    {'pkg_resource.version': MagicMock(return_value='1.15'),
-                                     'lowpkg.version_cmp': MagicMock(return_value=1)}):
-                        ret = zypper.upgrade(
-                            dist_upgrade=True,
-                            dryrun=True,
-                            fromrepo=["Dummy", "Dummy2"],
-                            allowendorchange=True,
-                        )
-                        assert "--allow-vendor-change" in zypper.__zypper__._Zypper__cmd 
-                        zypper_mock.assert_any_call(
-                            "dist-upgrade",
-                            "--auto-agree-with-licenses",
-                            "--dry-run",
-                            "--from",
-                            "Dummy",
-                            "--from",
-                            "Dummy2",
-                        )
-                        zypper_mock.assert_any_call(
-                            "dist-upgrade",
-                            "--auto-agree-with-licenses",
-                            "--dry-run",
-                            "--from",
-                            "Dummy",
-                            "--from",
-                            "Dummy2",
-                            "--debug-solver",
-                        )
-
-                with patch(
-                    "salt.modules.zypperpkg.list_pkgs",
-                    MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.1"}])
-                ):
-                    with patch.dict(zypper.__salt__,
-                                    {'pkg_resource.version': MagicMock(return_value='1.11'),
-                                     'lowpkg.version_cmp': MagicMock(return_value=1)}):
-                        ret = zypper.upgrade(
-                            dist_upgrade=True,
-                            dryrun=True,
-                            fromrepo=["Dummy", "Dummy2"],
-                            novendorchange=False,
-                        )
-                        zypper_mock.assert_any_call(
-                            "dist-upgrade",
-                            "--auto-agree-with-licenses",
-                            "--dry-run",
-                            "--from",
-                            "Dummy",
-                            "--from",
-                            "Dummy2",
-                        )
-                        zypper_mock.assert_any_call(
-                            "dist-upgrade",
-                            "--auto-agree-with-licenses",
-                            "--dry-run",
-                            "--from",
-                            "Dummy",
-                            "--from",
-                            "Dummy2",
-                            "--debug-solver",
-                        )
                 with patch(
                     "salt.modules.zypperpkg.list_pkgs",
                     MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.1"}]),
@@ -656,41 +655,6 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                         "Dummy2",
                     )
 
-                with patch(
-                    "salt.modules.zypperpkg.list_pkgs",
-                    MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.2"}]),
-                ):
-                    ret = zypper.upgrade(
-                        dist_upgrade=True,
-                        fromrepo=["Dummy", "Dummy2"],
-                        novendorchange=True,
-                    )
-                    self.assertDictEqual(ret, {"vim": {"old": "1.1", "new": "1.2"}})
-                    zypper_mock.assert_any_call('dist-upgrade', '--auto-agree-with-licenses', '--from', "Dummy",
-                                                '--from', 'Dummy2')
-
-                with patch(
-                    "salt.modules.zypperpkg.list_pkgs",
-                    MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.2"}]),
-                ):
-                    with patch.dict(zypper.__salt__,
-                                    {'pkg_resource.version': MagicMock(return_value='1.11'),
-                                     'lowpkg.version_cmp': MagicMock(return_value=1)}):
-                        ret = zypper.upgrade(
-                            dist_upgrade=True,
-                            fromrepo=["Dummy", "Dummy2"],
-                            novendorchange=False,
-                        )
-                        self.assertDictEqual(ret, {"vim": {"old": "1.1", "new": "1.2"}})
-                        assert "--allow-vendor-change" in zypper.__zypper__._Zypper__cmd 
-                        zypper_mock.assert_any_call(
-                            "dist-upgrade",
-                            "--auto-agree-with-licenses",
-                            "--from",
-                            "Dummy",
-                            "--from",
-                            "Dummy2",
-                        )
     def test_upgrade_kernel(self):
         '''
         Test kernel package upgrade success.

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -457,8 +457,7 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Dist-upgrade without vendor change option.
         '''
-        with patch.dict(zypper.__grains__, {'osrelease_info': [12, 1]}), \
-                patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
+        with patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
                 patch('salt.modules.zypperpkg._systemd_scope', MagicMock(return_value=False)):
             with patch('salt.modules.zypperpkg.__zypper__.noraise.call', MagicMock()) as zypper_mock:
                 with patch('salt.modules.zypperpkg.list_pkgs', MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.2"}])):
@@ -469,15 +468,177 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                         "--auto-agree-with-licenses",
                     )
 
+    def test_refresh_zypper_flags(self):
+        zypper.__zypper__._reset()
+        with patch('salt.modules.zypperpkg.version', MagicMock(return_value="0.5")), \
+            patch.dict(zypper.__salt__, {'lowpkg.version_cmp': MagicMock(side_effect=[-1, -1])}):
+            zypper.__zypper__.refresh_zypper_flags()
+            assert zypper.__zypper__.inst_avc == False
+            assert zypper.__zypper__.dup_avc == False
+        with patch('salt.modules.zypperpkg.version', MagicMock(return_value="1.11.34")), \
+            patch.dict(zypper.__salt__, {'lowpkg.version_cmp': MagicMock(side_effect=[0, -1])}):
+            zypper.__zypper__.refresh_zypper_flags()
+            assert zypper.__zypper__.inst_avc == False
+            assert zypper.__zypper__.dup_avc == True
+        with patch('salt.modules.zypperpkg.version', MagicMock(return_value="1.14.8")), \
+            patch.dict(zypper.__salt__, {'lowpkg.version_cmp': MagicMock(side_effect=[0, 0])}):
+            zypper.__zypper__.refresh_zypper_flags()
+            assert zypper.__zypper__.inst_avc == True
+            assert zypper.__zypper__.dup_avc == True
 
-    #def test_refresh_zypper.....
-      #mocking version_cmp() 
+    @patch('salt.modules.zypperpkg.__zypper__.refresh_zypper_flags', MagicMock())
+    def test_allow_vendor_change_function(self):
+        zypper.__zypper__._reset()
+        zypper.__zypper__.inst_avc = True
+        zypper.__zypper__.dup_avc = True
+        zypper.__zypper__.avc = False
+        zypper.__zypper__.allow_vendor_change(False, False)
+        assert zypper.__zypper__.avc == True
+        zypper.__zypper__.avc = False
+        zypper.__zypper__.allow_vendor_change(True, False)
+        assert zypper.__zypper__.avc == True
+        zypper.__zypper__.avc = False
+        zypper.__zypper__.allow_vendor_change(False, True)
+        assert zypper.__zypper__.avc == False
+        zypper.__zypper__.avc = False
+        zypper.__zypper__.allow_vendor_change(True, True)
+        assert zypper.__zypper__.avc == True
 
+        zypper.__zypper__._reset()
+        zypper.__zypper__.inst_avc = False
+        zypper.__zypper__.dup_avc = True
+        zypper.__zypper__.avc = False
+        zypper.__zypper__.allow_vendor_change(False, False)
+        assert zypper.__zypper__.avc == True
+        zypper.__zypper__.avc = False
+        zypper.__zypper__.allow_vendor_change(True, False)
+        assert zypper.__zypper__.avc == True
+        zypper.__zypper__.avc = False
+        zypper.__zypper__.allow_vendor_change(False, True)
+        assert zypper.__zypper__.avc == False
+        zypper.__zypper__.avc = False
+        zypper.__zypper__.allow_vendor_change(True, True)
+        assert zypper.__zypper__.avc == True
 
-    def test_upgrade_with_novendorchange(self):
+        zypper.__zypper__._reset()
+        zypper.__zypper__.inst_avc = False
+        zypper.__zypper__.dup_avc = False
+        zypper.__zypper__.avc = False
+        zypper.__zypper__.allow_vendor_change(False, False)
+        assert zypper.__zypper__.avc == False
+        zypper.__zypper__.avc = False
+        zypper.__zypper__.allow_vendor_change(True, False)
+        assert zypper.__zypper__.avc == False
+        zypper.__zypper__.avc = False
+        zypper.__zypper__.allow_vendor_change(False, True)
+        assert zypper.__zypper__.avc == False
+        zypper.__zypper__.avc = False
+        zypper.__zypper__.allow_vendor_change(True, True)
+        assert zypper.__zypper__.avc == False
+
+    @patch('salt.utils.environment.get_module_environment', MagicMock(return_value={'SALT_RUNNING': "1"}))
+    def test_zypper_call_dist_upgrade_with_avc_true(self):
+        cmd_run_mock = MagicMock(return_value={
+            'retcode': 0,
+            'stdout': None
+        })
+        zypper.__zypper__._reset()
+        with patch.dict(zypper.__salt__, {'cmd.run_all': cmd_run_mock}), \
+            patch('salt.modules.zypperpkg.__zypper__.refresh_zypper_flags', MagicMock()), \
+                patch('salt.modules.zypperpkg.__zypper__._reset', MagicMock()):
+                    zypper.__zypper__.dup_avc = True
+                    zypper.__zypper__.avc = True
+                    zypper.__zypper__.call("dist-upgrade")
+                    cmd_run_mock.assert_any_call(
+                        [
+                            "zypper",
+                            "--non-interactive",
+                            "--no-refresh",
+                            "dist-upgrade",
+                            "--allow-vendor-change",
+                        ],
+                        output_loglevel="trace",
+                        python_shell=False,
+                        env={"SALT_RUNNING": "1"})
+
+    @patch('salt.utils.environment.get_module_environment', MagicMock(return_value={'SALT_RUNNING': "1"}))
+    def test_zypper_call_dist_upgrade_with_avc_false(self):
+        cmd_run_mock = MagicMock(return_value={
+            'retcode': 0,
+            'stdout': None
+        })
+        zypper.__zypper__._reset()
+        with patch.dict(zypper.__salt__, {'cmd.run_all': cmd_run_mock}), \
+            patch('salt.modules.zypperpkg.__zypper__.refresh_zypper_flags', MagicMock()), \
+                patch('salt.modules.zypperpkg.__zypper__._reset', MagicMock()):
+                    zypper.__zypper__.dup_avc = False
+                    zypper.__zypper__.avc = False
+                    zypper.__zypper__.call("dist-upgrade")
+                    cmd_run_mock.assert_any_call(
+                        [
+                            "zypper",
+                            "--non-interactive",
+                            "--no-refresh",
+                            "dist-upgrade",
+                        ],
+                        output_loglevel="trace",
+                        python_shell=False,
+                        env={"SALT_RUNNING": "1"})
+
+    @patch('salt.utils.environment.get_module_environment', MagicMock(return_value={'SALT_RUNNING': "1"}))
+    def test_zypper_call_install_with_avc_true(self):
+        cmd_run_mock = MagicMock(return_value={
+            'retcode': 0,
+            'stdout': None
+        })
+        zypper.__zypper__._reset()
+        with patch.dict(zypper.__salt__, {'cmd.run_all': cmd_run_mock}), \
+            patch('salt.modules.zypperpkg.__zypper__.refresh_zypper_flags', MagicMock()), \
+                patch('salt.modules.zypperpkg.__zypper__._reset', MagicMock()):
+                    zypper.__zypper__.inst_avc = True
+                    zypper.__zypper__.avc = True
+                    zypper.__zypper__.call("install")
+                    cmd_run_mock.assert_any_call(
+                        [
+                            "zypper",
+                            "--non-interactive",
+                            "--no-refresh",
+                            "install",
+                            "--allow-vendor-change",
+                        ],
+                        output_loglevel="trace",
+                        python_shell=False,
+                        env={"SALT_RUNNING": "1"})
+
+    @patch('salt.utils.environment.get_module_environment', MagicMock(return_value={'SALT_RUNNING': "1"}))
+    def test_zypper_call_install_with_avc_false(self):
+        cmd_run_mock = MagicMock(return_value={
+            'retcode': 0,
+            'stdout': None
+        })
+        zypper.__zypper__._reset()
+        with patch.dict(zypper.__salt__, {'cmd.run_all': cmd_run_mock}), \
+            patch('salt.modules.zypperpkg.__zypper__.refresh_zypper_flags', MagicMock()), \
+                patch('salt.modules.zypperpkg.__zypper__._reset', MagicMock()):
+                    zypper.__zypper__.inst_avc = False
+                    zypper.__zypper__.avc = False
+                    zypper.__zypper__.call("install")
+                    cmd_run_mock.assert_any_call(
+                        [
+                            "zypper",
+                            "--non-interactive",
+                            "--no-refresh",
+                            "install",
+                        ],
+                        output_loglevel="trace",
+                        python_shell=False,
+                        env={"SALT_RUNNING": "1"})
+
+    def test_upgrade_with_novendorchange_true(self):
         '''
         Dist-upgrade without vendor change option.
         '''
+        zypper.__zypper__._reset()
         with patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
                 patch('salt.modules.zypperpkg.__zypper__.refresh_zypper_flags', MagicMock()) as refresh_flags_mock, \
                 patch('salt.modules.zypperpkg._systemd_scope', MagicMock(return_value=False)):
@@ -490,10 +651,11 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                         "--auto-agree-with-licenses",
                     )
 
-    def test_upgrade_with_vendorchange(self):
+    def test_upgrade_with_novendorchange_false(self):
         '''
         Perform dist-upgrade with novendorchange set to False.
         '''
+        zypper.__zypper__._reset()
         with patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
                 patch('salt.modules.zypperpkg.__zypper__.refresh_zypper_flags', MagicMock()), \
                 patch('salt.modules.zypperpkg._systemd_scope', MagicMock(return_value=False)):
@@ -519,10 +681,11 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                             assert zypper.__zypper__.avc == True
 
 
-    def test_upgrade_with_allowvendorchange(self):
+    def test_upgrade_with_allowvendorchange_true(self):
         '''
         Perform dist-upgrade with allowvendorchange set to True.
         '''
+        zypper.__zypper__._reset()
         with patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
                 patch('salt.modules.zypperpkg.__zypper__.refresh_zypper_flags', MagicMock()), \
                 patch('salt.modules.zypperpkg._systemd_scope', MagicMock(return_value=False)):
@@ -548,8 +711,39 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                             # flag insertion is in thes __call method.
                             assert zypper.__zypper__.avc == True
 
+    def test_upgrade_with_allowvendorchange_false(self):
+        '''
+        Perform dist-upgrade with allowvendorchange set to False.
+        '''
+        zypper.__zypper__._reset()
+        with patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
+                patch('salt.modules.zypperpkg.__zypper__.refresh_zypper_flags', MagicMock()), \
+                patch('salt.modules.zypperpkg._systemd_scope', MagicMock(return_value=False)):
+            with patch('salt.modules.zypperpkg.__zypper__.noraise.call', MagicMock()) as zypper_mock:
+                    with patch(
+                        "salt.modules.zypperpkg.list_pkgs",
+                        MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.1"}])
+                    ):
+                        with patch.dict(zypper.__salt__,
+                                        {'pkg_resource.version': MagicMock(return_value='1.15'),
+                                        'lowpkg.version_cmp': MagicMock(return_value=1)}):
+
+                            zypper.__zypper__.inst_avc = True
+                            zypper.__zypper__.dup_avc = True
+                            ret = zypper.upgrade(
+                                dist_upgrade=True,
+                                dryrun=True,
+                                fromrepo=["Dummy", "Dummy2"],
+                                allowvendorchange=False,
+                            )
+                            # Since the "call" method is completely mocked away, we need to
+                            # assert on the vendor_change_mock, because the logic of the vendor-change
+                            # flag insertion is in thes __call method.
+                            assert zypper.__zypper__.avc == False
+
     def test_upgrade_old_zypper(self):
-         with patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
+        zypper.__zypper__._reset()
+        with patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
                 patch('salt.modules.zypperpkg.__zypper__.refresh_zypper_flags', MagicMock()) as refresh_flags_mock, \
                 patch('salt.modules.zypperpkg._systemd_scope', MagicMock(return_value=False)):
             with patch('salt.modules.zypperpkg.__zypper__.noraise.call', MagicMock()) as zypper_mock:
@@ -560,14 +754,15 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                     with patch.dict(zypper.__salt__,
                                     {'pkg_resource.version': MagicMock(return_value='1.11'),
                                     'lowpkg.version_cmp': MagicMock(return_value=-1)}):
-                        refresh_flags_mock.assert_not_called()
+                        zypper.__zypper__.inst_avc = False
+                        zypper.__zypper__.dup_avc = False
                         ret = zypper.upgrade(
                             dist_upgrade=True,
                             dryrun=True,
                             fromrepo=["Dummy", "Dummy2"],
                             novendorchange=False,
                         )
-
+                        zypper.__zypper__.avc = False
 
     def test_upgrade_success(self):
         '''
@@ -575,8 +770,7 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
 
         :return:
         '''
-        with patch.dict(zypper.__grains__, {'osrelease_info': [12, 1]}), \
-                patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
+        with patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
                 patch('salt.modules.zypperpkg._systemd_scope', MagicMock(return_value=False)):
             with patch('salt.modules.zypperpkg.__zypper__.noraise.call', MagicMock()) as zypper_mock:
                 with patch('salt.modules.zypperpkg.list_pkgs', MagicMock(side_effect=[{"vim": "1.1"}, {"vim": "1.2"}])):
@@ -659,8 +853,7 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
 
         :return:
         '''
-        with patch.dict(zypper.__grains__, {'osrelease_info': [12, 1]}), \
-             patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
+        with patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
              patch('salt.modules.zypperpkg._systemd_scope', MagicMock(return_value=False)):
             with patch.dict(zypper.__salt__, {'pkg_resource.parse_targets': MagicMock(return_value=(['kernel-default'],
                                                                                                     None))}):
@@ -698,8 +891,7 @@ Repository 'DUMMY' not found by its alias, number, or URI.
                 return self
 
 
-        with patch.dict(zypper.__grains__, {'osrelease_info': [12, 1]}), \
-                patch('salt.modules.zypperpkg.__zypper__', FailingZypperDummy()) as zypper_mock, \
+        with patch('salt.modules.zypperpkg.__zypper__', FailingZypperDummy()) as zypper_mock, \
                 patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
                 patch('salt.modules.zypperpkg._systemd_scope', MagicMock(return_value=False)):
             zypper_mock.noraise.call = MagicMock()

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -510,6 +510,7 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                             # Since the "call" method is completely mocked away, we need to
                             # assert on the vendor_change_mock, because the logic of the vendor-change
                             # flag insertion is in thes __call method.
+                            assert zypper.__zypper__.avc == True
                             vendor_change_mock.assert_any_call(False, False, True)
 
 
@@ -539,10 +540,10 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                             # Since the "call" method is completely mocked away, we need to
                             # assert on the vendor_change_mock, because the logic of the vendor-change
                             # flag insertion is in thes __call method.
+                            assert zypper.__zypper__.avc == True
                             vendor_change_mock.assert_any_call(True, True, True)
 
     def test_upgrade_old_zypper(self):
-        # FIXME: This test is a false negative!!!!!!g
         with patch.dict(zypper.__grains__, {'osrelease_info': [12, 1]}), \
                 patch('salt.modules.zypperpkg.refresh_db', MagicMock(return_value=True)), \
                 patch('salt.modules.zypperpkg._systemd_scope', MagicMock(return_value=False)):
@@ -553,23 +554,14 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                 ):
                     with patch.dict(zypper.__salt__,
                                     {'pkg_resource.version': MagicMock(return_value='1.11'),
-                                    'lowpkg.version_cmp': MagicMock(return_value=1)}):
+                                    'lowpkg.version_cmp': MagicMock(return_value=-1)}):
                         ret = zypper.upgrade(
                             dist_upgrade=True,
                             dryrun=True,
                             fromrepo=["Dummy", "Dummy2"],
                             novendorchange=False,
                         )
-                        # zypper version is too old, so no 
-                        zypper_mock.assert_any_call(
-                            "dist-upgrade",
-                            "--auto-agree-with-licenses",
-                            "--dry-run",
-                            "--from",
-                            "Dummy",
-                            "--from",
-                            "Dummy2",
-                        )
+                        assert zypper.__zypper__.avc == False
 
     def test_upgrade_success(self):
         '''


### PR DESCRIPTION
### What does this PR do?
Moves vendor change logic to the zypper class and re-organizes some tests, as well as adds the allowvendorchange option.  

We need to fix one of the tests.  

### What issues does this PR fix or reference?
https://github.com/SUSE/spacewalk/issues/14313
Upstream PR: https://github.com/saltstack/salt/pull/58560


### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes


### Commits signed with GPG?

No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
