### PR TITLE
Enhance openscap module: add "xccdf_eval" call

### DIFF
--- a/changelog/59756.added
+++ b/changelog/59756.added
@@ -1,0 +1,1 @@
+adding new call for openscap xccdf eval supporting new parameters

--- a/salt/modules/openscap.py
+++ b/salt/modules/openscap.py
@@ -89,6 +89,12 @@ def xccdf_eval(xccdffile, ovalfiles=None, **kwargs):
     fetch_remote_resources
         download remote content referenced by XCCDF (True or False)
 
+    tailoring_file
+        use given XCCDF Tailoring file
+
+    tailoring_id
+        use given DS component as XCCDF Tailoring file
+
     remediate
         automatically execute XCCDF fix elements for failed rules.
         Use of this option is always at your own risk. (True or False)
@@ -122,6 +128,12 @@ def xccdf_eval(xccdffile, ovalfiles=None, **kwargs):
     if "rule" in kwargs:
         cmd_opts.append("--rule")
         cmd_opts.append(kwargs["rule"])
+    if "tailoring_file" in kwargs:
+        cmd_opts.append("--tailoring-file")
+        cmd_opts.append(kwargs["tailoring_file"])
+    if "tailoring_id" in kwargs:
+        cmd_opts.append("--tailoring-id")
+        cmd_opts.append(kwargs["tailoring_id"])
     if kwargs.get("fetch_remote_resources"):
         cmd_opts.append("--fetch-remote-resources")
     if kwargs.get("remediate"):

--- a/salt/modules/openscap.py
+++ b/salt/modules/openscap.py
@@ -1,19 +1,14 @@
-# -*- coding: utf-8 -*-
 """
 Module for OpenSCAP Management
 
 """
 
-# Import Python libs
-from __future__ import absolute_import, print_function, unicode_literals
 
+import os.path
 import shlex
 import shutil
 import tempfile
 from subprocess import PIPE, Popen
-
-# Import Salt libs
-from salt.ext import six
 
 ArgumentParser = object
 
@@ -44,7 +39,7 @@ def __virtual__():
 
 class _ArgumentParser(ArgumentParser):
     def __init__(self, action=None, *args, **kwargs):
-        super(_ArgumentParser, self).__init__(*args, prog="oscap", **kwargs)
+        super().__init__(*args, prog="oscap", **kwargs)
         self.add_argument("action", choices=["eval"])
         add_arg = None
         for params, kwparams in _XCCDF_MAP["eval"]["parser_arguments"]:
@@ -59,6 +54,103 @@ _OSCAP_EXIT_CODES_MAP = {
     1: False,  # there is an error during evaluation
     2: True,  # there is at least one rule with either fail or unknown result
 }
+
+
+def xccdf_eval(xccdffile, ovalfiles=None, **kwargs):
+    """
+    Run ``oscap xccdf eval`` commands on minions.
+    It uses cp.push_dir to upload the generated files to the salt master
+    in the master's minion files cachedir
+    (defaults to ``/var/cache/salt/master/minions/minion-id/files``)
+
+    It needs ``file_recv`` set to ``True`` in the master configuration file.
+
+    xccdffile
+        the path to the xccdf file to evaluate
+
+    ovalfiles
+        additional oval definition files
+
+    profile
+        the name of Profile to be evaluated
+
+    rule
+        the name of a single rule to be evaluated
+
+    oval_results
+        save OVAL results as well (True or False)
+
+    results
+        write XCCDF Results into given file
+
+    report
+        write HTML report into given file
+
+    fetch_remote_resources
+        download remote content referenced by XCCDF (True or False)
+
+    remediate
+        automatically execute XCCDF fix elements for failed rules.
+        Use of this option is always at your own risk. (True or False)
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*'  openscap.xccdf_eval /usr/share/openscap/scap-yast2sec-xccdf.xml profile=Default
+
+    """
+    success = True
+    error = None
+    upload_dir = None
+    returncode = None
+    if not ovalfiles:
+        ovalfiles = []
+
+    cmd_opts = ["oscap", "xccdf", "eval"]
+    if kwargs.get("oval_results"):
+        cmd_opts.append("--oval-results")
+    if "results" in kwargs:
+        cmd_opts.append("--results")
+        cmd_opts.append(kwargs["results"])
+    if "report" in kwargs:
+        cmd_opts.append("--report")
+        cmd_opts.append(kwargs["report"])
+    if "profile" in kwargs:
+        cmd_opts.append("--profile")
+        cmd_opts.append(kwargs["profile"])
+    if "rule" in kwargs:
+        cmd_opts.append("--rule")
+        cmd_opts.append(kwargs["rule"])
+    if kwargs.get("fetch_remote_resources"):
+        cmd_opts.append("--fetch-remote-resources")
+    if kwargs.get("remediate"):
+        cmd_opts.append("--remediate")
+    cmd_opts.append(xccdffile)
+    cmd_opts.extend(ovalfiles)
+
+    if not os.path.exists(xccdffile):
+        success = False
+        error = "XCCDF File '{}' does not exist".format(xccdffile)
+    for ofile in ovalfiles:
+        if success and not os.path.exists(ofile):
+            success = False
+            error = "Oval File '{}' does not exist".format(ofile)
+
+    if success:
+        tempdir = tempfile.mkdtemp()
+        proc = Popen(cmd_opts, stdout=PIPE, stderr=PIPE, cwd=tempdir)
+        (stdoutdata, error) = proc.communicate()
+        success = _OSCAP_EXIT_CODES_MAP[proc.returncode]
+        returncode = proc.returncode
+        if success:
+            __salt__["cp.push_dir"](tempdir)
+            upload_dir = tempdir
+        shutil.rmtree(tempdir, ignore_errors=True)
+
+    return dict(
+        success=success, upload_dir=upload_dir, error=error, returncode=returncode
+    )
 
 
 def xccdf(params):
