### PR TITLE
Backport loader contexts 3000

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,3 +7,4 @@ requests>=1.0.0
 singledispatch==3.4.0.3; python_version < '3.4'
 # Required by Tornado to handle threads stuff.
 futures>=2.0; python_version < '3.0'
+contextvars; python_version < '3.7'

--- a/requirements/static/py3.4/cloud.txt
+++ b/requirements/static/py3.4/cloud.txt
@@ -88,11 +88,46 @@ azure-storage-common==1.4.0  # via azure-cosmosdb-table, azure-storage-blob, azu
 azure-storage-file==1.4.0  # via azure
 azure-storage-queue==1.4.0  # via azure
 azure==4.0.0
-certifi==2019.3.9         # via msrest, requests
-cffi==1.12.2              # via azure-datalake-store, cryptography
-chardet==3.0.4            # via requests
-cryptography==2.6.1       # via adal, azure-cosmosdb-table, azure-keyvault, azure-storage-common, requests-ntlm, smbprotocol
-idna==2.8                 # via requests
+backports.functools-lru-cache==1.5
+backports.ssl-match-hostname==3.7.0.1 ; python_version < "3.7"
+bcrypt==3.1.6             # via paramiko
+boto3==1.13.5
+boto==2.49.0
+botocore==1.16.26         # via boto3, moto, s3transfer
+cachetools==3.1.0         # via google-auth
+cassandra-driver==3.23.0
+certifi==2020.6.20
+certvalidator==0.11.1     # via vcert
+cffi==1.14.3
+chardet==3.0.4
+cheetah3==3.1.0
+cheroot==6.5.4
+cherrypy==17.3.0
+click==7.1.1              # via geomet
+contextlib2==0.5.5
+contextvars==2.4 ; python_version < "3.7"
+croniter==0.3.29
+cryptography==3.2
+distlib==0.3.0            # via virtualenv
+dnspython==1.16.0
+docker-pycreds==0.4.0     # via docker
+docker==3.7.2
+docutils==0.15.2          # via botocore
+ecdsa==0.13.3             # via python-jose
+filelock==3.0.12          # via virtualenv
+future==0.17.1            # via python-jose, textfsm
+genshi==0.7.3
+geomet==0.1.2             # via cassandra-driver
+gitdb2==2.0.5             # via gitpython
+gitpython==2.1.11
+google-auth==1.6.3        # via kubernetes
+hgtools==8.1.1
+idna==2.8
+immutables==0.14
+importlib-metadata==0.23  # via importlib-resources, pluggy, pytest, virtualenv
+importlib-resources==1.5.0  # via virtualenv
+iniconfig==1.0.1          # via pytest
+ipaddress==1.0.22         # via kubernetes
 isodate==0.6.0            # via msrest
 msrest==0.6.6             # via azure-applicationinsights, azure-eventgrid, azure-keyvault, azure-loganalytics, azure-mgmt-cdn, azure-mgmt-compute, azure-mgmt-containerinstance, azure-mgmt-containerregistry, azure-mgmt-containerservice, azure-mgmt-dns, azure-mgmt-eventhub, azure-mgmt-keyvault, azure-mgmt-media, azure-mgmt-network, azure-mgmt-rdbms, azure-mgmt-resource, azure-mgmt-servicebus, azure-mgmt-servicefabric, azure-mgmt-signalr, azure-servicefabric, msrestazure
 msrestazure==0.6.0        # via azure-batch, azure-eventgrid, azure-graphrbac, azure-keyvault, azure-mgmt-advisor, azure-mgmt-applicationinsights, azure-mgmt-authorization, azure-mgmt-batch, azure-mgmt-batchai, azure-mgmt-billing, azure-mgmt-cdn, azure-mgmt-cognitiveservices, azure-mgmt-commerce, azure-mgmt-compute, azure-mgmt-consumption, azure-mgmt-containerinstance, azure-mgmt-containerregistry, azure-mgmt-containerservice, azure-mgmt-cosmosdb, azure-mgmt-datafactory, azure-mgmt-datalake-analytics, azure-mgmt-datalake-store, azure-mgmt-datamigration, azure-mgmt-devspaces, azure-mgmt-devtestlabs, azure-mgmt-dns, azure-mgmt-eventgrid, azure-mgmt-eventhub, azure-mgmt-hanaonazure, azure-mgmt-iotcentral, azure-mgmt-iothub, azure-mgmt-iothubprovisioningservices, azure-mgmt-keyvault, azure-mgmt-loganalytics, azure-mgmt-logic, azure-mgmt-machinelearningcompute, azure-mgmt-managementgroups, azure-mgmt-managementpartner, azure-mgmt-maps, azure-mgmt-marketplaceordering, azure-mgmt-media, azure-mgmt-monitor, azure-mgmt-msi, azure-mgmt-network, azure-mgmt-notificationhubs, azure-mgmt-policyinsights, azure-mgmt-powerbiembedded, azure-mgmt-rdbms, azure-mgmt-recoveryservices, azure-mgmt-recoveryservicesbackup, azure-mgmt-redis, azure-mgmt-relay, azure-mgmt-reservations, azure-mgmt-resource, azure-mgmt-scheduler, azure-mgmt-search, azure-mgmt-servicebus, azure-mgmt-servicefabric, azure-mgmt-signalr, azure-mgmt-sql, azure-mgmt-storage, azure-mgmt-subscription, azure-mgmt-trafficmanager, azure-mgmt-web

--- a/requirements/static/py3.5/windows.txt
+++ b/requirements/static/py3.5/windows.txt
@@ -22,8 +22,10 @@ cheetah3==3.1.0
 cheroot==6.5.5            # via cherrypy
 cherrypy==17.4.1
 colorama==0.4.1           # via pytest
-contextlib2==0.5.5        # via cherrypy
-cryptography==2.6.1
+contextlib2==0.6.0.post1
+contextvars==2.4 ; python_version < "3.7"
+cryptography==3.2
+distlib==0.3.0            # via virtualenv
 dmidecode==0.9.0
 dnspython==1.16.0
 docker-pycreds==0.4.0     # via docker
@@ -38,7 +40,10 @@ gitdb==0.6.4
 gitpython==2.1.10
 google-auth==1.6.3        # via kubernetes
 idna==2.8
-importlib-metadata==0.23  # via pluggy, pytest
+immutables==0.14
+importlib-metadata==0.23  # via importlib-resources, pluggy, pytest, virtualenv
+importlib-resources==1.5.0  # via virtualenv
+iniconfig==1.0.1          # via pytest
 ioloop==0.1a0
 ipaddress==1.0.22
 jaraco.functools==2.0     # via tempora

--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -228,8 +228,7 @@ class BaseCaller(object):
                     sys.stderr.write(trace)
                 sys.exit(salt.defaults.exitcodes.EX_GENERIC)
             try:
-                retcode = sys.modules[
-                    func.__module__].__context__.get('retcode', 0)
+                retcode = self.minion.executors.pack["__context__"].get("retcode", 0)
             except AttributeError:
                 retcode = salt.defaults.exitcodes.EX_GENERIC
 

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1077,6 +1077,8 @@ class Single(object):
             opts_pkg['extension_modules'] = self.opts['extension_modules']
             opts_pkg['module_dirs'] = self.opts['module_dirs']
             opts_pkg['_ssh_version'] = self.opts['_ssh_version']
+            opts_pkg['thin_dir'] = self.opts['thin_dir']
+            opts_pkg['master_tops'] = self.opts['master_tops']
             opts_pkg['__master_opts__'] = self.context['master_opts']
             if 'known_hosts_file' in self.opts:
                 opts_pkg['known_hosts_file'] = self.opts['known_hosts_file']
@@ -1138,6 +1140,7 @@ class Single(object):
             fsclient=self.fsclient,
             minion_opts=self.minion_opts,
             **self.target)
+        wrapper.fsclient.opts['cachedir'] = opts['cachedir']
         self.wfuncs = salt.loader.ssh_wrapper(opts, wrapper, self.context)
         wrapper.wfuncs = self.wfuncs
 

--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -192,7 +192,7 @@ def sls(mods, saltenv='base', test=None, exclude=None, **kwargs):
             __context__['fileclient'])
     st_.push_active()
     mods = _parse_mods(mods)
-    high_data, errors = st_.render_highstate({saltenv: mods})
+    high_data, errors = st_.render_highstate({saltenv: mods}, context=__context__)
     if exclude:
         if isinstance(exclude, six.string_types):
             exclude = exclude.split(',')

--- a/salt/cloud/clouds/vmware.py
+++ b/salt/cloud/clouds/vmware.py
@@ -185,10 +185,12 @@ def get_configured_provider():
     '''
     Return the first configured instance.
     '''
+    try:
+        active_provider = __active_provider_name__.value()
+    except AttributeError:
+        active_provider = __active_provider_name__
     return config.is_provider_configured(
-        __opts__,
-        __active_provider_name__ or __virtualname__,
-        ('url', 'user', 'password',)
+        __opts__, active_provider or __virtualname__, ("url", "user", "password",),
     )
 
 

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1250,10 +1250,8 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         self.module_dirs = module_dirs
         self.tag = tag
         self._gc_finalizer = None
-        if loaded_base_name:
+        if loaded_base_name and loaded_base_name != LOADED_BASE_NAME:
             self.loaded_base_name = loaded_base_name
-        else:
-            self.loaded_base_name = "{}_{}".format(LOADED_BASE_NAME, id(self))
             # Remove any modules matching self.loaded_base_name that have been set to None previously
             self.clean_modules()
             # Make sure that, when this module is about to be GC'ed, we at least set any modules in
@@ -1266,6 +1264,8 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             )
             # This finalizer does not need to run when the process is exiting
             self._gc_finalizer.atexit = False
+        else:
+            self.loaded_base_name = LOADED_BASE_NAME
         self.mod_type_check = mod_type_check or _mod_type
 
         if '__context__' not in self.pack:

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1203,7 +1203,10 @@ class LazyLoader(salt.utils.lazy.LazyDict):
 
         self.module_dirs = module_dirs
         self.tag = tag
-        self.loaded_base_name = loaded_base_name or LOADED_BASE_NAME
+        if loaded_base_name:
+            self.loaded_base_name = loaded_base_name
+        else:
+            self.loaded_base_name = "{}_{}".format(LOADED_BASE_NAME, id(self))
         self.mod_type_check = mod_type_check or _mod_type
 
         if '__context__' not in self.pack:
@@ -1260,6 +1263,12 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         _generate_module('{0}.int.{1}'.format(self.loaded_base_name, tag))
         _generate_module('{0}.ext'.format(self.loaded_base_name))
         _generate_module('{0}.ext.{1}'.format(self.loaded_base_name, tag))
