### PR TITLE
Handle "master tops" data when states are applied by "transactional_update" (bsc#1187787)

### DIFF
--- a/salt/modules/transactional_update.py
+++ b/salt/modules/transactional_update.py
@@ -301,6 +301,11 @@ def __virtual__():
         return (False, "Module transactional_update requires a transactional system")
 
 
+class TransactionalUpdateHighstate(salt.client.ssh.state.SSHHighState):
+    def _master_tops(self):
+        return self.client.master_tops()
+
+
 def _global_params(self_update, snapshot=None, quiet=False):
     """Utility function to prepare common global parameters."""
     params = ["--non-interactive", "--drop-if-no-change"]
@@ -1107,7 +1112,7 @@ def sls(
     # Clone the options data and apply some default values. May not be
     # needed, as this module just delegate
     opts = salt.utils.state.get_sls_opts(__opts__, **kwargs)
-    st_ = salt.client.ssh.state.SSHHighState(
+    st_ = TransactionalUpdateHighstate(
         opts, pillar, __salt__, salt.fileclient.get_file_client(__opts__)
     )
 
@@ -1180,7 +1185,7 @@ def highstate(activate_transaction=False, **kwargs):
     # Clone the options data and apply some default values. May not be
     # needed, as this module just delegate
     opts = salt.utils.state.get_sls_opts(__opts__, **kwargs)
-    st_ = salt.client.ssh.state.SSHHighState(
+    st_ = TransactionalUpdateHighstate(
         opts, pillar, __salt__, salt.fileclient.get_file_client(__opts__)
     )
 

--- a/tests/unit/modules/test_transactional_update.py
+++ b/tests/unit/modules/test_transactional_update.py
@@ -622,22 +622,22 @@ class TransactionalUpdateTestCase(TestCase, LoaderModuleMockMixin):
             utils_mock["files.rm_rf"].assert_called_once()
 
     @patch("salt.modules.transactional_update._create_and_execute_salt_state")
-    @patch("salt.client.ssh.state.SSHHighState")
+    @patch("salt.modules.transactional_update.TransactionalUpdateHighstate")
     @patch("salt.fileclient.get_file_client")
     @patch("salt.utils.state.get_sls_opts")
     def test_sls(
         self,
         get_sls_opts,
         get_file_client,
-        SSHHighState,
+        TransactionalUpdateHighstate,
         _create_and_execute_salt_state,
     ):
         """Test transactional_update.sls"""
-        SSHHighState.return_value = SSHHighState
-        SSHHighState.render_highstate.return_value = (None, [])
-        SSHHighState.state.reconcile_extend.return_value = (None, [])
-        SSHHighState.state.requisite_in.return_value = (None, [])
-        SSHHighState.state.verify_high.return_value = []
+        TransactionalUpdateHighstate.return_value = TransactionalUpdateHighstate
+        TransactionalUpdateHighstate.render_highstate.return_value = (None, [])
+        TransactionalUpdateHighstate.state.reconcile_extend.return_value = (None, [])
+        TransactionalUpdateHighstate.state.requisite_in.return_value = (None, [])
+        TransactionalUpdateHighstate.state.verify_high.return_value = []
 
         _create_and_execute_salt_state.return_value = "result"
         opts_mock = {
@@ -649,18 +649,18 @@ class TransactionalUpdateTestCase(TestCase, LoaderModuleMockMixin):
             _create_and_execute_salt_state.assert_called_once()
 
     @patch("salt.modules.transactional_update._create_and_execute_salt_state")
-    @patch("salt.client.ssh.state.SSHHighState")
+    @patch("salt.modules.transactional_update.TransactionalUpdateHighstate")
     @patch("salt.fileclient.get_file_client")
     @patch("salt.utils.state.get_sls_opts")
     def test_highstate(
         self,
         get_sls_opts,
         get_file_client,
-        SSHHighState,
+        TransactionalUpdateHighstate,
         _create_and_execute_salt_state,
     ):
         """Test transactional_update.highstage"""
-        SSHHighState.return_value = SSHHighState
+        TransactionalUpdateHighstate.return_value = TransactionalUpdateHighstate
 
         _create_and_execute_salt_state.return_value = "result"
         opts_mock = {


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue when running the highstate via the "transactional_update" module (SLE Micro).

Before this PR, the "master_tops" data was not injected into the rendered highstate (only top.sls data). This issue leads into empty highstates for registered minions in Uyuni/SUSE Manager.

Backported from upstream PR: https://github.com/saltstack/salt/pull/58520
(only this commit https://github.com/saltstack/salt/pull/58520/commits/f660165561c9c9daffe4f13e35944161791b6128 - others are already in our package)

/cc @aplanas