### PR TITLE
Implementation of held/unheld functions for state pkg

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -3550,3 +3550,313 @@ def mod_watch(name, **kwargs):
         "comment": "pkg.{} does not work with the watch requisite".format(sfun),
         "result": False,
     }
+
+
+def held(name, version=None, pkgs=None, replace=False, **kwargs):
+    """
+    Set package in 'hold' state, meaning it will not be changed.
+
+    :param str name:
+        The name of the package to be held. This parameter is ignored
+        if ``pkgs`` is used.
+
+    :param str version:
+        Hold a specific version of a package.
+        Full description of this parameter is in `installed` function.
+
+        .. note::
+
+            This parameter make sense for Zypper-based systems.
+            Ignored for YUM/DNF and APT
+
+    :param list pkgs:
+        A list of packages to be held. All packages listed under ``pkgs``
+        will be held.
+
+        .. code-block:: yaml
+
+            mypkgs:
+              pkg.held:
+                - pkgs:
+                  - foo
+                  - bar: 1.2.3-4
+                  - baz
+
+        .. note::
+
+            For Zypper-based systems the package could be held for
+            the version specified. YUM/DNF and APT ingore it.
+
+    :param bool replace:
+        Force replacement of existings holds with specified.
+        By default, this parameter is set to ``False``.
+    """
+
+    if isinstance(pkgs, list) and len(pkgs) == 0 and not replace:
+        return {
+            "name": name,
+            "changes": {},
+            "result": True,
+            "comment": "No packages to be held provided",
+        }
+
+    # If just a name (and optionally a version) is passed, just pack them into
+    # the pkgs argument.
+    if name and pkgs is None:
+        if version:
+            pkgs = [{name: version}]
+            version = None
+        else:
+            pkgs = [name]
+
+    locks = {}
+    vr_lock = False
+    if "pkg.list_locks" in __salt__:
+        locks = __salt__["pkg.list_locks"]()
+        vr_lock = True
+    elif "pkg.list_holds" in __salt__:
+        _locks = __salt__["pkg.list_holds"](full=True)
+        lock_re = re.compile(r"^(.+)-(\d+):(.*)\.\*")
+        for lock in _locks:
+            match = lock_re.match(lock)
+            if match:
+                epoch = match.group(2)
+                if epoch == "0":
+                    epoch = ""
+                else:
+                    epoch = "{}:".format(epoch)
+                locks.update(
+                    {match.group(1): {"version": "{}{}".format(epoch, match.group(3))}}
+                )
+            else:
+                locks.update({lock: {}})
+    elif "pkg.get_selections" in __salt__:
+        _locks = __salt__["pkg.get_selections"](state="hold")
+        for lock in _locks.get("hold", []):
+            locks.update({lock: {}})
+    else:
+        return {
+            "name": name,
+            "changes": {},
+            "result": False,
+            "comment": "No any function to get the list of held packages available.\n"
+            "Check if the package manager supports package locking.",
+        }
+
+    if "pkg.hold" not in __salt__:
+        return {
+            "name": name,
+            "changes": {},
+            "result": False,
+            "comment": "`hold` function is not implemented for the package manager.",
+        }
+
+    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
+    comments = []
+
+    held_pkgs = set()
+    for pkg in pkgs:
+        if isinstance(pkg, dict):
+            (pkg_name, pkg_ver) = next(iter(pkg.items()))
+        else:
+            pkg_name = pkg
+            pkg_ver = None
+        lock_ver = None
+        if pkg_name in locks and "version" in locks[pkg_name]:
+            lock_ver = locks[pkg_name]["version"]
+            lock_ver = lock_ver.lstrip("= ")
+        held_pkgs.add(pkg_name)
+        if pkg_name not in locks or (vr_lock and lock_ver != pkg_ver):
+            if __opts__["test"]:
+                if pkg_name in locks:
+                    comments.append(
+                        "The following package's hold rule would be updated: {}{}".format(
+                            pkg_name,
+                            "" if not pkg_ver else " (version = {})".format(pkg_ver),
+                        )
+                    )
+                else:
+                    comments.append(
+                        "The following package would be held: {}{}".format(
+                            pkg_name,
+                            "" if not pkg_ver else " (version = {})".format(pkg_ver),
+                        )
+                    )
+            else:
+                unhold_ret = None
+                if pkg_name in locks:
+                    unhold_ret = __salt__["pkg.unhold"](name=name, pkgs=[pkg_name])
+                hold_ret = __salt__["pkg.hold"](name=name, pkgs=[pkg])
+                if not hold_ret.get(pkg_name, {}).get("result", False):
+                    ret["result"] = False
+                if (
+                    unhold_ret
+                    and unhold_ret.get(pkg_name, {}).get("result", False)
+                    and hold_ret
+                    and hold_ret.get(pkg_name, {}).get("result", False)
+                ):
+                    comments.append(
+                        "Package {} was updated with hold rule".format(pkg_name)
+                    )
+                elif hold_ret and hold_ret.get(pkg_name, {}).get("result", False):
+                    comments.append("Package {} is now being held".format(pkg_name))
+                else:
+                    comments.append("Package {} was not held".format(pkg_name))
+                ret["changes"].update(hold_ret)
+
+    if replace:
+        for pkg_name in locks:
+            if locks[pkg_name].get("type", "package") != "package":
+                continue
+            if __opts__["test"]:
+                if pkg_name not in held_pkgs:
+                    comments.append(
+                        "The following package would be unheld: {}".format(pkg_name)
+                    )
+            else:
+                if pkg_name not in held_pkgs:
+                    unhold_ret = __salt__["pkg.unhold"](name=name, pkgs=[pkg_name])
+                    if not unhold_ret.get(pkg_name, {}).get("result", False):
+                        ret["result"] = False
+                    if unhold_ret and unhold_ret.get(pkg_name, {}).get("comment"):
+                        comments.append(unhold_ret.get(pkg_name).get("comment"))
+                    ret["changes"].update(unhold_ret)
+
+    ret["comment"] = "\n".join(comments)
+    if not (ret["changes"] or ret["comment"]):
+        ret["comment"] = "No changes made"
+
+    return ret
+
+
+def unheld(name, version=None, pkgs=None, all=False, **kwargs):
+    """
+    Unset package from 'hold' state, to allow operations with the package.
+
+    :param str name:
+        The name of the package to be unheld. This parameter is ignored if "pkgs"
+        is used.
+
+    :param str version:
+        Unhold a specific version of a package.
+        Full description of this parameter is in `installed` function.
+
+        .. note::
+
+            This parameter make sense for Zypper-based systems.
+            Ignored for YUM/DNF and APT.
+
+    :param list pkgs:
+        A list of packages to be unheld. All packages listed under ``pkgs``
+        will be unheld.
+
+        .. code-block:: yaml
+
+            mypkgs:
+              pkg.unheld:
+                - pkgs:
+                  - foo
+                  - bar: 1.2.3-4
+                  - baz
+
+        .. note::
+
+            For Zypper-based systems the package could be held for
+            the version specified. YUM/DNF and APT ingore it.
+            For ``unheld`` there is no need to specify the exact version
+            to be unheld.
+
+    :param bool all:
+        Force removing of all existings locks.
+        By default, this parameter is set to ``False``.
+    """
+
+    if isinstance(pkgs, list) and len(pkgs) == 0 and not all:
+        return {
+            "name": name,
+            "changes": {},
+            "result": True,
+            "comment": "No packages to be unheld provided",
+        }
+
+    # If just a name (and optionally a version) is passed, just pack them into
+    # the pkgs argument.
+    if name and pkgs is None:
+        pkgs = [{name: version}]
+        version = None
+
+    locks = {}
+    vr_lock = False
+    if "pkg.list_locks" in __salt__:
+        locks = __salt__["pkg.list_locks"]()
+        vr_lock = True
+    elif "pkg.list_holds" in __salt__:
+        _locks = __salt__["pkg.list_holds"](full=True)
+        lock_re = re.compile(r"^(.+)-(\d+):(.*)\.\*")
+        for lock in _locks:
+            match = lock_re.match(lock)
+            if match:
+                epoch = match.group(2)
+                if epoch == "0":
+                    epoch = ""
+                else:
+                    epoch = "{}:".format(epoch)
+                locks.update(
+                    {match.group(1): {"version": "{}{}".format(epoch, match.group(3))}}
+                )
+            else:
+                locks.update({lock: {}})
+    elif "pkg.get_selections" in __salt__:
+        _locks = __salt__["pkg.get_selections"](state="hold")
+        for lock in _locks.get("hold", []):
+            locks.update({lock: {}})
+    else:
+        return {
+            "name": name,
+            "changes": {},
+            "result": False,
+            "comment": "No any function to get the list of held packages available.\n"
+            "Check if the package manager supports package locking.",
+        }
+
+    dpkgs = {}
+    for pkg in pkgs:
+        if isinstance(pkg, dict):
+            (pkg_name, pkg_ver) = next(iter(pkg.items()))
+            dpkgs.update({pkg_name: pkg_ver})
+        else:
+            dpkgs.update({pkg: None})
+
+    ret = {"name": name, "changes": {}, "result": True, "comment": ""}
+    comments = []
+
+    for pkg_name in locks:
+        if locks[pkg_name].get("type", "package") != "package":
+            continue
+        lock_ver = None
+        if vr_lock and "version" in locks[pkg_name]:
+            lock_ver = locks[pkg_name]["version"]
+            lock_ver = lock_ver.lstrip("= ")
+        if all or (pkg_name in dpkgs and (not lock_ver or lock_ver == dpkgs[pkg_name])):
+            if __opts__["test"]:
+                comments.append(
+                    "The following package would be unheld: {}{}".format(
+                        pkg_name,
+                        ""
+                        if not dpkgs.get(pkg_name)
+                        else " (version = {})".format(lock_ver),
+                    )
+                )
+            else:
+                unhold_ret = __salt__["pkg.unhold"](name=name, pkgs=[pkg_name])
+                if not unhold_ret.get(pkg_name, {}).get("result", False):
+                    ret["result"] = False
+                if unhold_ret and unhold_ret.get(pkg_name, {}).get("comment"):
+                    comments.append(unhold_ret.get(pkg_name).get("comment"))
+                ret["changes"].update(unhold_ret)
+
+    ret["comment"] = "\n".join(comments)
+    if not (ret["changes"] or ret["comment"]):
+        ret["comment"] = "No changes made"
+
+    return ret

