### PR TITLE
Add venv executor

### DIFF
--- a/salt/executors/venv.py
+++ b/salt/executors/venv.py
@@ -1,0 +1,13 @@
+"""
+Wipe PYTHONHOME environment variable for venvjailed salt-minion
+"""
+import os
+
+
+def execute(opts, data, func, args, kwargs):
+    """
+    Wipe PYTHONHOME environment variable for venvjailed salt-minion
+    """
+    if os.environ.get("VIRTUAL_ENV", None) == os.environ.get("PYTHONHOME", ""):
+        os.environ.pop("PYTHONHOME", None)
+    return __executors__["direct_call.execute"](opts, data, func, args, kwargs)

--- a/tests/pytests/unit/executors/test_venv.py
+++ b/tests/pytests/unit/executors/test_venv.py
@@ -1,0 +1,43 @@
+"""
+Unit test for venv executor
+"""
+
+import pytest
+
+import os
+
+import salt.executors.venv as venv_exec
+
+
+@pytest.fixture(scope="session", autouse=True)
+def executors():
+    env_save = dict(os.environ)
+    venv_exec.__executors__ = {"direct_call.execute": direct_call_helper}
+    yield
+    os.environ.clear()
+    os.environ.update(env_save)
+
+
+def direct_call_helper(_opts, _data, _func, _args, _kwargs):
+    return
+
+
+def test_wipe_PYTHONHOME_environment_variable_for_venvjailed_minion(executors):
+    """
+    In case of using salt-minion in the venvjailed environment
+    PYTHONHOME environment variable should be wiped
+    """
+    os.environ["PYTHONHOME"] = os.environ["VIRTUAL_ENV"] = "/opt/venv-salt-minion"
+    venv_exec.execute(None, None, None, None, None)
+    assert "PYTHONHOME" not in os.environ
+
+
+def test_no_wipe_PYTHONHOME_environment_variable_for_non_venvjailed_minion(executors):
+    """
+    In case of using salt-minion in the non venvjailed environment
+    PYTHONHOME environment variable shouldn't be changed
+    """
+    test_path = "/usr"
+    os.environ["PYTHONHOME"] = test_path
+    venv_exec.execute(None, None, None, None, None)
+    assert os.environ["PYTHONHOME"] == test_path


### PR DESCRIPTION
### What does this PR do?

This executor prevents passing `PYTHONHOME` environment variable
to child processes from venvjailed salt-minion

The change is only required for `3002.2` as a base of the salt-minion bundle.

Requires additional config section for salt minion config:
```
module_executors:
  - venv
```

### Previous Behavior
Possible tracebacks on calling external python scripts from `salt-minion`.
For examle: `dnf` called with `yumpkg` or `dpkgnotify` with `aptpkg` and any other python script could fail on calling with `cmd` salt module.

### New Behavior
Remove this section if not relevant

### Tests written?
Yes
