### PR TITLE
Fix save for iptables state module (bsc#1185131) - 3002.2

### DIFF
--- a/salt/states/iptables.py
+++ b/salt/states/iptables.py
@@ -401,7 +401,7 @@ def append(name, table="filter", family="ipv4", **kwargs):
         if save:
             if save_file is True:
                 save_file = None
-            __salt__["iptables.save"](save_file, family=family)
+            __salt__["iptables.save"](filename=save_file, family=family)
         if not ret["changes"]["locale"]:
             del ret["changes"]["locale"]
         ret["comment"] = "\n".join(comments)
@@ -426,7 +426,9 @@ def append(name, table="filter", family="ipv4", **kwargs):
                 filename = kwargs["save"]
             else:
                 filename = None
-            saved_rules = __salt__["iptables.get_saved_rules"](family=family)
+            saved_rules = __salt__["iptables.get_saved_rules"](
+                conf_file=filename, family=family
+            )
             _rules = __salt__["iptables.get_rules"](family=family)
             __rules = []
             for table in _rules:
@@ -438,7 +440,7 @@ def append(name, table="filter", family="ipv4", **kwargs):
                     __saved_rules.append(saved_rules[table][chain].get("rules"))
             # Only save if rules in memory are different than saved rules
             if __rules != __saved_rules:
-                out = __salt__["iptables.save"](filename, family=family)
+                out = __salt__["iptables.save"](filename=filename, family=family)
                 ret["comment"] += ("\nSaved iptables rule {} for {}\n" "{}\n{}").format(
                     name, family, command.strip(), out
                 )
@@ -454,16 +456,15 @@ def append(name, table="filter", family="ipv4", **kwargs):
         ret["comment"] = "Set iptables rule for {} to: {} for {}".format(
             name, command.strip(), family
         )
-        if "save" in kwargs:
-            if kwargs["save"]:
-                if kwargs["save"] is not True:
-                    filename = kwargs["save"]
-                else:
-                    filename = None
-                out = __salt__["iptables.save"](filename, family=family)
-                ret["comment"] = (
-                    "Set and saved iptables rule {} for {}\n" "{}\n{}"
-                ).format(name, family, command.strip(), out)
+        if "save" in kwargs and kwargs["save"]:
+            if kwargs["save"] is not True:
+                filename = kwargs["save"]
+            else:
+                filename = None
+            out = __salt__["iptables.save"](filename=filename, family=family)
+            ret["comment"] = (
+                "Set and saved iptables rule {} for {}\n" "{}\n{}"
+            ).format(name, family, command.strip(), out)
         return ret
     else:
         ret["result"] = False
@@ -527,7 +528,7 @@ def insert(name, table="filter", family="ipv4", **kwargs):
         if save:
             if save_file is True:
                 save_file = None
-            __salt__["iptables.save"](save_file, family=family)
+            __salt__["iptables.save"](filename=save_file, family=family)
         if not ret["changes"]["locale"]:
             del ret["changes"]["locale"]
         ret["comment"] = "\n".join(comments)
@@ -552,7 +553,9 @@ def insert(name, table="filter", family="ipv4", **kwargs):
                 filename = kwargs["save"]
             else:
                 filename = None
-            saved_rules = __salt__["iptables.get_saved_rules"](family=family)
+            saved_rules = __salt__["iptables.get_saved_rules"](
+                conf_file=filename, family=family
+            )
             _rules = __salt__["iptables.get_rules"](family=family)
             __rules = []
             for table in _rules:
@@ -564,7 +567,7 @@ def insert(name, table="filter", family="ipv4", **kwargs):
                     __saved_rules.append(saved_rules[table][chain].get("rules"))
             # Only save if rules in memory are different than saved rules
             if __rules != __saved_rules:
-                out = __salt__["iptables.save"](filename, family=family)
+                out = __salt__["iptables.save"](filename=filename, family=family)
                 ret["comment"] += ("\nSaved iptables rule {} for {}\n" "{}\n{}").format(
                     name, family, command.strip(), out
                 )
@@ -582,12 +585,15 @@ def insert(name, table="filter", family="ipv4", **kwargs):
         ret["comment"] = "Set iptables rule for {} to: {} for {}".format(
             name, command.strip(), family
         )
-        if "save" in kwargs:
-            if kwargs["save"]:
-                out = __salt__["iptables.save"](filename=None, family=family)
-                ret["comment"] = (
-                    "Set and saved iptables rule {} for {}\n" "{}\n{}"
-                ).format(name, family, command.strip(), out)
+        if "save" in kwargs and kwargs["save"]:
+            if kwargs["save"] is not True:
+                filename = kwargs["save"]
+            else:
+                filename = None
+            out = __salt__["iptables.save"](filename=filename, family=family)
+            ret["comment"] = (
+                "Set and saved iptables rule {} for {}\n" "{}\n{}"
+            ).format(name, family, command.strip(), out)
         return ret
     else:
         ret["result"] = False
@@ -646,7 +652,7 @@ def delete(name, table="filter", family="ipv4", **kwargs):
         if save:
             if save_file is True:
                 save_file = None
-            __salt__["iptables.save"](save_file, family=family)
+            __salt__["iptables.save"](filename=save_file, family=family)
         if not ret["changes"]["locale"]:
             del ret["changes"]["locale"]
         ret["comment"] = "\n".join(comments)
@@ -688,12 +694,15 @@ def delete(name, table="filter", family="ipv4", **kwargs):
         ret["changes"] = {"locale": name}
         ret["result"] = True
         ret["comment"] = "Delete iptables rule for {} {}".format(name, command.strip())
-        if "save" in kwargs:
-            if kwargs["save"]:
-                out = __salt__["iptables.save"](filename=None, family=family)
-                ret["comment"] = (
-                    "Deleted and saved iptables rule {} for {}\n" "{}\n{}"
-                ).format(name, family, command.strip(), out)
+        if "save" in kwargs and kwargs["save"]:
+            if kwargs["save"] is not True:
+                filename = kwargs["save"]
+            else:
+                filename = None
+            out = __salt__["iptables.save"](filename=filename, family=family)
+            ret["comment"] = (
+                "Deleted and saved iptables rule {} for {}\n" "{}\n{}"
+            ).format(name, family, command.strip(), out)
         return ret
     else:
         ret["result"] = False
@@ -751,14 +760,17 @@ def set_policy(name, table="filter", family="ipv4", **kwargs):
         ret["comment"] = "Set default policy for {} to {} family {}".format(
             kwargs["chain"], kwargs["policy"], family
         )
-        if "save" in kwargs:
-            if kwargs["save"]:
-                __salt__["iptables.save"](filename=None, family=family)
-                ret[
-                    "comment"
-                ] = "Set and saved default policy for {} to {} family {}".format(
-                    kwargs["chain"], kwargs["policy"], family
-                )
+        if "save" in kwargs and kwargs["save"]:
+            if kwargs["save"] is not True:
+                filename = kwargs["save"]
+            else:
+                filename = None
+            __salt__["iptables.save"](filename=filename, family=family)
+            ret[
+                "comment"
+            ] = "Set and saved default policy for {} to {} family {}".format(
+                kwargs["chain"], kwargs["policy"], family
+            )
         return ret
     else:
         ret["result"] = False

--- a/tests/unit/states/test_iptables.py
+++ b/tests/unit/states/test_iptables.py
@@ -135,7 +135,7 @@ class IptablesTestCase(TestCase, LoaderModuleMockMixin):
         with patch.object(iptables, "_STATE_INTERNAL_KEYWORDS", mock):
             mock = MagicMock(return_value="a")
             with patch.dict(iptables.__salt__, {"iptables.build_rule": mock}):
-                mock = MagicMock(side_effect=[True, False, False, False])
+                mock = MagicMock(side_effect=[True, False, False, False, False, True])
                 with patch.dict(iptables.__salt__, {"iptables.check": mock}):
                     ret.update(
                         {
@@ -161,7 +161,7 @@ class IptablesTestCase(TestCase, LoaderModuleMockMixin):
                         )
 
                     with patch.dict(iptables.__opts__, {"test": False}):
-                        mock = MagicMock(side_effect=[True, False])
+                        mock = MagicMock(side_effect=[True, False, True, True])
                         with patch.dict(iptables.__salt__, {"iptables.append": mock}):
                             ret.update(
                                 {
@@ -188,6 +188,65 @@ class IptablesTestCase(TestCase, LoaderModuleMockMixin):
                                 iptables.append("salt", table="", chain=""), ret
                             )
 
+                            mock_save = MagicMock(
+                                side_effect=['Wrote 1 lines to "/tmp/iptables"', ""]
+                            )
+                            with patch.dict(
+                                iptables.__salt__, {"iptables.save": mock_save}
+                            ):
+                                mock_get_saved_rules = MagicMock(side_effect=[""])
+                                with patch.dict(
+                                    iptables.__salt__,
+                                    {"iptables.get_saved_rules": mock_get_saved_rules},
+                                ):
+                                    mock = MagicMock(side_effect=[""])
+                                    with patch.dict(
+                                        iptables.__salt__, {"iptables.get_rules": mock}
+                                    ):
+                                        ret.update(
+                                            {
+                                                "changes": {"locale": "salt"},
+                                                "result": True,
+                                                "comment": "Set and saved iptables rule"
+                                                ' salt for ipv4\na\nWrote 1 lines to "/tmp/iptables"',
+                                            }
+                                        )
+                                        self.assertDictEqual(
+                                            iptables.append(
+                                                "salt",
+                                                table="",
+                                                chain="",
+                                                save="/tmp/iptables",
+                                            ),
+                                            ret,
+                                        )
+                                        ret.update(
+                                            {
+                                                "changes": {},
+                                                "result": True,
+                                                "comment": "iptables rule for salt already set (a) for ipv4",
+                                            }
+                                        )
+                                        self.assertDictEqual(
+                                            iptables.append(
+                                                "salt",
+                                                table="",
+                                                chain="",
+                                                save="/tmp/iptables",
+                                            ),
+                                            ret,
+                                        )
+                                        self.assertEqual(
+                                            mock_get_saved_rules.mock_calls[0][2][
+                                                "conf_file"
+                                            ],
+                                            "/tmp/iptables",
+                                        )
+                                        self.assertEqual(
+                                            mock_save.mock_calls[0][2]["filename"],
+                                            "/tmp/iptables",
+                                        )
+
     def test_insert(self):
         """
             Test to insert a rule into a chain
@@ -200,7 +259,7 @@ class IptablesTestCase(TestCase, LoaderModuleMockMixin):
         with patch.object(iptables, "_STATE_INTERNAL_KEYWORDS", mock):
             mock = MagicMock(return_value="a")
             with patch.dict(iptables.__salt__, {"iptables.build_rule": mock}):
-                mock = MagicMock(side_effect=[True, False, False, False])
+                mock = MagicMock(side_effect=[True, False, False, False, False, True])
                 with patch.dict(iptables.__salt__, {"iptables.check": mock}):
                     ret.update(
                         {
@@ -226,7 +285,7 @@ class IptablesTestCase(TestCase, LoaderModuleMockMixin):
                         )
 
                     with patch.dict(iptables.__opts__, {"test": False}):
-                        mock = MagicMock(side_effect=[False, True])
+                        mock = MagicMock(side_effect=[False, True, False, True])
                         with patch.dict(iptables.__salt__, {"iptables.insert": mock}):
                             ret.update(
                                 {
@@ -258,6 +317,67 @@ class IptablesTestCase(TestCase, LoaderModuleMockMixin):
                                 ret,
                             )
 
+                            mock_save = MagicMock(
+                                side_effect=['Wrote 1 lines to "/tmp/iptables"', ""]
+                            )
+                            with patch.dict(
+                                iptables.__salt__, {"iptables.save": mock_save}
+                            ):
+                                mock_get_saved_rules = MagicMock(side_effect=[""])
+                                with patch.dict(
+                                    iptables.__salt__,
+                                    {"iptables.get_saved_rules": mock_get_saved_rules},
+                                ):
+                                    mock = MagicMock(side_effect=[""])
+                                    with patch.dict(
+                                        iptables.__salt__, {"iptables.get_rules": mock}
+                                    ):
+                                        ret.update(
+                                            {
+                                                "changes": {"locale": "salt"},
+                                                "result": True,
+                                                "comment": "Set and saved iptables rule"
+                                                ' salt for ipv4\na\nWrote 1 lines to "/tmp/iptables"',
+                                            }
+                                        )
+                                        self.assertDictEqual(
+                                            iptables.insert(
+                                                "salt",
+                                                table="",
+                                                chain="",
+                                                position="",
+                                                save="/tmp/iptables",
+                                            ),
+                                            ret,
+                                        )
+                                        ret.update(
+                                            {
+                                                "changes": {},
+                                                "result": True,
+                                                "comment": "iptables rule for salt already set for ipv4 (a)",
+                                            }
+                                        )
+                                        self.assertDictEqual(
+                                            iptables.insert(
+                                                "salt",
+                                                table="",
+                                                chain="",
+                                                position="",
+                                                save="/tmp/iptables",
+                                            ),
+                                            ret,
+                                        )
+                                        self.assertEqual(
+                                            mock_get_saved_rules.mock_calls[0][2][
+                                                "conf_file"
+                                            ],
+                                            "/tmp/iptables",
+                                        )
+                                        self.assertEqual(
+                                            mock_save.mock_calls[0][2]["filename"],
+                                            "/tmp/iptables",
+                                        )
+
     def test_delete(self):
         """
             Test to delete a rule to a chain
@@ -270,7 +390,7 @@ class IptablesTestCase(TestCase, LoaderModuleMockMixin):
         with patch.object(iptables, "_STATE_INTERNAL_KEYWORDS", mock):
             mock = MagicMock(return_value="a")
             with patch.dict(iptables.__salt__, {"iptables.build_rule": mock}):
-                mock = MagicMock(side_effect=[False, True, True, True])
+                mock = MagicMock(side_effect=[False, True, True, True, True, False])
                 with patch.dict(iptables.__salt__, {"iptables.check": mock}):
                     ret.update(
                         {
@@ -296,7 +416,7 @@ class IptablesTestCase(TestCase, LoaderModuleMockMixin):
                         )
 
                     with patch.dict(iptables.__opts__, {"test": False}):
-                        mock = MagicMock(side_effect=[False, True])
+                        mock = MagicMock(side_effect=[False, True, False, False])
                         with patch.dict(iptables.__salt__, {"iptables.delete": mock}):
                             ret.update(
                                 {
@@ -326,6 +446,58 @@ class IptablesTestCase(TestCase, LoaderModuleMockMixin):
                                 ),
                                 ret,
                             )
+
+                            mock_save = MagicMock(
+                                side_effect=['Wrote 1 lines to "/tmp/iptables"', ""]
+                            )
+                            with patch.dict(
+                                iptables.__salt__, {"iptables.save": mock_save}
+                            ):
+                                mock = MagicMock(side_effect=[True, False])
+                                with patch.dict(
+                                    iptables.__salt__, {"iptables.check": mock}
+                                ):
+                                    mock = MagicMock(side_effect=[""])
+                                    with patch.dict(
+                                        iptables.__salt__, {"iptables.get_rules": mock}
+                                    ):
+                                        ret.update(
+                                            {
+                                                "changes": {"locale": "salt"},
+                                                "result": True,
+                                                "comment": "Deleted and saved iptables rule"
+                                                ' salt for ipv4\na\nWrote 1 lines to "/tmp/iptables"',
+                                            }
+                                        )
+                                        self.assertDictEqual(
+                                            iptables.delete(
+                                                "salt",
+                                                table="",
+                                                chain="",
+                                                save="/tmp/iptables",
+                                            ),
+                                            ret,
+                                        )
+                                        ret.update(
+                                            {
+                                                "changes": {},
+                                                "result": True,
+                                                "comment": "iptables rule for salt already absent for ipv4 (a)",
+                                            }
+                                        )
+                                        self.assertDictEqual(
+                                            iptables.delete(
+                                                "salt",
+                                                table="",
+                                                chain="",
+                                                save="/tmp/iptables",
+                                            ),
+                                            ret,
+                                        )
+                                        self.assertEqual(
+                                            mock_save.mock_calls[0][2]["filename"],
+                                            "/tmp/iptables",
+                                        )
 
     def test_set_policy(self):
         """


### PR DESCRIPTION
### What does this PR do?

Fixes bsc#1185131

`state.apply` is failing on second and every next apply of state like the following:
```
test_iptables_rule:
  iptables.append:
    - table: filter
    - chain: INPUT
    - jump: ACCEPT
    - source: 172.16.1.1/32
    - protocol: tcp
    - match:
      - tcp
      - comment
    - dport: 80
    - save: "/etc/iptables.conf"
```
With the traceback like this:
```
An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/site-packages/salt/state.py", line 1987, in call
                  ret = self.states[cdata['full']](*cdata['args'], **cdata['kwargs'])
                File "/usr/lib/python2.7/site-packages/salt/loader.py", line 2031, in wrapper
                  return f(*args, **kwargs)
                File "/usr/lib/python2.7/site-packages/salt/states/iptables.py", line 441, in append
                  saved_rules = __salt__['iptables.get_saved_rules'](family=family)
                File "/usr/lib/python2.7/site-packages/salt/modules/iptables.py", line 561, in get_saved_rules
                  return _parse_conf(conf_file=conf_file, family=family)
                File "/usr/lib/python2.7/site-packages/salt/modules/iptables.py", line 990, in _parse_conf
                  with salt.utils.files.fopen(conf_file, 'r') as ifile:
                File "/usr/lib/python2.7/site-packages/salt/utils/files.py", line 399, in fopen
                  f_handle = open(*args, **kwargs) # pylint: disable=resource-leakage
              IOError: [Errno 2] No such file or directory: u'/etc/sysconfig/scripts/SuSEfirewall2-custom'
```
Note that the file name is different than was specified in the state.
The same issue can be found with `iptables.append` `iptables.insert` and `iptables.delete`

### Previous Behavior
Traceback on every next apply the state with `iptables.append` `iptables.insert` or `iptables.delete` with `save` parameter set to file path value.

### New Behavior
Normal expected behavior

### Tests written?
Yes
Existing test was extended to check for behavior on setting `save` parameter.