--- a/tests/pytests/unit/modules/test_zypperpkg.py
+++ b/tests/pytests/unit/modules/test_zypperpkg.py
@@ -1,0 +1,142 @@
+import pytest
+import salt.modules.pkg_resource as pkg_resource
+import salt.modules.zypperpkg as zypper
+from tests.support.mock import MagicMock, patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {zypper: {"rpm": None}, pkg_resource: {}}
+
+
+def test_pkg_hold():
+    """
+    Tests holding packages with Zypper
+    """
+
+    # Test openSUSE 15.3
+    list_locks_mock = {
+        "bar": {"type": "package", "match_type": "glob", "case_sensitive": "on"},
+        "minimal_base": {
+            "type": "pattern",
+            "match_type": "glob",
+            "case_sensitive": "on",
+        },
+        "baz": {"type": "package", "match_type": "glob", "case_sensitive": "on"},
+    }
+
+    cmd = MagicMock(
+        return_value={
+            "pid": 1234,
+            "retcode": 0,
+            "stdout": "Specified lock has been successfully added.",
+            "stderr": "",
+        }
+    )
+    with patch.object(
+        zypper, "list_locks", MagicMock(return_value=list_locks_mock)
+    ), patch.dict(zypper.__salt__, {"cmd.run_all": cmd}):
+        ret = zypper.hold("foo")
+        assert ret["foo"]["changes"]["old"] == ""
+        assert ret["foo"]["changes"]["new"] == "hold"
+        assert ret["foo"]["comment"] == "Package foo is now being held."
+        cmd.assert_called_once_with(
+            ["zypper", "--non-interactive", "--no-refresh", "al", "foo"],
+            env={},
+            output_loglevel="trace",
+            python_shell=False,
+        )
+        cmd.reset_mock()
+        ret = zypper.hold(pkgs=["foo", "bar"])
+        assert ret["foo"]["changes"]["old"] == ""
+        assert ret["foo"]["changes"]["new"] == "hold"
+        assert ret["foo"]["comment"] == "Package foo is now being held."
+        assert ret["bar"]["changes"] == {}
+        assert ret["bar"]["comment"] == "Package bar is already set to be held."
+        cmd.assert_called_once_with(
+            ["zypper", "--non-interactive", "--no-refresh", "al", "foo"],
+            env={},
+            output_loglevel="trace",
+            python_shell=False,
+        )
+
+
+def test_pkg_unhold():
+    """
+    Tests unholding packages with Zypper
+    """
+
+    # Test openSUSE 15.3
+    list_locks_mock = {
+        "bar": {"type": "package", "match_type": "glob", "case_sensitive": "on"},
+        "minimal_base": {
+            "type": "pattern",
+            "match_type": "glob",
+            "case_sensitive": "on",
+        },
+        "baz": {"type": "package", "match_type": "glob", "case_sensitive": "on"},
+    }
+
+    cmd = MagicMock(
+        return_value={
+            "pid": 1234,
+            "retcode": 0,
+            "stdout": "1 lock has been successfully removed.",
+            "stderr": "",
+        }
+    )
+    with patch.object(
+        zypper, "list_locks", MagicMock(return_value=list_locks_mock)
+    ), patch.dict(zypper.__salt__, {"cmd.run_all": cmd}):
+        ret = zypper.unhold("foo")
+        assert ret["foo"]["comment"] == "Package foo was already unheld."
+        cmd.assert_not_called()
+        cmd.reset_mock()
+        ret = zypper.unhold(pkgs=["foo", "bar"])
+        assert ret["foo"]["changes"] == {}
+        assert ret["foo"]["comment"] == "Package foo was already unheld."
+        assert ret["bar"]["changes"]["old"] == "hold"
+        assert ret["bar"]["changes"]["new"] == ""
+        assert ret["bar"]["comment"] == "Package bar is no longer held."
+        cmd.assert_called_once_with(
+            ["zypper", "--non-interactive", "--no-refresh", "rl", "bar"],
+            env={},
+            output_loglevel="trace",
+            python_shell=False,
+        )
+
+
+def test_pkg_list_holds():
+    """
+    Tests listing of calculated held packages with Zypper
+    """
+
+    # Test openSUSE 15.3
+    list_locks_mock = {
+        "bar": {"type": "package", "match_type": "glob", "case_sensitive": "on"},
+        "minimal_base": {
+            "type": "pattern",
+            "match_type": "glob",
+            "case_sensitive": "on",
+        },
+        "baz": {"type": "package", "match_type": "glob", "case_sensitive": "on"},
+    }
+    installed_pkgs = {
+        "foo": [{"edition": "1.2.3-1.1"}],
+        "bar": [{"edition": "2.3.4-2.1", "epoch": "2"}],
+    }
+
+    def zypper_search_mock(name, *_args, **_kwargs):
+        if name in installed_pkgs:
+            return {name: installed_pkgs.get(name)}
+
+    with patch.object(
+        zypper, "list_locks", MagicMock(return_value=list_locks_mock)
+    ), patch.object(
+        zypper, "search", MagicMock(side_effect=zypper_search_mock)
+    ), patch.object(
+        zypper, "info_installed", MagicMock(side_effect=zypper_search_mock)
+    ):
+        ret = zypper.list_holds()
+        assert len(ret) == 1
+        assert "bar-2:2.3.4-2.1.*" in ret