+
+    def clean_modules(self):
+        for name in list(sys.modules):
+            if name.startswith(self.loaded_base_name):
+                mod = sys.modules.pop(name)
+                del mod
 
     def __getitem__(self, item):
         '''

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -7,6 +7,8 @@ plugin interfaces used by Salt.
 
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
+import contextvars
+import copy
 import os
 import re
 import sys
@@ -24,6 +26,7 @@ from zipimport import zipimporter
 # Import salt libs
 import salt.config
 import salt.defaults.exitcodes
+import salt.loader_context
 import salt.syspaths
 import salt.utils.args
 import salt.utils.context
@@ -256,9 +259,8 @@ def minion_mods(
         loaded_base_name=loaded_base_name,
         static_modules=static_modules,
         extra_module_dirs=utils.module_dirs if utils else None,
+        pack_self="__salt__",
     )
-
-    ret.pack['__salt__'] = ret
 
     # Load any provider overrides from the configuration file providers option
     #  Note: Providers can be pkg, service, user or group - not to be confused
@@ -317,7 +319,6 @@ def metaproxy(opts):
     '''
     Return functions used in the meta proxy
     '''
-
     return LazyLoader(
         _module_dirs(opts, 'metaproxy'),
         opts,
@@ -353,21 +354,26 @@ def engines(opts, functions, runners, utils, proxy=None):
     )
 
 
-def proxy(opts, functions=None, returners=None, whitelist=None, utils=None):
+def proxy(
+    opts,
+    functions=None,
+    returners=None,
+    whitelist=None,
+    utils=None,
+    context=None,
+    pack_self="__proxy__",
+):
     '''
     Returns the proxy module for this salt-proxy-minion
     '''
-    ret = LazyLoader(
-        _module_dirs(opts, 'proxy'),
+    return LazyLoader(
+        _module_dirs(opts, "proxy"),
         opts,
         tag='proxy',
         pack={'__salt__': functions, '__ret__': returners, '__utils__': utils},
         extra_module_dirs=utils.module_dirs if utils else None,
+        pack_self=pack_self,
     )
-
-    ret.pack['__proxy__'] = ret
-
-    return ret
 
 
 def returners(opts, functions, whitelist=None, context=None, proxy=None):
@@ -383,7 +389,7 @@ def returners(opts, functions, whitelist=None, context=None, proxy=None):
     )
 
 
-def utils(opts, whitelist=None, context=None, proxy=proxy):
+def utils(opts, whitelist=None, context=None, proxy=proxy, pack_self=None):
     '''
     Returns the utility modules
     '''
@@ -393,6 +399,7 @@ def utils(opts, whitelist=None, context=None, proxy=proxy):
         tag='utils',
         whitelist=whitelist,
         pack={'__context__': context, '__proxy__': proxy or {}},
+        pack_self=pack_self,
     )
 
 
@@ -401,14 +408,14 @@ def pillars(opts, functions, context=None):
     Returns the pillars modules
     '''
     _utils = utils(opts)
-    ret = LazyLoader(_module_dirs(opts, 'pillar'),
-                     opts,
-                     tag='pillar',
-                     pack={'__salt__': functions,
-                           '__context__': context,
-                           '__utils__': _utils},
-                     extra_module_dirs=_utils.module_dirs)
-    ret.pack['__ext_pillar__'] = ret
+    ret = LazyLoader(
+        _module_dirs(opts, 'pillar'),
+        opts,
+        tag='pillar',
+        pack={'__salt__': functions, '__context__': context, '__utils__': _utils},
+        extra_module_dirs=_utils.module_dirs,
+        pack_self='__ext_pillar__',
+    )
     return FilterDictWrapper(ret, '.ext_pillar')
 
 