@@ -91,7 +183,7 @@ def xccdf(params):
         args, argv = _ArgumentParser(action=action).parse_known_args(args=params)
     except Exception as err:  # pylint: disable=broad-except
         success = False
-        error = six.text_type(err)
+        error = str(err)
 
     if success:
         cmd = _XCCDF_MAP[action]["cmd_pattern"].format(args.profile, policy)

--- a/tests/unit/modules/test_openscap.py
+++ b/tests/unit/modules/test_openscap.py
@@ -1,18 +1,8 @@
-# -*- coding: utf-8 -*-
-
-# Import python libs
-from __future__ import absolute_import, print_function, unicode_literals
-
 from subprocess import PIPE
 
-# Import salt libs
 import salt.modules.openscap as openscap
-
-# Import 3rd-party libs
 from salt.ext import six
 from tests.support.mock import MagicMock, Mock, patch
-
-# Import salt test libs
 from tests.support.unit import TestCase
 
 
@@ -51,7 +41,7 @@ class OpenscapTestCase(TestCase):
             ),
         ):
             response = openscap.xccdf(
-                "eval --profile Default {0}".format(self.policy_file)
+                "eval --profile Default {}".format(self.policy_file)
             )
 
             self.assertEqual(openscap.tempfile.mkdtemp.call_count, 1)
@@ -98,7 +88,7 @@ class OpenscapTestCase(TestCase):
             ),
         ):
             response = openscap.xccdf(
-                "eval --profile Default {0}".format(self.policy_file)
+                "eval --profile Default {}".format(self.policy_file)
             )
 
             self.assertEqual(openscap.tempfile.mkdtemp.call_count, 1)
@@ -137,10 +127,7 @@ class OpenscapTestCase(TestCase):
 
     def test_openscap_xccdf_eval_fail_no_profile(self):
         response = openscap.xccdf("eval --param Default /unknown/param")
-        if six.PY2:
-            error = "argument --profile is required"
-        else:
-            error = "the following arguments are required: --profile"
+        error = "the following arguments are required: --profile"
         self.assertEqual(
             response,
             {"error": error, "upload_dir": None, "success": False, "returncode": None},
@@ -200,7 +187,7 @@ class OpenscapTestCase(TestCase):
             ),
         ):
             response = openscap.xccdf(
-                "eval --profile Default {0}".format(self.policy_file)
+                "eval --profile Default {}".format(self.policy_file)
             )
 
             self.assertEqual(
@@ -214,11 +201,8 @@ class OpenscapTestCase(TestCase):
             )
 
     def test_openscap_xccdf_eval_fail_not_implemented_action(self):
-        response = openscap.xccdf("info {0}".format(self.policy_file))
-        if six.PY2:
-            mock_err = "argument action: invalid choice: 'info' (choose from u'eval')"
-        else:
-            mock_err = "argument action: invalid choice: 'info' (choose from 'eval')"
+        response = openscap.xccdf("info {}".format(self.policy_file))
+        mock_err = "argument action: invalid choice: 'info' (choose from 'eval')"
 
         self.assertEqual(
             response,

--- a/tests/unit/modules/test_openscap.py
+++ b/tests/unit/modules/test_openscap.py
@@ -32,6 +32,7 @@ class OpenscapTestCase(TestCase):
                 "salt.modules.openscap.tempfile.mkdtemp",
                 Mock(return_value=self.random_temp_dir),
             ),