--- a/tests/pytests/unit/states/test_pkg.py
+++ b/tests/pytests/unit/states/test_pkg.py
@@ -1,0 +1,155 @@
+import pytest
+import salt.states.pkg as pkg
+from tests.support.mock import MagicMock, patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {
+        pkg: {
+            "__env__": "base",
+            "__salt__": {},
+            "__grains__": {"os": "CentOS"},
+            "__opts__": {"test": False, "cachedir": ""},
+            "__instance_id__": "",
+            "__low__": {},
+            "__utils__": {},
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    "package_manager", [("Zypper"), ("YUM/DNF"), ("APT")],
+)
+def test_held_unheld(package_manager):
+    """
+    Test pkg.held and pkg.unheld with Zypper, YUM/DNF and APT
+    """
+
+    if package_manager == "Zypper":
+        list_holds_func = "pkg.list_locks"
+        list_holds_mock = MagicMock(
+            return_value={
+                "bar": {
+                    "type": "package",
+                    "match_type": "glob",
+                    "case_sensitive": "on",
+                },
+                "minimal_base": {
+                    "type": "pattern",
+                    "match_type": "glob",
+                    "case_sensitive": "on",
+                },
+                "baz": {
+                    "type": "package",
+                    "match_type": "glob",
+                    "case_sensitive": "on",
+                },
+            }
+        )
+    elif package_manager == "YUM/DNF":
+        list_holds_func = "pkg.list_holds"
+        list_holds_mock = MagicMock(
+            return_value=["bar-0:1.2.3-1.1.*", "baz-0:2.3.4-2.1.*"]
+        )
+    elif package_manager == "APT":
+        list_holds_func = "pkg.get_selections"
+        list_holds_mock = MagicMock(return_value={"hold": ["bar", "baz"]})
+
+    def pkg_hold(name, pkgs=None, *_args, **__kwargs):
+        if name and pkgs is None:
+            pkgs = [name]
+        ret = {}
+        for pkg in pkgs:
+            ret.update(
+                {
+                    pkg: {
+                        "name": pkg,
+                        "changes": {"new": "hold", "old": ""},
+                        "result": True,
+                        "comment": "Package {} is now being held.".format(pkg),
+                    }
+                }
+            )
+        return ret
+
+    def pkg_unhold(name, pkgs=None, *_args, **__kwargs):
+        if name and pkgs is None:
+            pkgs = [name]
+        ret = {}
+        for pkg in pkgs:
+            ret.update(
+                {
+                    pkg: {
+                        "name": pkg,
+                        "changes": {"new": "", "old": "hold"},
+                        "result": True,
+                        "comment": "Package {} is no longer held.".format(pkg),
+                    }
+                }
+            )
+        return ret
+
+    hold_mock = MagicMock(side_effect=pkg_hold)
+    unhold_mock = MagicMock(side_effect=pkg_unhold)
+
+    # Testing with Zypper
+    with patch.dict(
+        pkg.__salt__,
+        {
+            list_holds_func: list_holds_mock,
+            "pkg.hold": hold_mock,
+            "pkg.unhold": unhold_mock,
+        },
+    ):
+        # Holding one of two packages
+        ret = pkg.held("held-test", pkgs=["foo", "bar"])
+        assert "foo" in ret["changes"]
+        assert len(ret["changes"]) == 1
+        hold_mock.assert_called_once_with(name="held-test", pkgs=["foo"])
+        unhold_mock.assert_not_called()
+
+        hold_mock.reset_mock()
+        unhold_mock.reset_mock()
+
+        # Holding one of two packages and replacing all the rest held packages
+        ret = pkg.held("held-test", pkgs=["foo", "bar"], replace=True)
+        assert "foo" in ret["changes"]
+        assert "baz" in ret["changes"]
+        assert len(ret["changes"]) == 2
+        hold_mock.assert_called_once_with(name="held-test", pkgs=["foo"])
+        unhold_mock.assert_called_once_with(name="held-test", pkgs=["baz"])
+
+        hold_mock.reset_mock()
+        unhold_mock.reset_mock()
+
+        # Remove all holds
+        ret = pkg.held("held-test", pkgs=[], replace=True)
+        assert "bar" in ret["changes"]
+        assert "baz" in ret["changes"]
+        assert len(ret["changes"]) == 2
+        hold_mock.assert_not_called()
+        unhold_mock.assert_any_call(name="held-test", pkgs=["baz"])
+        unhold_mock.assert_any_call(name="held-test", pkgs=["bar"])
+
+        hold_mock.reset_mock()
+        unhold_mock.reset_mock()
+
+        # Unolding one of two packages
+        ret = pkg.unheld("held-test", pkgs=["foo", "bar"])
+        assert "bar" in ret["changes"]
+        assert len(ret["changes"]) == 1
+        unhold_mock.assert_called_once_with(name="held-test", pkgs=["bar"])
+        hold_mock.assert_not_called()
+
+        hold_mock.reset_mock()
+        unhold_mock.reset_mock()
+
+        # Remove all holds
+        ret = pkg.unheld("held-test", all=True)
+        assert "bar" in ret["changes"]
+        assert "baz" in ret["changes"]
+        assert len(ret["changes"]) == 2
+        hold_mock.assert_not_called()
+        unhold_mock.assert_any_call(name="held-test", pkgs=["baz"])
+        unhold_mock.assert_any_call(name="held-test", pkgs=["bar"])


### PR DESCRIPTION
### What does this PR do?

Port of https://github.com/saltstack/salt/pull/56935 and https://github.com/saltstack/salt/pull/60432
Fixes https://github.com/SUSE/spacewalk/issues/15258 (bsc#1187813)

Implements `held`/`unheld` functions for state `pkg` module.
Examples:
```
sysstat:
  pkg.held: []
```
```
held-pkgs:
  pkg.held:
    - pkgs:
      - sysstat
      - vnstat: 1.17-bp153.1.18
```
```
held-pkgs-clear:
  pkg.held:
    - pkgs: []
    - replace: True
```
```
unheld-pkgs:
  pkg.unheld:
    - pkgs:
      - sysstat
      - vnstat: 1.17-bp153.1.18
      - test-package
```
```
unheld-all:
  pkg.unheld:
    - all: True
```

Implements `list_holds` function for `zypperpkg` module. The output is similar to `yumpkg.list_holds`. The only difference is that `zypperpkg` calculates the current locked packages from `list_locks` as the yum and zypper have different way of managing locks.

Improves `hold` function for `zypperpkg` to handle package version if specified.

### Previous Behavior
Tracebacks on calling `zypperpkg.hold`/`zypperpkg.unhold`

### New Behavior
Expected behavior and implementation of `pkg.held` and `pkg.unheld`.

### Tests written?
No