@@ -565,19 +572,21 @@ def states(opts, functions, utils, serializers, whitelist=None, proxy=None, cont
     if context is None:
         context = {}
 
-    ret = LazyLoader(
+    return LazyLoader(
         _module_dirs(opts, 'states'),
         opts,
         tag='states',
-        pack={'__salt__': functions, '__proxy__': proxy or {}},
+        pack={
+            '__salt__': functions,
+            '__proxy__': proxy or {},
+            '__utils__': utils,
+            '__serializers__': serializers,
+            '__context__': context,
+        },
         whitelist=whitelist,
         extra_module_dirs=utils.module_dirs if utils else None,
+        pack_self="__states__",
     )
-    ret.pack['__states__'] = ret
-    ret.pack['__utils__'] = utils
-    ret.pack['__serializers__'] = serializers
-    ret.pack['__context__'] = context
-    return ret
 
 
 def beacons(opts, functions, context=None, proxy=None):
@@ -650,7 +659,11 @@ def render(opts, functions, states=None, proxy=None, context=None):
 
     if states:
         pack['__states__'] = states
-    pack['__proxy__'] = proxy or {}
+
+    if proxy is None:
+        proxy = {}
+    pack['__proxy__'] = proxy
+
     ret = LazyLoader(
         _module_dirs(
             opts,
@@ -684,7 +697,8 @@ def grain_funcs(opts, proxy=None):
           __opts__ = salt.config.minion_config('/etc/salt/minion')
           grainfuncs = salt.loader.grain_funcs(__opts__)
     '''
-    _utils = utils(opts)
+    _utils = utils(opts, proxy=proxy)
+    pack = {"__utils__": utils(opts, proxy=proxy), "__context__": context}
     ret = LazyLoader(
         _module_dirs(
             opts,
@@ -695,8 +709,9 @@ def grain_funcs(opts, proxy=None):
         opts,
         tag='grains',
         extra_module_dirs=_utils.module_dirs,
+        pack=pack,
     )
-    ret.pack['__utils__'] = utils(opts, proxy=proxy)
+    ret.pack['__utils__'] = _utils
     return ret
 
 
@@ -953,17 +968,16 @@ def runner(opts, utils=None, context=None, whitelist=None):
         utils = {}
     if context is None:
         context = {}
-    ret = LazyLoader(
+    return LazyLoader(
         _module_dirs(opts, 'runners', 'runner', ext_type_dirs='runner_dirs'),
         opts,
         tag='runners',
         pack={'__utils__': utils, '__context__': context},
         whitelist=whitelist,
         extra_module_dirs=utils.module_dirs if utils else None,
+        # TODO: change from __salt__ to something else, we overload __salt__ too much
+        pack_self="__salt__",
     )
-    # TODO: change from __salt__ to something else, we overload __salt__ too much
-    ret.pack['__salt__'] = ret
-    return ret
 
 
 def queues(opts):
@@ -990,7 +1004,6 @@ def sdb(opts, functions=None, whitelist=None, utils=None):
         tag='sdb',
         pack={
             '__sdb__': functions,
-            '__opts__': opts,
             '__utils__': utils,
             '__salt__': minion_mods(opts, utils=utils),
         },
@@ -1077,14 +1090,17 @@ def executors(opts, functions=None, context=None, proxy=None):
     '''
     Returns the executor modules
     '''
-    executors = LazyLoader(
+    return LazyLoader(
         _module_dirs(opts, 'executors', 'executor'),
         opts,
         tag='executor',
-        pack={'__salt__': functions, '__context__': context or {}, '__proxy__': proxy or {}},
+        pack={
+            '__salt__': functions,
+            '__context__': context or {},
+            '__proxy__': proxy or {},
+        },
+        pack_self='__executors__',
     )
-    executors.pack['__executors__'] = executors
-    return executors
 
 
 def cache(opts, serial):
@@ -1095,7 +1111,7 @@ def cache(opts, serial):
         _module_dirs(opts, 'cache', 'cache'),
         opts,
         tag='cache',
-        pack={'__opts__': opts, '__context__': {'serial': serial}},
+        pack={'__context__': {'serial': serial}},
     )
 
 
@@ -1190,6 +1206,54 @@ class FilterDictWrapper(MutableMapping):
                 yield key.replace(self.suffix, '')
 
 
+class LoadedFunc:
+    """
+    The functions loaded by LazyLoader instances using subscript notation
+    'a[k]' will be wrapped with LoadedFunc.
+
+      - Makes sure functions are called with the correct loader's context.
+      - Provides access to a wrapped func's __global__ attribute
+
+    :param func callable: The callable to wrap.
+    :param dict loader: The loader to use in the context when the wrapped callable is called.
+    """
+
+    def __init__(self, func, loader):
+        self.func = func
+        self.loader = loader
+        functools.update_wrapper(self, func)
+
+    def __getattr__(self, name):
+        if name == "__globals__":
+            return self.func.__globals__
+
+    def __call__(self, *args, **kwargs):
+        if self.loader.inject_globals:
+            run_func = global_injector_decorator(self.loader.inject_globals)(self.func)
+        else:
+            run_func = self.func
+        return self.loader.run(run_func, *args, **kwargs)
+
+
+class LoadedMod:
+    def __init__(self, mod, loader):
+        """
+        Return the wrapped func's globals via this object's __globals__
+        attribute.
+        """
+        self.mod = mod
+        self.loader = loader
+
+    def __getattr__(self, name):
+        """
+        Run the wrapped function in the loader's context.
+        """
+        attr = getattr(self.mod, name)
+        if inspect.isfunction(attr) or inspect.ismethod(attr):
+            return LoadedFunc(attr, self.loader)
+        return attr
+
+
 class LazyLoader(salt.utils.lazy.LazyDict):
     '''
     A pseduo-dictionary which has a set of keys which are the
@@ -1211,6 +1275,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
     :param str virtual_funcs: The name of additional functions in the module to call to verify its functionality.
                                 If not true, the module will not load.
     :param list extra_module_dirs: A list of directories that will be able to import from
+    :param str pack_self: Pack this module into a variable by this name into modules loaded
     :returns: A LazyLoader object which functions as a dictionary. Keys are 'module.function' and values
     are function references themselves which are loaded on-demand.
     # TODO:
@@ -1233,19 +1298,25 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                  proxy=None,
                  virtual_funcs=None,
                  extra_module_dirs=None,
+                 pack_self=None,
                  ):  # pylint: disable=W0231
         '''
         In pack, if any of the values are None they will be replaced with an
         empty context-specific dict
         '''
 
+        self.parent_loader = None
         self.inject_globals = {}
         self.pack = {} if pack is None else pack
+        for i in self.pack:
+            if isinstance(self.pack[i], salt.loader_context.NamedLoaderContext):
+                self.pack[i] = self.pack[i].value()
         if opts is None:
             opts = {}
         threadsafety = not opts.get('multiprocessing')
         self.context_dict = salt.utils.context.ContextDict(threadsafe=threadsafety)
         self.opts = self.__prep_mod_opts(opts)
+        self.pack_self = pack_self
 
         self.module_dirs = module_dirs
         self.tag = tag
@@ -1338,10 +1409,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         to last-minute inject globals
         '''
         func = super(LazyLoader, self).__getitem__(item)
-        if self.inject_globals:
-            return global_injector_decorator(self.inject_globals)(func)
-        else:
-            return func
+        return LoadedFunc(func, self)
 
     def __getattr__(self, mod_name):
         '''
@@ -1366,7 +1434,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                 if self._load_module(name) and mod_name in self.loaded_modules:
                     break
         if mod_name in self.loaded_modules:
-            return self.loaded_modules[mod_name]
+            return LoadedMod(self.loaded_modules[mod_name], self)
         else:
             raise AttributeError(mod_name)
 
@@ -1719,7 +1787,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                         # loading using exec_module has been causing odd things
                         # with the magic dunders we pack into the loaded
                         # modules, most notably with salt-ssh's __opts__.
-                        mod = spec.loader.load_module()
+                        mod = self.run(spec.loader.load_module)
                         #mod = importlib.util.module_from_spec(spec)
                         #spec.loader.exec_module(mod)
                         # pylint: enable=no-member
@@ -1727,7 +1795,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                     else:
                         with salt.utils.files.fopen(fpath, desc[1]) as fn_:
                             mod = imp.load_module(mod_namespace, fn_, fpath, desc)
-        except IOError:
+        except (IOError, OSError):
             raise
         except ImportError as exc:
             if 'magic number' in six.text_type(exc):
@@ -1774,14 +1842,55 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             sys.path.remove(fpath_dirname)
             self.__clean_sys_path()
 
-        if hasattr(mod, '__opts__'):
-            mod.__opts__.update(self.opts)
+        loader_context = salt.loader_context.LoaderContext()
+        if hasattr(mod, '__salt_loader__'):
+            if not isinstance(mod.__salt_loader__, salt.loader_context.LoaderContext):
+                log.warning('Override  __salt_loader__: %s', mod)
+                mod.__salt_loader__ = loader_context
         else:
-            mod.__opts__ = self.opts
+            mod.__salt_loader__ = loader_context
+        if hasattr(mod, '__opts__'):
+            if not isinstance(mod.__opts__, salt.loader_context.NamedLoaderContext):
+                if not hasattr(mod, '__orig_opts__'):
+                    mod.__orig_opts__ = copy.deepcopy(mod.__opts__)
+                mod.__opts__ = copy.deepcopy(mod.__orig_opts__)
+                mod.__opts__.update(self.opts)
+        else:
+            if not hasattr(mod, '__orig_opts__'):
+                mod.__orig_opts__ = {}
+            mod.__opts__ = copy.deepcopy(mod.__orig_opts__)
+            mod.__opts__.update(self.opts)
 
         # pack whatever other globals we were asked to
         for p_name, p_value in six.iteritems(self.pack):
-            setattr(mod, p_name, p_value)
+            mod_named_context = getattr(mod, p_name, None)
+            if hasattr(mod_named_context, 'default'):
+                default = copy.deepcopy(mod_named_context.default)
+            else:
+                default = None
+            named_context = loader_context.named_context(p_name, default)
+            if mod_named_context is None:
+                setattr(mod, p_name, named_context)
+            elif named_context != mod_named_context:
+                log.debug('Override  %s: %s', p_name, mod)
+                setattr(mod, p_name, named_context)
+            else:
+                setattr(mod, p_name, named_context)
+
+        if self.pack_self is not None:
+            mod_named_context = getattr(mod, self.pack_self, None)
+            if hasattr(mod_named_context, 'default'):
+                default = copy.deepcopy(mod_named_context.default)
+            else:
+                default = None
+            named_context = loader_context.named_context(self.pack_self, default)
+            if mod_named_context is None:
+                setattr(mod, self.pack_self, named_context)
+            elif named_context != mod_named_context:
+                log.debug('Override  %s: %s', self.pack_self, mod)
+                setattr(mod, self.pack_self, named_context)
+            else:
+                setattr(mod, self.pack_self, named_context)
 
         module_name = mod.__name__.rsplit('.', 1)[-1]
 
@@ -1789,7 +1898,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         module_init = getattr(mod, '__init__', None)
         if inspect.isfunction(module_init):
             try:
-                module_init(self.opts)
+                self.run(module_init, self.opts)
             except TypeError as e:
                 log.error(e)
             except Exception:  # pylint: disable=broad-except
@@ -2010,7 +2119,8 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             if hasattr(mod, '__virtual__') and inspect.isfunction(mod.__virtual__):
                 try:
                     start = time.time()
-                    virtual = getattr(mod, virtual_func)()
+                    virtual_attr = getattr(mod, virtual_func)
+                    virtual = self.run(virtual_attr)
                     if isinstance(virtual, tuple):
                         error_reason = virtual[1]
                         virtual = virtual[0]
@@ -2090,6 +2200,45 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             return (False, module_name, error_reason, virtual_aliases)
 
         return (True, module_name, None, virtual_aliases)
+
+    def run(self, method, *args, **kwargs):
+        """
+        Run the method in this loader's context
+        """
+        self._last_context = contextvars.copy_context()
+        return self._last_context.run(self._run_as, method, *args, **kwargs)
+
+    def _run_as(self, method, *args, **kwargs):
+        """
+        Handle setting up the context properly and call the method
+        """
+        self.parent_loader = None
+        try:
+            current_loader = salt.loader_context.loader_ctxvar.get()
+        except LookupError:
+            current_loader = None
+        if current_loader is not self:
+            self.parent_loader = current_loader
+        token = salt.loader_context.loader_ctxvar.set(self)
+        try:
+            return method(*args, **kwargs)
+        finally:
+            self.parent_loader = None
+            salt.loader_context.loader_ctxvar.reset(token)
+
+    def run_in_thread(self, method, *args, **kwargs):
+        """
+        Run the function in a new thread with the context of this loader
+        """
+        argslist = [self, method]
+        argslist.extend(args)
+        thread = threading.Thread(target=self.target, args=argslist, kwargs=kwargs)
+        thread.start()
+        return thread
+
+    @staticmethod
+    def target(loader, method, *args, **kwargs):
+        loader.run(method, *args, **kwargs)
 
 
 def global_injector_decorator(inject_globals):

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -18,6 +18,7 @@ import functools
 import threading
 import traceback
 import types
+import weakref
 from zipimport import zipimporter
 
 # Import salt libs
@@ -1115,6 +1116,51 @@ def _mod_type(module_path):
     return 'ext'
 
 
+def _cleanup_module_namespace(loaded_base_name, delete_from_sys_modules=False):
+    """
+    Clean module namespace.
+    If ``delete_from_sys_modules`` is ``False``, then the module instance in ``sys.modules``
+    will only be set to ``None``, when ``True``, it's actually ``del``elted.
+
+    The reason for this two stage cleanup procedure is because this function might
+    get called during the GC collection cycle and trigger https://bugs.python.org/issue40327
+
+    We seem to specially trigger this during the CI test runs with ``coverage.py`` tracking
+    the code usage:
+
+        Traceback (most recent call last):
+          File "/urs/lib64/python3.6/site-packages/coverage/multiproc.py", line 37, in _bootstrap
+            cov.start()
+          File "/urs/lib64/python3.6/site-packages/coverage/control.py", line 527, in start
+            self._init_for_start()
+          File "/urs/lib64/python3.6/site-packages/coverage/control.py", line 455, in _init_for_start
+            concurrency=concurrency,
+          File "/urs/lib64/python3.6/site-packages/coverage/collector.py", line 111, in __init__
+            self.origin = short_stack()
+          File "/urs/lib64/python3.6/site-packages/coverage/debug.py", line 157, in short_stack
+            stack = inspect.stack()[limit:skip:-1]
+          File "/usr/lib64/python3.6/inspect.py", line 1501, in stack
+            return getouterframes(sys._getframe(1), context)
+          File "/usr/lib64/python3.6/inspect.py", line 1478, in getouterframes
+            frameinfo = (frame,) + getframeinfo(frame, context)
+          File "/usr/lib64/python3.6/inspect.py", line 1452, in getframeinfo
+            lines, lnum = findsource(frame)
+          File "/usr/lib64/python3.6/inspect.py", line 780, in findsource
+            module = getmodule(object, file)
+          File "/usr/lib64/python3.6/inspect.py", line 732, in getmodule
+            for modname, module in list(sys.modules.items()):
+        RuntimeError: dictionary changed size during iteration
+    """
+    for name in list(sys.modules):
+        if name.startswith(loaded_base_name):
+            if delete_from_sys_modules:
+                del sys.modules[name]
+            else:
+                mod = sys.modules[name]
+                sys.modules[name] = None
+                del mod
+
+
 # TODO: move somewhere else?
 class FilterDictWrapper(MutableMapping):
     '''
@@ -1203,10 +1249,23 @@ class LazyLoader(salt.utils.lazy.LazyDict):
 
         self.module_dirs = module_dirs
         self.tag = tag
+        self._gc_finalizer = None
         if loaded_base_name:
             self.loaded_base_name = loaded_base_name
         else:
             self.loaded_base_name = "{}_{}".format(LOADED_BASE_NAME, id(self))
+            # Remove any modules matching self.loaded_base_name that have been set to None previously
+            self.clean_modules()
+            # Make sure that, when this module is about to be GC'ed, we at least set any modules in
+            # sys.modules which match self.loaded_base_name to None to reduce memory usage over time.
+            # ATTENTION: Do not replace the '_cleanup_module_namespace' function on the call below with
+            #            self.clean_modules as that WILL prevent this loader object from being garbage
+            #            collected and the finalizer running.
+            self._gc_finalizer = weakref.finalize(
+                self, _cleanup_module_namespace, "{}".format(self.loaded_base_name)
+            )
+            # This finalizer does not need to run when the process is exiting
+            self._gc_finalizer.atexit = False
         self.mod_type_check = mod_type_check or _mod_type
 
         if '__context__' not in self.pack:
@@ -1265,10 +1324,13 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         _generate_module('{0}.ext.{1}'.format(self.loaded_base_name, tag))
 
     def clean_modules(self):
-        for name in list(sys.modules):
-            if name.startswith(self.loaded_base_name):
-                mod = sys.modules.pop(name)
-                del mod
+        """
+        Clean modules
+        """
+        if self._gc_finalizer is not None and self._gc_finalizer.alive:
+            # Prevent the weakref.finalizer instance from running, there's no point after the next call.
+            self._gc_finalizer.detach()
+        _cleanup_module_namespace(self.loaded_base_name, delete_from_sys_modules=True)
 
     def __getitem__(self, item):
         '''

--- a/salt/loader_context.py
+++ b/salt/loader_context.py
@@ -1,0 +1,156 @@
+"""
+Manage the context a module loaded by Salt's loader
+"""
+import collections.abc
+import contextlib
+import contextvars
+
+DEFAULT_CTX_VAR = "loader_ctxvar"
+
+loader_ctxvar = contextvars.ContextVar(DEFAULT_CTX_VAR)
+
+
+@contextlib.contextmanager
+def loader_context(loader):
+    """
+    A context manager that sets and un-sets the loader context
+    """
+    tok = loader_ctxvar.set(loader)
+    try:
+        yield
+    finally:
+        loader_ctxvar.reset(tok)
+
+
+class NamedLoaderContext(collections.abc.MutableMapping):
+    """
+    A NamedLoaderContext object is injected by the loader providing access to
+    Salt's 'magic dunders' (__salt__, __utils__, ect).
+    """
+
+    def __init__(self, name, loader_context, default=None):
+        self.name = name
+        self.loader_context = loader_context
+        self.default = default
+
+    def loader(self):
+        """
+        The LazyLoader in the current context. This will return None if there
+        is no context established.
+        """
+        try:
+            return self.loader_context.loader()
+        except AttributeError:
+            return None
+
+    def eldest_loader(self):
+        if self.loader() is None:
+            return None
+        loader = self.loader()
+        while loader.parent_loader is not None:
+            loader = loader.parent_loader
+        return loader
+
+    def value(self):
+        """
+        The value of the current for this context
+        """
+        loader = self.loader()
+        if loader is None:
+            return self.default
+        if self.name == "__context__":
+            return loader.pack[self.name]
+        if self.name == loader.pack_self:
+            return loader
+        return loader.pack[self.name]
+
+    def get(self, key, default=None):
+        return self.value().get(key, default)
+
+    def __getitem__(self, item):
+        return self.value()[item]
+
+    def __contains__(self, item):
+        return item in self.value()
+
+    def __setitem__(self, item, value):
+        self.value()[item] = value
+
+    def __bool__(self):
+        try:
+            self.loader
+        except LookupError:
+            return False
+        return True
+
+    def __len__(self):
+        return self.value().__len__()
+
+    def __iter__(self):
+        return self.value().__iter__()
+
+    def __delitem__(self, item):
+        return self.value().__delitem__(item)
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        return self.loader_context == other.loader_context and self.name == other.name
+
+    def __getstate__(self):
+        return {
+            "name": self.name,
+            "loader_context": self.loader_context,
+            "default": None,
+        }
+
+    def __setstate__(self, state):
+        self.name = state["name"]
+        self.loader_context = state["loader_context"]
+        self.default = state["default"]
+
+    def __getattr__(self, name):
+        return getattr(self.value(), name)
+
+    def missing_fun_string(self, name):
+        return self.loader().missing_fun_string(name)
+
+
+class LoaderContext(object):
+    """
+    A loader context object, this object is injected at <loaded
+    module>.__salt_loader__ by the Salt loader. It is responsible for providing
+    access to the current context's loader
+    """
+
+    def __init__(self, loader_ctxvar=loader_ctxvar):
+        self.loader_ctxvar = loader_ctxvar
+
+    def __getitem__(self, item):
+        return self.loader[item]
+
+    def loader(self):
+        """
+        Return the LazyLoader in the current context. If there is no value set raise an AttributeError
+        """
+        try:
+            return self.loader_ctxvar.get()
+        except LookupError:
+            raise AttributeError("No loader context")
+
+    def named_context(self, name, default=None, ctx_class=NamedLoaderContext):
+        """
+        Return a NamedLoaderContext instance which will use this LoaderContext
+        """
+        return ctx_class(name, self, default)
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+        return self.loader_ctxvar == other.loader_ctxvar
+
+    def __getstate__(self):
+        return {"varname": self.loader_ctxvar.name}
+
+    def __setstate__(self, state):
+        self.loader_ctxvar = contextvars.ContextVar(state["varname"])

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -170,7 +170,7 @@ def items(sanitize=False):
                 out[key] = func(out[key])
         return out
     else:
-        return __grains__
+        return dict(__grains__)
 
 
 def item(*args, **kwargs):

--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -269,7 +269,7 @@ def items(*args, **kwargs):
 
     pillar = salt.pillar.get_pillar(
         __opts__,
-        __grains__,
+        dict(__grains__),
         __opts__['id'],
         pillar_override=pillar_override,
         pillarenv=pillarenv)
@@ -444,7 +444,7 @@ def raw(key=None):
     if key:
         ret = __pillar__.get(key, {})
     else:
-        ret = __pillar__
+        ret = dict(__pillar__)
 
     return ret
 

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -80,8 +80,7 @@ def _get_top_file_envs():
         return __context__['saltutil._top_file_envs']
     except KeyError:
         try:
-            st_ = salt.state.HighState(__opts__,
-                                       initial_pillar=__pillar__)
+            st_ = salt.state.HighState(__opts__, initial_pillar=__pillar__.value())
             top = st_.get_top()
             if top:
                 envs = list(st_.top_matches(top).keys()) or 'base'

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -508,12 +508,14 @@ def high(data, test=None, queue=False, **kwargs):
             'is specified.'
         )
     try:
-        st_ = salt.state.State(opts,
-                               pillar_override,
-                               pillar_enc=pillar_enc,
-                               proxy=__proxy__,
-                               context=__context__,
-                               initial_pillar=_get_initial_pillar(opts))
+        st_ = salt.state.State(
+            opts,
+            pillar_override,
+            pillar_enc=pillar_enc,
+            proxy=dict(__proxy__),
+            context=dict(__context__),
+            initial_pillar=_get_initial_pillar(opts),
+        )
     except NameError:
         st_ = salt.state.State(opts,
                                pillar_override,
@@ -548,14 +550,16 @@ def template(tem, queue=False, **kwargs):
 
     opts = salt.utils.state.get_sls_opts(__opts__, **kwargs)
     try:
-        st_ = salt.state.HighState(opts,
-                                   context=__context__,
-                                   proxy=__proxy__,
-                                   initial_pillar=_get_initial_pillar(opts))
+        st_ = salt.state.HighState(
+            opts,
+            context=dict(__context__),
+            proxy=dict(__proxy__),
+            initial_pillar=_get_initial_pillar(opts),
+        )
     except NameError:
-        st_ = salt.state.HighState(opts,
-                                   context=__context__,
-                                   initial_pillar=_get_initial_pillar(opts))
+        st_ = salt.state.HighState(
+            opts, context=dict(__context__), initial_pillar=_get_initial_pillar(opts)
+        )
 
     errors = _get_pillar_errors(kwargs, pillar=st_.opts['pillar'])
     if errors:
@@ -1054,14 +1058,16 @@ def highstate(test=None, queue=False, **kwargs):
         )
 
     try:
-        st_ = salt.state.HighState(opts,
-                                   pillar_override,
-                                   kwargs.get('__pub_jid'),
-                                   pillar_enc=pillar_enc,
-                                   proxy=__proxy__,
-                                   context=__context__,
-                                   mocked=kwargs.get('mock', False),
-                                   initial_pillar=_get_initial_pillar(opts))
+        st_ = salt.state.HighState(
+            opts,
+            pillar_override,
+            kwargs.get("__pub_jid"),
+            pillar_enc=pillar_enc,
+            proxy=dict(__proxy__),
+            context=dict(__context__),
+            mocked=kwargs.get("mock", False),
+            initial_pillar=_get_initial_pillar(opts),
+        )
     except NameError:
         st_ = salt.state.HighState(opts,
                                    pillar_override,
@@ -1299,14 +1305,16 @@ def sls(mods, test=None, exclude=None, queue=False, sync_mods=None, **kwargs):
             )
 
     try:
-        st_ = salt.state.HighState(opts,
-                                   pillar_override,
-                                   kwargs.get('__pub_jid'),
-                                   pillar_enc=pillar_enc,
-                                   proxy=__proxy__,
-                                   context=__context__,
-                                   mocked=kwargs.get('mock', False),
-                                   initial_pillar=_get_initial_pillar(opts))
+        st_ = salt.state.HighState(
+            opts,
+            pillar_override,
+            kwargs.get("__pub_jid"),
+            pillar_enc=pillar_enc,
+            proxy=dict(__proxy__),
+            context=dict(__context__),
+            mocked=kwargs.get("mock", False),
+            initial_pillar=_get_initial_pillar(opts),
+        )
     except NameError:
         st_ = salt.state.HighState(opts,
                                    pillar_override,
@@ -1438,20 +1446,23 @@ def top(topfn, test=None, queue=False, **kwargs):
             'Pillar data must be formatted as a dictionary, unless pillar_enc '
             'is specified.'
         )
-    try:
-        st_ = salt.state.HighState(opts,
-                                   pillar_override,
-                                   pillar_enc=pillar_enc,
-                                   context=__context__,
-                                   proxy=__proxy__,
-                                   initial_pillar=_get_initial_pillar(opts))
+        st_ = salt.state.HighState(
+            opts,
+            pillar_override,
+            pillar_enc=pillar_enc,
+            context=dict(__context__),
+            proxy=dict(__proxy__),
+            initial_pillar=_get_initial_pillar(opts),
+        )
     except NameError:
-        st_ = salt.state.HighState(opts,
-                                   pillar_override,
-                                   pillar_enc=pillar_enc,
-                                   context=__context__,
-                                   initial_pillar=_get_initial_pillar(opts))
-    errors = _get_pillar_errors(kwargs, pillar=st_.opts['pillar'])
+        st_ = salt.state.HighState(
+            opts,
+            pillar_override,
+            pillar_enc=pillar_enc,
+            context=dict(__context__),
+            initial_pillar=_get_initial_pillar(opts),
+        )
+    errors = _get_pillar_errors(kwargs, pillar=st_.opts["pillar"])
     if errors:
         __context__['retcode'] = salt.defaults.exitcodes.EX_PILLAR_FAILURE
         return ['Pillar failed to render with the following messages:'] + errors

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -8,11 +8,13 @@ in here
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
 # import sys  # Use if sys is commented out below
+import collections.abc
 import logging
 import gc
 import datetime
 
 # Import salt libs
+import salt.loader_context
 import salt.log
 import salt.transport.frame
 import salt.utils.immutabletypes as immutabletypes
@@ -186,7 +188,9 @@ class Serial(object):
                 return tuple(obj)
             elif isinstance(obj, CaseInsensitiveDict):
                 return dict(obj)
-            # Nothing known exceptions found. Let msgpack raise it's own.
+            elif isinstance(obj, collections.abc.MutableMapping):
+                return dict(obj)
+            # Nothing known exceptions found. Let msgpack raise its own.
             return obj
 
         try:

--- a/salt/renderers/jinja.py
+++ b/salt/renderers/jinja.py
@@ -10,8 +10,9 @@ from __future__ import absolute_import, print_function, unicode_literals
 import logging
 
 # Import salt libs
-from salt.exceptions import SaltRenderError
 import salt.utils.templates
+from salt.exceptions import SaltRenderError
+from salt.loader_context import NamedLoaderContext
 
 # Import 3rd-party libs
 from salt.ext import six
@@ -30,9 +31,12 @@ def _split_module_dicts():
 
         {{ salt.cmd.run('uptime') }}
     '''
-    if not isinstance(__salt__, dict):
-        return __salt__
-    mod_dict = dict(__salt__)
+    funcs = __salt__
+    if isinstance(__salt__, NamedLoaderContext) and isinstance(__salt__.value(), dict):
+        funcs = __salt__.value()
+    if not isinstance(funcs, dict):
+        return funcs
+    mod_dict = dict(funcs)
     for module_func_name, mod_fun in six.iteritems(mod_dict.copy()):
         mod, fun = module_func_name.split('.', 1)
         if mod not in mod_dict:

--- a/salt/renderers/pyobjects.py
+++ b/salt/renderers/pyobjects.py
@@ -344,7 +344,7 @@ def load_states():
 
     # the loader expects to find pillar & grain data
     __opts__['grains'] = salt.loader.grains(__opts__)
-    __opts__['pillar'] = __pillar__
+    __opts__['pillar'] = __pillar__.value()
     lazy_utils = salt.loader.utils(__opts__)
     lazy_funcs = salt.loader.minion_mods(__opts__, utils=lazy_utils)
     lazy_serializers = salt.loader.serializers(__opts__)

--- a/salt/state.py
+++ b/salt/state.py
@@ -3608,7 +3608,7 @@ class BaseHighState(object):
             self.state.opts['pillar'] = self.state._gather_pillar()
         self.state.module_refresh()
 
-    def render_state(self, sls, saltenv, mods, matches, local=False):
+    def render_state(self, sls, saltenv, mods, matches, local=False, context=None):
         '''
         Render a state file and retrieve all of the include states
         '''
@@ -3932,7 +3932,7 @@ class BaseHighState(object):
                 errors.append(err)
             state.setdefault('__exclude__', []).extend(exc)
 
-    def render_highstate(self, matches):
+    def render_highstate(self, matches, context=None):
         '''
         Gather the state files and render them into a single unified salt
         high data structure.
@@ -3964,7 +3964,8 @@ class BaseHighState(object):
                     if r_env in mods:
                         continue
                     state, errors = self.render_state(
-                        sls, saltenv, mods, matches)
+                        sls, saltenv, mods, matches, context=context
+                    )
                     if state:
                         self.merge_included_states(highstate, state, errors)
                     for i, error in enumerate(errors[:]):

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -6236,7 +6236,7 @@ def patch(name,
         try:
             orig_test = __opts__['test']
             __opts__['test'] = False
-            sys.modules[__salt__['test.ping'].__module__].__opts__['test'] = False
+            sys.modules[__salt__['file.patch'].__module__].__opts__['test'] = False
             result = managed(patch_file,
                              source=source_match,
                              source_hash=source_hash,
@@ -6257,7 +6257,7 @@ def patch(name,
             log.debug('file.managed: %s', result)
         finally:
             __opts__['test'] = orig_test
-            sys.modules[__salt__['test.ping'].__module__].__opts__['test'] = orig_test
+            sys.modules[__salt__['file.patch'].__module__].__opts__['test'] = orig_test
 
         if not result['result']:
             log.debug(

--- a/salt/template.py
+++ b/salt/template.py
@@ -32,15 +32,18 @@ SLS_ENCODING = 'utf-8'  # this one has no BOM.
 SLS_ENCODER = codecs.getencoder(SLS_ENCODING)
 
 
-def compile_template(template,
-                     renderers,
-                     default,
-                     blacklist,
-                     whitelist,
-                     saltenv='base',
-                     sls='',
-                     input_data='',
-                     **kwargs):
+def compile_template(
+    template,
+    renderers,
+    default,
+    blacklist,
+    whitelist,
+    saltenv='base',
+    sls='',
+    input_data='',
+    context=None,
+    **kwargs
+):
     '''
     Take the path to a template and return the high data structure
     derived from the template.
@@ -94,6 +97,8 @@ def compile_template(template,
         if salt.utils.stringio.is_readable(input_data):
             input_data.seek(0)      # pylint: disable=no-member
         render_kwargs = dict(renderers=renderers, tmplpath=template)
+        if context:
+            render_kwargs["context"] = context
         render_kwargs.update(kwargs)
         if argline:
             render_kwargs['argline'] = argline

--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -256,7 +256,7 @@ def get_function_argspec(func, is_class_method=None):
     if not callable(func):
         raise TypeError('{0} is not a callable'.format(func))
 
-    if hasattr(func, "__wrapped__"):
+    while hasattr(func, "__wrapped__"):
         func = func.__wrapped__
 
     if six.PY2:

--- a/salt/utils/boto3mod.py
+++ b/salt/utils/boto3mod.py
@@ -43,6 +43,7 @@ from functools import partial
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 from salt.exceptions import SaltInvocationError
 from salt.ext import six
+import salt.loader_context
 import salt.utils.stringutils
 import salt.utils.versions
 
@@ -67,6 +68,8 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 __virtualname__ = 'boto3'
+__salt_loader__ = salt.loader_context.LoaderContext()
+__context__ = __salt_loader__.named_context("__context__", {})
 
 
 def __virtual__():

--- a/salt/utils/botomod.py
+++ b/salt/utils/botomod.py
@@ -44,6 +44,7 @@ from salt.loader import minion_mods
 from salt.ext import six
 from salt.ext.six.moves import range  # pylint: disable=import-error,redefined-builtin
 from salt.exceptions import SaltInvocationError
+import salt.loader_context
 import salt.utils.stringutils
 import salt.utils.versions
 
@@ -65,6 +66,8 @@ log = logging.getLogger(__name__)
 
 __salt__ = None
 __virtualname__ = 'boto'
+__salt_loader__ = salt.loader_context.LoaderContext()
+__context__ = __salt_loader__.named_context("__context__", {})
 
 
 def __virtual__():

--- a/salt/utils/compat.py
+++ b/salt/utils/compat.py
@@ -22,7 +22,9 @@ def pack_dunder(name):
 
     mod = sys.modules[name]
     if not hasattr(mod, '__utils__'):
-        setattr(mod, '__utils__', salt.loader.utils(mod.__opts__))
+        setattr(
+            mod, '__utils__', salt.loader.utils(mod.__opts__, pack_self='__utils__')
+        )
 
 
 def deepcopy_bound(name):

--- a/salt/utils/context.py
+++ b/salt/utils/context.py
@@ -30,7 +30,7 @@ def func_globals_inject(func, **overrides):
     Override specific variables within a function's global context.
     '''
     # recognize methods
-    if hasattr(func, 'im_func'):
+    if hasattr(func, 'im_func') and func.im_func:
         func = func.__func__
 
     # Get a reference to the function globals dictionary

--- a/salt/utils/systemd.py
+++ b/salt/utils/systemd.py
@@ -12,6 +12,7 @@ import subprocess
 # Import Salt libs
 from salt.exceptions import SaltInvocationError
 import salt.utils.path
+import salt.loader_context
 import salt.utils.stringutils
 
 try:
@@ -31,7 +32,7 @@ def booted(context=None):
     keep the logic below from needing to be run again during the same salt run.
     '''
     contextkey = 'salt.utils.systemd.booted'
-    if isinstance(context, dict):
+    if isinstance(context, (dict, salt.loader_context.NamedLoaderContext)):
         # Can't put this if block on the same line as the above if block,
         # because it willl break the elif below.
         if contextkey in context:
@@ -81,7 +82,7 @@ def version(context=None):
     version.
     '''
     contextkey = 'salt.utils.systemd.version'
-    if isinstance(context, dict):
+    if isinstance(context, (dict, salt.loader_context.NamedLoaderContext)):
         # Can't put this if block on the same line as the above if block,
         # because it will break the elif below.
         if contextkey in context:

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -293,6 +293,7 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
     saltenv = context['saltenv']
     loader = None
     newline = False
+    file_client = context.get("fileclient", None)
 
     if tmplstr and not isinstance(tmplstr, six.text_type):
         # http://jinja.pocoo.org/docs/api/#unicode
@@ -307,7 +308,12 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
         if tmplpath:
             loader = jinja2.FileSystemLoader(os.path.dirname(tmplpath))
     else:
-        loader = salt.utils.jinja.SaltCacheLoader(opts, saltenv, pillar_rend=context.get('_pillar_rend', False))
+        loader = salt.utils.jinja.SaltCacheLoader(
+            opts,
+            saltenv,
+            pillar_rend=context.get('_pillar_rend', False),
+            _file_client=file_client,
+        )
 
     env_args = {'extensions': [], 'loader': loader}
 

--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -6,6 +6,7 @@ Generate the salt thin tarball from the installed python files
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
 
+import contextvars
 import copy
 import logging
 import os
@@ -23,6 +24,16 @@ import yaml
 import msgpack
 import salt.ext.six as _six
 import salt.ext.tornado as tornado
+
+# This is needed until we drop support for python 3.6
+has_immutables = False
+try:
+    import immutables
+
+    has_immutables = True
+except ImportError:
+    pass
+
 
 try:
     import zlib
@@ -265,8 +276,24 @@ def get_tops(extra_mods='', so_mods=''):
     :return:
     '''
     tops = []
-    for mod in [salt, jinja2, yaml, tornado, msgpack, certifi, singledispatch, concurrent,
-                singledispatch_helpers, ssl_match_hostname, markupsafe, backports_abc]:
+    mods = [
+        salt,
+        jinja2,
+        yaml,
+        tornado,
+        msgpack,
+        certifi,
+        singledispatch,
+        concurrent,
+        singledispatch_helpers,
+        ssl_match_hostname,
+        markupsafe,
+        backports_abc,
+        contextvars,
+    ]
+    if has_immutables:
+        mods.append(immutables)
+    for mod in mods:
         if mod:
             log.debug('Adding module to the tops: "%s"', mod.__name__)
             _add_dependency(tops, mod)

--- a/tests/pytests/unit/test_loader.py
+++ b/tests/pytests/unit/test_loader.py
@@ -1,0 +1,95 @@
+"""
+Tests for salt.loader
+"""
+import os
+import shutil
+import sys
+
+import pytest
+import salt.loader
+import salt.loader_context
+import salt.utils.files
+from tests.support.helpers import dedent
+
+
+@pytest.fixture
+def loader_dir(tmp_path):
+    """
+    Create a simple directory with a couple modules to load and run tests
+    against.
+    """
+    mod_content = dedent(
+        """
+    def __virtual__():
+        return True
+
+    def set_context(key, value):
+        __context__[key] = value
+
+    def get_context(key):
+        return __context__[key]
+    """
+    )
+    tmp_path = str(tmp_path)
+    with salt.utils.files.fopen(os.path.join(tmp_path, "mod_a.py"), "w") as fp:
+        fp.write(mod_content)
+    with salt.utils.files.fopen(os.path.join(tmp_path, "mod_b.py"), "w") as fp:
+        fp.write(mod_content)
+    try:
+        yield tmp_path
+    finally:
+        shutil.rmtree(tmp_path)
+
+
+def test_loaders_have_uniq_context(loader_dir):
+    """
+    Loaded functions run in the LazyLoader's context.
+    """
+    opts = {"optimization_order": [0, 1, 2]}
+    loader_1 = salt.loader.LazyLoader([loader_dir], opts,)
+    loader_2 = salt.loader.LazyLoader([loader_dir], opts,)
+    loader_1._load_all()
+    loader_2._load_all()
+    assert loader_1.pack["__context__"] == {}
+    assert loader_2.pack["__context__"] == {}
+    loader_1["mod_a.set_context"]("foo", "bar")
+    assert loader_1.pack["__context__"] == {"foo": "bar"}
+    assert loader_1["mod_b.get_context"]("foo") == "bar"
+    with pytest.raises(KeyError):
+        loader_2["mod_a.get_context"]("foo")
+    assert loader_2.pack["__context__"] == {}
+
+
+def test_loaded_methods_are_loaded_func(loader_dir):
+    """
+    Functions loaded from LazyLoader's item lookups are LoadedFunc objects
+    """
+    opts = {"optimization_order": [0, 1, 2]}
+    loader_1 = salt.loader.LazyLoader([loader_dir], opts,)
+    fun = loader_1["mod_a.get_context"]
+    assert isinstance(fun, salt.loader.LoadedFunc)
+
+
+def test_loaded_modules_are_loaded_mods(loader_dir):
+    """
+    Modules looked up as attributes of LazyLoaders are LoadedMod objects.
+    """
+    opts = {"optimization_order": [0, 1, 2]}
+    loader_1 = salt.loader.LazyLoader([loader_dir], opts,)
+    mod = loader_1.mod_a
+    assert isinstance(mod, salt.loader.LoadedMod)
+
+
+def test_loaders_create_named_loader_contexts(loader_dir):
+    """
+    LazyLoader's create NamedLoaderContexts on the modules the load.
+    """
+    opts = {"optimization_order": [0, 1, 2]}
+    loader_1 = salt.loader.LazyLoader([loader_dir], opts,)
+    mod = loader_1.mod_a
+    assert isinstance(mod.mod, dict)
+    func = mod.set_context
+    assert isinstance(func, salt.loader.LoadedFunc)
+    module_name = func.func.__module__
+    module = sys.modules[module_name]
+    assert isinstance(module.__context__, salt.loader_context.NamedLoaderContext)

--- a/tests/pytests/unit/test_loader_context.py
+++ b/tests/pytests/unit/test_loader_context.py
@@ -1,0 +1,33 @@
+"""
+Tests for salt.loader_context
+"""
+import salt.loader
+import salt.loader_context
+
+
+def test_named_loader_context():
+    loader_context = salt.loader_context.LoaderContext()
+    named_context = salt.loader_context.NamedLoaderContext("__test__", loader_context)
+    test_dunder = {"foo": "bar"}
+    lazy_loader = salt.loader.LazyLoader(["/foo"], pack={"__test__": test_dunder})
+    assert named_context.loader() is None
+    token = salt.loader_context.loader_ctxvar.set(lazy_loader)
+    try:
+        assert named_context.loader() == lazy_loader
+        # The loader's value is the same object as test_dunder
+        assert named_context.value() is test_dunder
+        assert named_context["foo"] == "bar"
+    finally:
+        salt.loader_context.loader_ctxvar.reset(token)
+
+
+def test_named_loader_default():
+    loader_context = salt.loader_context.LoaderContext()
+    default = {"foo": "bar"}
+    named_context = salt.loader_context.NamedLoaderContext(
+        "__test__", loader_context, default=default
+    )
+    assert named_context.loader() is None
+    # The loader's value is the same object as default
+    assert named_context.value() is default
+    assert named_context["foo"] == "bar"

--- a/tests/support/events.py
+++ b/tests/support/events.py
@@ -25,7 +25,7 @@ def eventpublisher_process(sock_dir):
             # Travis is slow
             time.sleep(10)
         else:
-            time.sleep(2)
+            time.sleep(8)
         yield
     finally:
         clean_proc(proc)

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -1136,6 +1136,45 @@ class LazyLoaderDeepSubmodReloadingTest(TestCase):
                 self._verify_libs()
 
 
+class LoaderMultipleGlobalTest(ModuleCase):
+    """
+    Tests when using multiple lazyloaders
+    """
+
+    def setUp(self):
+        opts = salt.config.minion_config(None)
+        self.loader1 = salt.loader.LazyLoader(
+            salt.loader._module_dirs(copy.deepcopy(opts), "modules", "module"),
+            copy.deepcopy(opts),
+            pack={},
+            tag="module",
+        )
+        self.loader2 = salt.loader.LazyLoader(
+            salt.loader._module_dirs(copy.deepcopy(opts), "modules", "module"),
+            copy.deepcopy(opts),
+            pack={},
+            tag="module",
+        )
+
+    def tearDown(self):
+        del self.loader1
+        del self.loader2
+
+    def test_loader_globals(self):
+        """
+        Test to ensure loaders do not edit
+        each others loader's namespace
+        """
+        self.loader1.pack["__foo__"] = "bar1"
+        func1 = self.loader1["test.ping"]
+
+        self.loader2.pack["__foo__"] = "bar2"
+        func2 = self.loader2["test.ping"]
+
+        assert func1.__globals__["__foo__"] == "bar1"
+        assert func2.__globals__["__foo__"] == "bar2"
+
+
 class LoaderGlobalsTest(ModuleCase):
     '''
     Test all of the globals that the loader is responsible for adding to modules

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -30,6 +30,7 @@ from tests.support.mock import patch
 # Import Salt libs
 import salt.config
 import salt.loader
+import salt.loader_context
 import salt.utils.files
 import salt.utils.stringutils
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
@@ -121,8 +122,8 @@ class LazyLoaderTest(TestCase):
         # Make sure depends correctly allowed a function to load. If this
         # results in a KeyError, the decorator is broken.
         self.assertTrue(
-            inspect.isfunction(
-                self.loader[self.module_name + '.loaded']
+            isinstance(
+                self.loader[self.module_name + '.loaded'], salt.loader.LoadedFunc,
             )
         )
         # Make sure depends correctly kept a function from loading
@@ -205,8 +206,8 @@ class LazyLoaderUtilsTest(TestCase):
             tag='module',
             extra_module_dirs=[self.utils_dir])
         self.assertTrue(
-            inspect.isfunction(
-                loader[self.module_name + '.run']))
+            isinstance(loader[self.module_name + '.run'], salt.loader.LoadedFunc)
+        )
         self.assertTrue(loader[self.module_name + '.run']())
 
     def test_utils_not_found(self):
@@ -259,7 +260,7 @@ class LazyLoaderVirtualEnabledTest(TestCase):
         # make sure it starts empty
         self.assertEqual(self.loader._dict, {})
         # get something, and make sure its a func
-        self.assertTrue(inspect.isfunction(self.loader['test.ping']))
+        self.assertTrue(inspect.isfunction(self.loader['test.ping'].func))
 
         # make sure we only loaded "test" functions
         for key, val in six.iteritems(self.loader._dict):
@@ -307,30 +308,38 @@ class LazyLoaderVirtualEnabledTest(TestCase):
         self.assertEqual(self.loader._dict, {})
         # get something, and make sure its a func
         func = self.loader['test.ping']
-        with patch.dict(func.__globals__['__context__'], {'foo': 'bar'}):
-            self.assertEqual(self.loader['test.echo'].__globals__['__context__']['foo'], 'bar')
-            self.assertEqual(self.loader['grains.get'].__globals__['__context__']['foo'], 'bar')
+        with salt.loader_context.loader_context(self.loader):
+            with patch.dict(func.__globals__['__context__'], {'foo': 'bar'}):
+                self.assertEqual(
+                    self.loader['test.echo'].__globals__['__context__']['foo'], 'bar'
+                )
+                self.assertEqual(
+                    self.loader['grains.get'].__globals__['__context__']['foo'], 'bar'
+                )
+
 
     def test_globals(self):
-        func_globals = self.loader['test.ping'].__globals__
-        self.assertEqual(func_globals['__grains__'], self.opts.get('grains', {}))
-        self.assertEqual(func_globals['__pillar__'], self.opts.get('pillar', {}))
-        # the opts passed into modules is at least a subset of the whole opts
-        for key, val in six.iteritems(func_globals['__opts__']):
-            if key in salt.config.DEFAULT_MASTER_OPTS and key not in salt.config.DEFAULT_MINION_OPTS:
-                # We loaded the minion opts, but somewhere in the code, the master options got pulled in
-                # Let's just not check for equality since the option won't even exist in the loaded
-                # minion options
-                continue
-            if key not in salt.config.DEFAULT_MASTER_OPTS and key not in salt.config.DEFAULT_MINION_OPTS:
-                # This isn't even a default configuration setting, lets carry on
-                continue
-            self.assertEqual(self.opts[key], val)
+        with salt.loader_context.loader_context(self.loader):
+            func_globals = self.loader['test.ping'].__globals__
+            self.assertEqual(func_globals['__grains__'].value(), self.opts.get('grains', {}))
+            self.assertEqual(func_globals['__pillar__'].value(), self.opts.get('pillar', {}))
+            # the opts passed into modules is at least a subset of the whole opts
+            for key, val in six.iteritems(func_globals['__opts__']):
+                if key in salt.config.DEFAULT_MASTER_OPTS and key not in salt.config.DEFAULT_MINION_OPTS:
+                    # We loaded the minion opts, but somewhere in the code, the master options got pulled in
+                    # Let's just not check for equality since the option won't even exist in the loaded
+                    # minion options
+                    continue
+                if key not in salt.config.DEFAULT_MASTER_OPTS and key not in salt.config.DEFAULT_MINION_OPTS:
+                    # This isn't even a default configuration setting, lets carry on
+                    continue
+                self.assertEqual(self.opts[key], val)
 
     def test_pack(self):
-        self.loader.pack['__foo__'] = 'bar'
-        func_globals = self.loader['test.ping'].__globals__
-        self.assertEqual(func_globals['__foo__'], 'bar')
+        with salt.loader_context.loader_context(self.loader):
+            self.loader.pack['__foo__'] = 'bar'
+            func_globals = self.loader['test.ping'].__globals__
+            self.assertEqual(func_globals['__foo__'].value(), 'bar')
 
     def test_virtual(self):
         self.assertNotIn('test_virtual.ping', self.loader)
@@ -369,7 +378,9 @@ class LazyLoaderVirtualDisabledTest(TestCase):
         del cls.proxy
 
     def test_virtual(self):
-        self.assertTrue(inspect.isfunction(self.loader['test_virtual.ping']))
+        self.assertTrue(
+            isinstance(self.loader['test_virtual.ping'], salt.loader.LoadedFunc,)
+        )
 
 
 class LazyLoaderWhitelistTest(TestCase):
@@ -405,8 +416,8 @@ class LazyLoaderWhitelistTest(TestCase):
         del cls.proxy
 
     def test_whitelist(self):
-        self.assertTrue(inspect.isfunction(self.loader['test.ping']))
-        self.assertTrue(inspect.isfunction(self.loader['pillar.get']))
+        self.assertTrue(inspect.isfunction(self.loader['test.ping'].func))
+        self.assertTrue(inspect.isfunction(self.loader['pillar.get'].func))
 
         self.assertNotIn('grains.get', self.loader)
 
@@ -582,15 +593,29 @@ class LazyLoaderReloadingTest(TestCase):
 
         self.update_module()
         self.assertNotIn('{0}.test_alias'.format(self.module_name), self.loader)
-        self.assertTrue(inspect.isfunction(self.loader['{0}.working_alias'.format(self.module_name)]))
+        self.assertTrue(
+            isinstance(
+                self.loader['{0}.working_alias'.format(self.module_name)],
+                salt.loader.LoadedFunc,
+            )
+        )
+        self.assertTrue(
+            inspect.isfunction(
+                self.loader['{0}.working_alias'.format(self.module_name)].func
+            )
+        )
 
     def test_clear(self):
-        self.assertTrue(inspect.isfunction(self.loader['test.ping']))
+        self.assertTrue(isinstance(self.loader['test.ping'], salt.loader.LoadedFunc))
+        self.assertTrue(inspect.isfunction(self.loader['test.ping'].func))
         self.update_module()  # write out out custom module
         self.loader.clear()  # clear the loader dict
 
         # force a load of our module
-        self.assertTrue(inspect.isfunction(self.loader[self.module_key]))
+        self.assertTrue(
+            isinstance(self.loader[self.module_key], salt.loader.LoadedFunc)
+        )
+        self.assertTrue(inspect.isfunction(self.loader[self.module_key].func))
 
         # make sure we only loaded our custom module
         # which means that we did correctly refresh the file mapping
@@ -602,7 +627,10 @@ class LazyLoaderReloadingTest(TestCase):
         self.assertNotIn(self.module_key, self.loader)
 
         self.update_module()
-        self.assertTrue(inspect.isfunction(self.loader[self.module_key]))
+        self.assertTrue(
+            isinstance(self.loader[self.module_key], salt.loader.LoadedFunc)
+        )
+        self.assertTrue(inspect.isfunction(self.loader[self.module_key].func))
 
     def test__load__(self):
         '''
@@ -1173,9 +1201,16 @@ class LoaderMultipleGlobalTest(ModuleCase):
 
         self.loader2.pack["__foo__"] = "bar2"
         func2 = self.loader2["test.ping"]
-
-        assert func1.__globals__["__foo__"] == "bar1"
-        assert func2.__globals__["__foo__"] == "bar2"
+        token = salt.loader_context.loader_ctxvar.set(self.loader1)
+        try:
+            assert func1.__globals__["__foo__"].value() == "bar1"
+        finally:
+            salt.loader_context.loader_ctxvar.reset(token)
+        token = salt.loader_context.loader_ctxvar.set(self.loader2)
+        try:
+            assert func2.__globals__["__foo__"].value() == "bar2"
+        finally:
+            salt.loader_context.loader_ctxvar.reset(token)
 
 
 class LoaderCleanupTest(ModuleCase):

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import collections
 import compileall
 import copy
+import gc
 import imp
 import inspect
 import logging
@@ -1173,6 +1174,95 @@ class LoaderMultipleGlobalTest(ModuleCase):
 
         assert func1.__globals__["__foo__"] == "bar1"
         assert func2.__globals__["__foo__"] == "bar2"
+
+
+class LoaderCleanupTest(ModuleCase):
+    """
+    Tests the loader cleanup procedures
+    """
+
+    def setUp(self):
+        opts = salt.config.minion_config(None)
+        self.loader1 = salt.loader.LazyLoader(
+            salt.loader._module_dirs(copy.deepcopy(opts), "modules", "module"),
+            copy.deepcopy(opts),
+            pack={},
+            tag="module",
+        )
+
+    def tearDown(self):
+        del self.loader1
+
+    def test_loader_gc_cleanup(self):
+        loaded_base_name = self.loader1.loaded_base_name
+        for name in list(sys.modules):
+            if name.startswith(loaded_base_name):
+                break
+        else:
+            self.fail(
+                "Did not find any modules in sys.modules matching {!r}".format(
+                    loaded_base_name
+                )
+            )
+
+        # Assert that the weakref.finalizer is alive
+        assert self.loader1._gc_finalizer.alive is True
+
+        gc.collect()
+        # Even after a gc.collect call, we should still have our module in sys.modules
+        for name in list(sys.modules):
+            if name.startswith(loaded_base_name):
+                if sys.modules[name] is None:
+                    self.fail(
+                        "Found at least one module in sys.modules matching {!r} prematurely set to None".format(
+                            loaded_base_name
+                        )
+                    )
+                break
+        else:
+            self.fail(
+                "Did not find any modules in sys.modules matching {!r}".format(
+                    loaded_base_name
+                )
+            )
+        # Should still be true because there's still at least one reference to self.loader1
+        assert self.loader1._gc_finalizer.alive is True
+
+        # Now we remove our refence to loader and trigger GC, thus triggering the loader weakref finalizer
+        self.loader1 = None
+        gc.collect()
+
+        for name in list(sys.modules):
+            if name.startswith(loaded_base_name):
+                if sys.modules[name] is not None:
+                    self.fail(
+                        "Found a real module reference in sys.modules matching {!r}.".format(
+                            loaded_base_name,
+                        )
+                    )
+                break
+        else:
+            self.fail(
+                "Did not find any modules in sys.modules matching {!r}".format(
+                    loaded_base_name
+                )
+            )
+
+    def test_loader_clean_modules(self):
+        loaded_base_name = self.loader1.loaded_base_name
+        self.loader1.clean_modules()
+
+        for name in list(sys.modules):
+            if name.startswith(loaded_base_name):
+                self.fail(
+                    "Found a real module reference in sys.modules matching {!r}".format(
+                        loaded_base_name
+                    )
+                )
+                break
+
+        # Additionally, assert that the weakref.finalizer is now dead
+        assert self.loader1._gc_finalizer.alive is False
 
 
 class LoaderGlobalsTest(ModuleCase):

--- a/tests/unit/test_loader.py
+++ b/tests/unit/test_loader.py
@@ -1149,12 +1149,14 @@ class LoaderMultipleGlobalTest(ModuleCase):
             copy.deepcopy(opts),
             pack={},
             tag="module",
+            loaded_base_name="salt.loader1",
         )
         self.loader2 = salt.loader.LazyLoader(
             salt.loader._module_dirs(copy.deepcopy(opts), "modules", "module"),
             copy.deepcopy(opts),
             pack={},
             tag="module",
+            loaded_base_name="salt.loader2",
         )
 
     def tearDown(self):
@@ -1188,6 +1190,7 @@ class LoaderCleanupTest(ModuleCase):
             copy.deepcopy(opts),
             pack={},
             tag="module",
+            loaded_base_name="salt.test",
         )
 
     def tearDown(self):

--- a/tests/unit/utils/cache_mods/cache_mod.py
+++ b/tests/unit/utils/cache_mods/cache_mod.py
@@ -16,4 +16,4 @@ def test_context_module():
         __context__['called'] += 1
     else:
         __context__['called'] = 0
-    return __context__
+    return __context__.value()

--- a/tests/unit/utils/test_thin.py
+++ b/tests/unit/utils/test_thin.py
@@ -7,10 +7,11 @@ from __future__ import absolute_import, print_function, unicode_literals
 import os
 import sys
 from tests.support.unit import TestCase, skipIf
-from tests.support.helpers import TstSuiteLoggingHandler
+from tests.support.helpers import TstSuiteLoggingHandler, slowTest
 from tests.support.mock import (
     MagicMock,
     patch)
+from tests.support.runtests import RUNTIME_VARS
 
 import salt.exceptions
 import salt.utils.json
@@ -25,6 +26,19 @@ try:
     import pytest
 except ImportError:
     pytest = None
+
+
+def patch_if(condition, *args, **kwargs):
+    """
+    Return a patch decorator if the provided condition is met
+    """
+    if condition:
+        return patch(*args, **kwargs)
+
+    def inner(func):
+        return func
+
+    return inner
 
 
 @skipIf(pytest is None, 'PyTest is missing')
@@ -290,6 +304,8 @@ class SSHThinTestCase(TestCase):
     @patch('salt.utils.thin.backports_abc', type(str('backports_abc'), (), {'__file__': '/site-packages/backports_abc'}))
     @patch('salt.utils.thin.concurrent', type(str('concurrent'), (), {'__file__': '/site-packages/concurrent'}))
     @patch('salt.utils.thin.log', MagicMock())
+    @patch('salt.utils.thin.contextvars', type('contextvars', (), {'__file__': '/site-packages/contextvars'}),)
+    @patch_if(salt.utils.thin.has_immutables, 'salt.utils.thin.immutables', type('immutables', (), {'__file__': '/site-packages/immutables'}),)
     def test_get_tops(self):
         '''
         Test thin.get_tops to get top directories, based on the interpreter.
@@ -298,11 +314,14 @@ class SSHThinTestCase(TestCase):
         base_tops = ['/site-packages/salt', '/site-packages/jinja2', '/site-packages/yaml',
                      '/site-packages/tornado', '/site-packages/msgpack', '/site-packages/certifi',
                      '/site-packages/sdp', '/site-packages/sdp_hlp', '/site-packages/ssl_mh',
-                     '/site-packages/markupsafe', '/site-packages/backports_abc', '/site-packages/concurrent']
+                     '/site-packages/markupsafe', '/site-packages/backports_abc', '/site-packages/concurrent',
+                     '/site-packages/contextvars',]
 
+        if salt.utils.thin.has_immutables:
+            base_tops.extend(["/site-packages/immutables"])
         tops = thin.get_tops()
         assert len(tops) == len(base_tops)
-        assert sorted(tops) == sorted(base_tops)
+        assert sorted(tops) == sorted(base_tops), sorted(tops)
 
     @patch('salt.utils.thin.salt', type(str('salt'), (), {'__file__': '/site-packages/salt'}))
     @patch('salt.utils.thin.jinja2', type(str('jinja2'), (), {'__file__': '/site-packages/jinja2'}))
@@ -317,6 +336,8 @@ class SSHThinTestCase(TestCase):
     @patch('salt.utils.thin.backports_abc', type(str('backports_abc'), (), {'__file__': '/site-packages/backports_abc'}))
     @patch('salt.utils.thin.concurrent', type(str('concurrent'), (), {'__file__': '/site-packages/concurrent'}))
     @patch('salt.utils.thin.log', MagicMock())
+    @patch('salt.utils.thin.contextvars', type('contextvars', (), {'__file__': '/site-packages/contextvars'}),)
+    @patch_if(salt.utils.thin.has_immutables, 'salt.utils.thin.immutables', type('immutables', (), {'__file__': '/site-packages/immutables'}),)
     def test_get_tops_extra_mods(self):
         '''
         Test thin.get_tops to get extra-modules alongside the top directories, based on the interpreter.
@@ -334,8 +355,11 @@ class SSHThinTestCase(TestCase):
                      '/site-packages/concurrent',
                      '/site-packages/markupsafe',
                      '/site-packages/backports_abc',
+                     '/site-packages/contextvars',
                      os.sep + os.path.join('custom', 'foo'),
                      os.sep + os.path.join('custom', 'bar.py')]
+        if salt.utils.thin.has_immutables:
+            base_tops.extend(["/site-packages/immutables"])
         builtins = sys.version_info.major == 3 and 'builtins' or '__builtin__'
         foo = {'__file__': os.sep + os.path.join('custom', 'foo', '__init__.py')}
         bar = {'__file__': os.sep + os.path.join('custom', 'bar')}
@@ -359,6 +383,8 @@ class SSHThinTestCase(TestCase):
     @patch('salt.utils.thin.backports_abc', type(str('backports_abc'), (), {'__file__': '/site-packages/backports_abc'}))
     @patch('salt.utils.thin.concurrent', type(str('concurrent'), (), {'__file__': '/site-packages/concurrent'}))
     @patch('salt.utils.thin.log', MagicMock())
+    @patch('salt.utils.thin.contextvars', type('contextvars', (), {'__file__': '/site-packages/contextvars'}),)
+    @patch_if(salt.utils.thin.has_immutables, 'salt.utils.thin.immutables', type('immutables', (), {'__file__': '/site-packages/immutables'}),)
     def test_get_tops_so_mods(self):
         '''
         Test thin.get_tops to get extra-modules alongside the top directories, based on the interpreter.
@@ -367,7 +393,10 @@ class SSHThinTestCase(TestCase):
         base_tops = ['/site-packages/salt', '/site-packages/jinja2', '/site-packages/yaml',
                      '/site-packages/tornado', '/site-packages/msgpack', '/site-packages/certifi',
                      '/site-packages/sdp', '/site-packages/sdp_hlp', '/site-packages/ssl_mh', '/site-packages/concurrent',
-                     '/site-packages/markupsafe', '/site-packages/backports_abc', '/custom/foo.so', '/custom/bar.so']
+                     '/site-packages/markupsafe', '/site-packages/backports_abc', '/site-packages/contextvars',
+                     '/custom/foo.so', '/custom/bar.so']
+        if salt.utils.thin.has_immutables:
+            base_tops.extend(["/site-packages/immutables"])
         builtins = sys.version_info.major == 3 and 'builtins' or '__builtin__'
         with patch('{}.__import__'.format(builtins),
                    MagicMock(side_effect=[type(str('salt'), (), {'__file__': '/custom/foo.so'}),
@@ -702,3 +731,348 @@ class SSHThinTestCase(TestCase):
             tops=tops, extended_cfg=ext_cfg)).strip().split(os.linesep)
         for t_line in ['second-system-effect:2:7', 'solar-interference:2:6']:
             self.assertIn(t_line, out)
+
+    @patch("salt.exceptions.SaltSystemExit", Exception)
+    @patch("salt.utils.thin.log", MagicMock())
+    @patch("salt.utils.thin.os.makedirs", MagicMock())
+    @patch("salt.utils.files.fopen", MagicMock())
+    @patch("salt.utils.thin._get_salt_call", MagicMock())
+    @patch("salt.utils.thin._get_ext_namespaces", MagicMock())
+    @patch("salt.utils.thin.get_tops", MagicMock(return_value=["/foo3", "/bar3"]))
+    @patch("salt.utils.thin.get_ext_tops", MagicMock(return_value={}))
+    @patch("salt.utils.thin.os.path.isfile", MagicMock())
+    @patch("salt.utils.thin.os.path.isdir", MagicMock(return_value=False))
+    @patch("salt.utils.thin.log", MagicMock())
+    @patch("salt.utils.thin.os.remove", MagicMock())
+    @patch("salt.utils.thin.os.path.exists", MagicMock())
+    @patch("salt.utils.path.os_walk", MagicMock(return_value=[]))
+    @patch(
+        "salt.utils.thin.subprocess.Popen",
+        _popen(
+            None,
+            side_effect=[(bts("2.7"), bts("")), (bts('["/foo27", "/bar27"]'), bts(""))],
+        ),
+    )
+    @patch("salt.utils.thin.tarfile", MagicMock())
+    @patch("salt.utils.thin.zipfile", MagicMock())
+    @patch("salt.utils.thin.os.getcwd", MagicMock())
+    @patch("salt.utils.thin.os.access", MagicMock(return_value=False))
+    @patch("salt.utils.thin.os.chdir", MagicMock())
+    @patch("salt.utils.thin.os.close", MagicMock())
+    @patch("salt.utils.thin.tempfile.mkdtemp", MagicMock(return_value=""))
+    @patch(
+        "salt.utils.thin.tempfile.mkstemp", MagicMock(return_value=(3, ".temporary"))
+    )
+    @patch("salt.utils.thin.shutil", MagicMock())
+    @patch("salt.utils.thin.sys.version_info", _version_info(None, 3, 6))
+    def test_gen_thin_control_files_written_access_denied_cwd(self):
+        """
+        Test thin.gen_thin function if control files are written (version, salt-call etc)
+        when the current working directory is inaccessible, eg. Salt is configured to run as
+        a non-root user but the command is executed in a directory that the user does not
+        have permissions to.  Issue #54317.
+
+        NOTE: Py2 version of this test is not required, as code shares the same spot across the versions.
+
+        :return:
+        """
+        thin.gen_thin("")
+        arc_name, arc_mode = thin.tarfile.method_calls[0][1]
+        self.assertEqual(arc_name, ".temporary")
+        self.assertEqual(arc_mode, "w:gz")
+        for idx, fname in enumerate(
+            ["version", ".thin-gen-py-version", "salt-call", "supported-versions"]
+        ):
+            name = thin.tarfile.open().method_calls[idx + 2][1][0]
+            self.assertEqual(name, fname)
+        thin.tarfile.open().close.assert_called()
+
+    def test_get_tops_python(self):
+        """
+        test get_tops_python
+        """
+        patch_proc = patch(
+            "salt.utils.thin.subprocess.Popen",
+            self._popen(
+                None,
+                side_effect=[
+                    (bts("jinja2/__init__.py"), bts("")),
+                    (bts("yaml/__init__.py"), bts("")),
+                    (bts("tornado/__init__.py"), bts("")),
+                    (bts("msgpack/__init__.py"), bts("")),
+                    (bts("certifi/__init__.py"), bts("")),
+                    (bts("singledispatch.py"), bts("")),
+                    (bts(""), bts("")),
+                    (bts(""), bts("")),
+                    (bts(""), bts("")),
+                    (bts(""), bts("")),
+                    (bts(""), bts("")),
+                    (bts("distro.py"), bts("")),
+                ],
+            ),
+        )
+
+        patch_os = patch("os.path.exists", return_value=True)
+        patch_which = patch("salt.utils.path.which", return_value=True)
+        with patch_proc, patch_os, patch_which:
+            with TstSuiteLoggingHandler() as log_handler:
+                exp_ret = copy.deepcopy(self.exp_ret)
+                ret = thin.get_tops_python("python3.7", ext_py_ver=[3, 7])
+                if salt.utils.platform.is_windows():
+                    for key, value in ret.items():
+                        ret[key] = str(pathlib.Path(value).resolve(strict=False))
+                    for key, value in exp_ret.items():
+                        exp_ret[key] = str(pathlib.Path(value).resolve(strict=False))
+                assert ret == exp_ret
+                assert (
+                    "ERROR:Could not auto detect file location for module concurrent for python version python3.7"
+                    in log_handler.messages
+                )
+
+    def test_get_tops_python_exclude(self):
+        """
+        test get_tops_python when excluding modules
+        """
+        patch_proc = patch(
+            "salt.utils.thin.subprocess.Popen",
+            self._popen(
+                None,
+                side_effect=[
+                    (bts("tornado/__init__.py"), bts("")),
+                    (bts("msgpack/__init__.py"), bts("")),
+                    (bts("certifi/__init__.py"), bts("")),
+                    (bts("singledispatch.py"), bts("")),
+                    (bts(""), bts("")),
+                    (bts(""), bts("")),
+                    (bts(""), bts("")),
+                    (bts(""), bts("")),
+                    (bts(""), bts("")),
+                    (bts("distro.py"), bts("")),
+                ],
+            ),
+        )
+        exp_ret = copy.deepcopy(self.exp_ret)
+        for lib in self.exc_libs:
+            exp_ret.pop(lib)
+
+        patch_os = patch("os.path.exists", return_value=True)
+        patch_which = patch("salt.utils.path.which", return_value=True)
+        with patch_proc, patch_os, patch_which:
+            ret = thin.get_tops_python(
+                "python3.7", exclude=self.exc_libs, ext_py_ver=[3, 7]
+            )
+            if salt.utils.platform.is_windows():
+                for key, value in ret.items():
+                    ret[key] = str(pathlib.Path(value).resolve(strict=False))
+                for key, value in exp_ret.items():
+                    exp_ret[key] = str(pathlib.Path(value).resolve(strict=False))
+            assert ret == exp_ret
+
+    def test_pack_alternatives_exclude(self):
+        """
+        test pack_alternatives when mixing
+        manually set dependencies and auto
+        detecting other modules.
+        """
+        patch_proc = patch(
+            "salt.utils.thin.subprocess.Popen",
+            self._popen(
+                None,
+                side_effect=[
+                    (bts(self.fake_libs["distro"]), bts("")),
+                    (bts(self.fake_libs["yaml"]), bts("")),
+                    (bts(self.fake_libs["tornado"]), bts("")),
+                    (bts(self.fake_libs["msgpack"]), bts("")),
+                    (bts(""), bts("")),
+                    (bts(""), bts("")),
+                    (bts(""), bts("")),
+                    (bts(""), bts("")),
+                    (bts(""), bts("")),
+                    (bts(""), bts("")),
+                    (bts(""), bts("")),
+                ],
+            ),
+        )
+
+        patch_os = patch("os.path.exists", return_value=True)
+        ext_conf = copy.deepcopy(self.ext_conf)
+        ext_conf["test"]["auto_detect"] = True
+
+        for lib in self.fake_libs.values():
+            os.makedirs(lib)
+            with salt.utils.files.fopen(os.path.join(lib, "__init__.py"), "w+") as fp_:
+                fp_.write("test")
+
+        exp_files = self.exp_files.copy()
+        exp_files.extend(
+            [
+                os.path.join("yaml", "__init__.py"),
+                os.path.join("tornado", "__init__.py"),
+                os.path.join("msgpack", "__init__.py"),
+            ]
+        )
+
+        patch_which = patch("salt.utils.path.which", return_value=True)
+
+        with patch_os, patch_proc, patch_which:
+            thin._pack_alternative(ext_conf, self.digest, self.tar)
+            calls = self.tar.mock_calls
+            for _file in exp_files:
+                assert [x for x in calls if "{}".format(_file) in x[-2]]
+
+    def test_pack_alternatives(self):
+        """
+        test thin._pack_alternatives
+        """
+        with patch("salt.utils.thin.get_ext_tops", MagicMock(return_value=self.tops)):
+            thin._pack_alternative(self.ext_conf, self.digest, self.tar)
+            calls = self.tar.mock_calls
+            for _file in self.exp_files:
+                assert [x for x in calls if "{}".format(_file) in x[-2]]
+                assert [
+                    x
+                    for x in calls
+                    if os.path.join("test", "pyall", _file) in x[-1]["arcname"]
+                ]
+
+    def test_pack_alternatives_not_normalized(self):
+        """
+        test thin._pack_alternatives when the path
+        is not normalized
+        """
+        tops = copy.deepcopy(self.tops)
+        tops["test"]["dependencies"] = [self.jinja_fp + "/"]
+        with patch("salt.utils.thin.get_ext_tops", MagicMock(return_value=tops)):
+            thin._pack_alternative(self.ext_conf, self.digest, self.tar)
+            calls = self.tar.mock_calls
+            for _file in self.exp_files:
+                assert [x for x in calls if "{}".format(_file) in x[-2]]
+                assert [
+                    x
+                    for x in calls
+                    if os.path.join("test", "pyall", _file) in x[-1]["arcname"]
+                ]
+
+    def test_pack_alternatives_path_doesnot_exist(self):
+        """
+        test thin._pack_alternatives when the path
+        doesnt exist. Check error log message
+        and expect that because the directory
+        does not exist jinja2 does not get
+        added to the tar
+        """
+        bad_path = os.path.join(tempfile.gettempdir(), "doesnotexisthere")
+        tops = copy.deepcopy(self.tops)
+        tops["test"]["dependencies"] = [bad_path]
+        with patch("salt.utils.thin.get_ext_tops", MagicMock(return_value=tops)):
+            with TstSuiteLoggingHandler() as log_handler:
+                thin._pack_alternative(self.ext_conf, self.digest, self.tar)
+                msg = "ERROR:File path {} does not exist. Unable to add to salt-ssh thin".format(
+                    bad_path
+                )
+                assert msg in log_handler.messages
+        calls = self.tar.mock_calls
+        for _file in self.exp_files:
+            arg = [x for x in calls if "{}".format(_file) in x[-2]]
+            kwargs = [
+                x
+                for x in calls
+                if os.path.join("test", "pyall", _file) in x[-1]["arcname"]
+            ]
+            if "jinja2" in _file:
+                assert not arg
+                assert not kwargs
+            else:
+                assert arg
+                assert kwargs
+
+    def test_pack_alternatives_auto_detect(self):
+        """
+        test thin._pack_alternatives when auto_detect
+        is enabled
+        """
+        ext_conf = copy.deepcopy(self.ext_conf)
+        ext_conf["test"]["auto_detect"] = True
+
+        for lib in self.fake_libs.values():
+            os.makedirs(lib)
+            with salt.utils.files.fopen(os.path.join(lib, "__init__.py"), "w+") as fp_:
+                fp_.write("test")
+
+        patch_tops_py = patch(
+            "salt.utils.thin.get_tops_python", return_value=self.fake_libs
+        )
+
+        exp_files = self.exp_files.copy()
+        exp_files.extend(
+            [
+                os.path.join("yaml", "__init__.py"),
+                os.path.join("tornado", "__init__.py"),
+                os.path.join("msgpack", "__init__.py"),
+            ]
+        )
+        with patch_tops_py:
+            thin._pack_alternative(ext_conf, self.digest, self.tar)
+            calls = self.tar.mock_calls
+            for _file in exp_files:
+                assert [x for x in calls if "{}".format(_file) in x[-2]]
+
+    def test_pack_alternatives_empty_dependencies(self):
+        """
+        test _pack_alternatives when dependencies is not
+        set in the config.
+        """
+        ext_conf = copy.deepcopy(self.ext_conf)
+        ext_conf["test"]["auto_detect"] = True
+        ext_conf["test"].pop("dependencies")
+
+        for lib in self.fake_libs.values():
+            os.makedirs(lib)
+            with salt.utils.files.fopen(os.path.join(lib, "__init__.py"), "w+") as fp_:
+                fp_.write("test")
+
+        patch_tops_py = patch(
+            "salt.utils.thin.get_tops_python", return_value=self.fake_libs
+        )
+
+        exp_files = self.exp_files.copy()
+        exp_files.extend(
+            [
+                os.path.join("yaml", "__init__.py"),
+                os.path.join("tornado", "__init__.py"),
+                os.path.join("msgpack", "__init__.py"),
+            ]
+        )
+        with patch_tops_py:
+            thin._pack_alternative(ext_conf, self.digest, self.tar)
+            calls = self.tar.mock_calls
+            for _file in exp_files:
+                assert [x for x in calls if "{}".format(_file) in x[-2]]
+
+    @slowTest
+    @skipIf(
+        salt.utils.platform.is_windows(), "salt-ssh does not deploy to/from windows"
+    )
+    def test_thin_dir(self):
+        """
+        Test the thin dir to make sure salt-call can run
+
+        Run salt call via a python in a new virtual environment to ensure
+        salt-call has all dependencies needed.
+        """
+        # This was previously an integration test and is now here, as a unit test.
+        # Should actually be a functional test
+        with VirtualEnv() as venv:
+            salt.utils.thin.gen_thin(venv.venv_dir)
+            thin_dir = os.path.join(venv.venv_dir, "thin")
+            thin_archive = os.path.join(thin_dir, "thin.tgz")
+            tar = tarfile.open(thin_archive)
+            tar.extractall(thin_dir)
+            tar.close()
+            ret = venv.run(
+                venv.venv_python,
+                os.path.join(thin_dir, "salt-call"),
+                "--version",
+                check=False,
+            )
+            assert ret.exitcode == 0, ret


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/saltstack/salt/pull/56513, https://github.com/saltstack/salt/pull/58862, https://github.com/saltstack/salt/pull/58630 and https://github.com/saltstack/salt/pull/58853. I tried to revert all changes breaking Python2 compatibility. I hope I didn't miss anything.

I also added the `slowTest` definition from https://github.com/saltstack/salt/pull/56872, but I didn't cherry pick the commit since that changes a ton of unrelated tests.