### PR TITLE
Fix exception in yumpkg.remove for not installed package - 3002.2

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -2051,6 +2051,8 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=W0613
     old = list_pkgs()
     targets = []
     for target in pkg_params:
+        if target not in old:
+            continue
         version_to_remove = pkg_params[target]
         installed_versions = old[target].split(",")
 

--- a/tests/unit/modules/test_yumpkg.py
+++ b/tests/unit/modules/test_yumpkg.py
@@ -1099,6 +1099,31 @@ class YumTestCase(TestCase, LoaderModuleMockMixin):
                 call = cmd_mock.mock_calls[0][1][0]
                 assert call == expected, call
 
+    def test_remove_not_existing(self):
+        """
+        Test if no exception on removing not installed package
+        """
+        name = "foo"
+        def list_pkgs_mock():
+            return {}
+        cmd_mock = MagicMock(
+            return_value={"pid": 12345, "retcode": 0, "stdout": "", "stderr": ""}
+        )
+        salt_mock = {
+            "cmd.run_all": cmd_mock,
+            "lowpkg.version_cmp": rpm.version_cmp,
+            "pkg_resource.parse_targets": MagicMock(
+                return_value=({name: None}, "repository")
+            ),
+        }
+        with patch.object(yumpkg, "list_pkgs", list_pkgs_mock), patch(
+            "salt.utils.systemd.has_scope", MagicMock(return_value=False)
+        ), patch.dict(yumpkg.__salt__, salt_mock):
+
+            with patch.dict(yumpkg.__grains__, {"os": "CentOS", "osrelease": 7}):
+                yumpkg.remove(name)
+                cmd_mock.assert_not_called()
+
     def test_install_with_epoch(self):
         """
         Tests that we properly identify a version containing an epoch as an


### PR DESCRIPTION
### What does this PR do?

Fixes exception on calling execution module function `pkg.remove` or `pkg.removed` state module function
if one of the listed packages is not installed.

### Previous Behavior
Exception on calling `pkg.remove` for not installed package:
```
      File "/opt/venv-salt-minion/lib/python3.6/site-packages/salt/modules/yumpkg.py", line 2055, in remove
        installed_versions = old[target].split(",")
    KeyError: 'not-installed-package'
```

### New Behavior
Blank output (the same behavior as `zypperpkg` and `aptpkg` have).

### Tests written?
Yes