+            patch("salt.modules.openscap.os.path.exists", Mock(return_value=True)),
         ]
         for patcher in patchers:
             self.apply_patch(patcher)
@@ -228,3 +229,236 @@ class OpenscapTestCase(TestCase):
                 "returncode": None,
             },
         )
+
+    def test_new_openscap_xccdf_eval_success(self):
+        with patch(
+            "salt.modules.openscap.Popen",
+            MagicMock(
+                return_value=Mock(
+                    **{"returncode": 0, "communicate.return_value": ("", "")}
+                )
+            ),
+        ):
+            response = openscap.xccdf_eval(
+                self.policy_file,
+                profile="Default",
+                oval_results=True,
+                results="results.xml",
+                report="report.html",
+            )
+
+            self.assertEqual(openscap.tempfile.mkdtemp.call_count, 1)
+            expected_cmd = [
+                "oscap",
+                "xccdf",
+                "eval",
+                "--oval-results",
+                "--results",
+                "results.xml",
+                "--report",
+                "report.html",
+                "--profile",
+                "Default",
+                self.policy_file,
+            ]
+            openscap.Popen.assert_called_once_with(
+                expected_cmd,
+                cwd=openscap.tempfile.mkdtemp.return_value,
+                stderr=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+            )
+            openscap.__salt__["cp.push_dir"].assert_called_once_with(
+                self.random_temp_dir
+            )
+            self.assertEqual(openscap.shutil.rmtree.call_count, 1)
+            self.assertEqual(
+                response,
+                {
+                    "upload_dir": self.random_temp_dir,
+                    "error": "",
+                    "success": True,
+                    "returncode": 0,
+                },
+            )
+
+    def test_new_openscap_xccdf_eval_success_with_extra_ovalfiles(self):
+        with patch(
+            "salt.modules.openscap.Popen",
+            MagicMock(
+                return_value=Mock(
+                    **{"returncode": 0, "communicate.return_value": ("", "")}
+                )
+            ),
+        ):
+            response = openscap.xccdf_eval(
+                self.policy_file,
+                ["/usr/share/xml/another-oval.xml", "/usr/share/xml/oval.xml"],
+                profile="Default",
+                oval_results=True,
+                results="results.xml",
+                report="report.html",
+            )
+
+            self.assertEqual(openscap.tempfile.mkdtemp.call_count, 1)
+            expected_cmd = [
+                "oscap",
+                "xccdf",
+                "eval",
+                "--oval-results",
+                "--results",
+                "results.xml",
+                "--report",
+                "report.html",
+                "--profile",
+                "Default",
+                self.policy_file,
+                "/usr/share/xml/another-oval.xml",
+                "/usr/share/xml/oval.xml",
+            ]
+            openscap.Popen.assert_called_once_with(
+                expected_cmd,
+                cwd=openscap.tempfile.mkdtemp.return_value,
+                stderr=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+            )
+            openscap.__salt__["cp.push_dir"].assert_called_once_with(
+                self.random_temp_dir
+            )
+            self.assertEqual(openscap.shutil.rmtree.call_count, 1)
+            self.assertEqual(
+                response,
+                {
+                    "upload_dir": self.random_temp_dir,
+                    "error": "",
+                    "success": True,
+                    "returncode": 0,
+                },
+            )
+
+    def test_new_openscap_xccdf_eval_success_with_failing_rules(self):
+        with patch(
+            "salt.modules.openscap.Popen",
+            MagicMock(
+                return_value=Mock(
+                    **{"returncode": 2, "communicate.return_value": ("", "some error")}
+                )
+            ),
+        ):
+            response = openscap.xccdf_eval(
+                self.policy_file,
+                profile="Default",
+                oval_results=True,
+                results="results.xml",
+                report="report.html",
+            )
+
+            self.assertEqual(openscap.tempfile.mkdtemp.call_count, 1)
+            expected_cmd = [
+                "oscap",
+                "xccdf",
+                "eval",
+                "--oval-results",
+                "--results",
+                "results.xml",
+                "--report",
+                "report.html",
+                "--profile",
+                "Default",
+                self.policy_file,
+            ]
+            openscap.Popen.assert_called_once_with(
+                expected_cmd,
+                cwd=openscap.tempfile.mkdtemp.return_value,
+                stderr=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+            )
+            openscap.__salt__["cp.push_dir"].assert_called_once_with(
+                self.random_temp_dir
+            )
+            self.assertEqual(openscap.shutil.rmtree.call_count, 1)
+            self.assertEqual(
+                response,
+                {
+                    "upload_dir": self.random_temp_dir,
+                    "error": "some error",
+                    "success": True,
+                    "returncode": 2,
+                },
+            )
+
+    def test_new_openscap_xccdf_eval_success_ignore_unknown_params(self):
+        with patch(
+            "salt.modules.openscap.Popen",
+            MagicMock(
+                return_value=Mock(
+                    **{"returncode": 2, "communicate.return_value": ("", "some error")}
+                )
+            ),
+        ):
+            response = openscap.xccdf_eval(
+                "/policy/file",
+                param="Default",
+                profile="Default",
+                oval_results=True,
+                results="results.xml",
+                report="report.html",
+            )
+
+            self.assertEqual(
+                response,
+                {
+                    "upload_dir": self.random_temp_dir,
+                    "error": "some error",
+                    "success": True,
+                    "returncode": 2,
+                },
+            )
+            expected_cmd = [
+                "oscap",
+                "xccdf",
+                "eval",
+                "--oval-results",
+                "--results",
+                "results.xml",
+                "--report",
+                "report.html",
+                "--profile",
+                "Default",
+                "/policy/file",
+            ]
+            openscap.Popen.assert_called_once_with(
+                expected_cmd,
+                cwd=openscap.tempfile.mkdtemp.return_value,
+                stderr=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+            )
+
+    def test_new_openscap_xccdf_eval_evaluation_error(self):
+        with patch(
+            "salt.modules.openscap.Popen",
+            MagicMock(
+                return_value=Mock(
+                    **{
+                        "returncode": 1,
+                        "communicate.return_value": ("", "evaluation error"),
+                    }
+                )
+            ),
+        ):
+            response = openscap.xccdf_eval(
+                self.policy_file,
+                profile="Default",
+                oval_results=True,
+                results="results.xml",
+                report="report.html",
+            )
+
+            self.assertEqual(
+                response,
+                {
+                    "upload_dir": None,
+                    "error": "evaluation error",
+                    "success": False,
+                    "returncode": 1,
+                },
+            )

