### PR TITLE
3000: aarch64 virt.all_capabilities fix

### DIFF
--- a/changelog/60491.fixed
+++ b/changelog/60491.fixed
@@ -1,0 +1,1 @@
+Pass emulator path to get guest capabilities from libvirt

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -6670,7 +6670,11 @@ def all_capabilities(**kwargs):
         host_caps = ElementTree.fromstring(conn.getCapabilities())
         domains = [
             [
-                (guest.get("arch", {}).get("name", None), key)
+                (
+                    guest.get("arch", {}).get("name", None),
+                    key,
+                    guest.get("arch", {}).get("emulator", None),
+                )
                 for key in guest.get("arch", {}).get("domains", {}).keys()
             ]
             for guest in [
@@ -6688,10 +6692,10 @@ def all_capabilities(**kwargs):
             "domains": [
                 _parse_domain_caps(
                     ElementTree.fromstring(
-                        conn.getDomainCapabilities(None, arch, None, domain)
+                        conn.getDomainCapabilities(emulator, arch, None, domain)
                     )
                 )
-                for (arch, domain) in flattened
+                for (arch, domain, emulator) in flattened
             ],
         }
     finally:

--- a/tests/unit/modules/test_virt.py
+++ b/tests/unit/modules/test_virt.py
@@ -5056,6 +5056,10 @@ class VirtTestCase(TestCase, LoaderModuleMockMixin):
             {"qemu", "kvm"}, {domainCaps["domain"] for domainCaps in caps["domains"]},
         )
 
+        self.mock_conn.getDomainCapabilities.assert_called_with(
+            "/usr/bin/qemu-system-x86_64", "x86_64", None, "kvm"
+        )
+
     def test_network_tag(self):
         """
         Test virt._get_net_xml() with VLAN tag


### PR DESCRIPTION
backport of saltstack/salt#60492