### PR TITLE
Check if dpkgnotify is executable (bsc#1186674) - 3002.2

### DIFF
--- a/scripts/suse/dpkg/99dpkgnotify
+++ b/scripts/suse/dpkg/99dpkgnotify
@@ -1,1 +1,1 @@
-DPkg::Post-Invoke {"/usr/bin/dpkgnotify";};
+DPkg::Post-Invoke {"if [ -x /usr/bin/dpkgnotify ]; then /usr/bin/dpkgnotify; fi;";};


### PR DESCRIPTION
### What does this PR do?

In case of removing `salt-minion` package from the system `apt` returns the error messages that it's impossible to execute the `dpkgnotify` as the apt config to invoke this call is still active.

https://github.com/openSUSE/salt/pull/365

### Previous Behavior
`apt` errors on removing `salt-minion` from the system

### New Behavior
No errors

### Tests written?
No