--- a/tests/unit/modules/test_openscap.py
+++ b/tests/unit/modules/test_openscap.py
@@ -264,8 +264,8 @@ class OpenscapTestCase(TestCase):
             openscap.Popen.assert_called_once_with(
                 expected_cmd,
                 cwd=openscap.tempfile.mkdtemp.return_value,
-                stderr=subprocess.PIPE,
-                stdout=subprocess.PIPE,
+                stderr=PIPE,
+                stdout=PIPE,
             )
             openscap.__salt__["cp.push_dir"].assert_called_once_with(
                 self.random_temp_dir
@@ -318,8 +318,8 @@ class OpenscapTestCase(TestCase):
             openscap.Popen.assert_called_once_with(
                 expected_cmd,
                 cwd=openscap.tempfile.mkdtemp.return_value,
-                stderr=subprocess.PIPE,
-                stdout=subprocess.PIPE,
+                stderr=PIPE,
+                stdout=PIPE,
             )
             openscap.__salt__["cp.push_dir"].assert_called_once_with(
                 self.random_temp_dir
@@ -369,8 +369,8 @@ class OpenscapTestCase(TestCase):
             openscap.Popen.assert_called_once_with(
                 expected_cmd,
                 cwd=openscap.tempfile.mkdtemp.return_value,
-                stderr=subprocess.PIPE,
-                stdout=subprocess.PIPE,
+                stderr=PIPE,
+                stdout=PIPE,
             )
             openscap.__salt__["cp.push_dir"].assert_called_once_with(
                 self.random_temp_dir
@@ -429,8 +429,8 @@ class OpenscapTestCase(TestCase):
             openscap.Popen.assert_called_once_with(
                 expected_cmd,
                 cwd=openscap.tempfile.mkdtemp.return_value,
-                stderr=subprocess.PIPE,
-                stdout=subprocess.PIPE,
+                stderr=PIPE,
+                stdout=PIPE,
             )
 
     def test_new_openscap_xccdf_eval_evaluation_error(self):


### PR DESCRIPTION
### What does this PR do?

This PR introduces a new function for the openscap execution module: `xccdf_eval`

This function, allows to pass more parameters than the `xccdf` function, like `--fetch-remote-resources`, `--rule`, `--remediate`, `--tailoring-file`, `--tailoring-id`, etc.

This PR keeps the old `xccdf` function so this shouldn't break or harm anyone that is using the old function of the module.

**IMPORTANT:** There is an upstream PR here https://github.com/saltstack/salt/pull/60211 that still needs some more work in order to not remove the old function and properly deprecate it. Once this upstream PR is fixed we would probably want to switch to the final `xccdf` function.

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

Yes

### Commits signed with GPG?

Yes

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
