### PR TITLE
transactional_update: prevent issues with systemd because of chroot errors (bsc#1187787)

### DIFF
--- a/salt/modules/transactional_update.py
+++ b/salt/modules/transactional_update.py
@@ -345,7 +345,7 @@ def _pkg_params(pkg, pkgs, args):
 
 def _cmd(cmd, retcode=False):
     """Utility function to run commands."""
-    result = __salt__["cmd.run_all"](cmd)
+    result = __salt__["cmd.run_all"](cmd, env={"SYSTEMD_IGNORE_CHROOT": 1})
     if retcode:
         return result["retcode"]
 

--- a/tests/unit/modules/test_transactional_update.py
+++ b/tests/unit/modules/test_transactional_update.py
@@ -163,7 +163,8 @@ class TransactionalUpdateTestCase(TestCase, LoaderModuleMockMixin):
                         cmd.replace("_", ".")
                         if cmd.startswith("grub")
                         else cmd.replace("_", "-"),
-                    ]
+                    ],
+                    env={"SYSTEMD_IGNORE_CHROOT": 1},
                 )
 
     def test_run_error(self):
@@ -190,7 +191,8 @@ class TransactionalUpdateTestCase(TestCase, LoaderModuleMockMixin):
                     "--flag",
                     "p1",
                     "p2",
-                ]
+                ],
+                env={"SYSTEMD_IGNORE_CHROOT": 1},
             )
 
     def test_run_array(self):
@@ -212,7 +214,8 @@ class TransactionalUpdateTestCase(TestCase, LoaderModuleMockMixin):
                     "--flag",
                     "p1",
                     "p2",
-                ]
+                ],
+                env={"SYSTEMD_IGNORE_CHROOT": 1},
             )
 
     def test_pkg_commands(self):
@@ -237,7 +240,8 @@ class TransactionalUpdateTestCase(TestCase, LoaderModuleMockMixin):
                         "pkg1",
                         "pkg2",
                         "pkg3",
-                    ]
+                    ],
+                    env={"SYSTEMD_IGNORE_CHROOT": 1},
                 )
 
     def test_rollback_error(self):
@@ -253,7 +257,7 @@ class TransactionalUpdateTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(tu.__salt__, salt_mock):
             assert tu.rollback() == "output"
             salt_mock["cmd.run_all"].assert_called_with(
-                ["transactional-update", "rollback"]
+                ["transactional-update", "rollback"], env={"SYSTEMD_IGNORE_CHROOT": 1}
             )
 
     def test_rollback_snapshot_number(self):
@@ -264,7 +268,8 @@ class TransactionalUpdateTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(tu.__salt__, salt_mock):
             assert tu.rollback(10) == "output"
             salt_mock["cmd.run_all"].assert_called_with(
-                ["transactional-update", "rollback", 10]
+                ["transactional-update", "rollback", 10],
+                env={"SYSTEMD_IGNORE_CHROOT": 1},
             )
 
     def test_rollback_snapshot_str(self):
@@ -275,7 +280,8 @@ class TransactionalUpdateTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(tu.__salt__, salt_mock):
             assert tu.rollback("10") == "output"
             salt_mock["cmd.run_all"].assert_called_with(
-                ["transactional-update", "rollback", "10"]
+                ["transactional-update", "rollback", "10"],
+                env={"SYSTEMD_IGNORE_CHROOT": 1},
             )
 
     def test_rollback_last(self):
@@ -286,7 +292,8 @@ class TransactionalUpdateTestCase(TestCase, LoaderModuleMockMixin):
         with patch.dict(tu.__salt__, salt_mock):
             assert tu.rollback("last") == "output"
             salt_mock["cmd.run_all"].assert_called_with(
-                ["transactional-update", "rollback", "last"]
+                ["transactional-update", "rollback", "last"],
+                env={"SYSTEMD_IGNORE_CHROOT": 1},
             )
 
     def test_pending_transaction(self):
@@ -310,7 +317,8 @@ class TransactionalUpdateTestCase(TestCase, LoaderModuleMockMixin):
                 with patch.dict(tu.__salt__, salt_mock):
                     assert tu.pending_transaction() is result
                     salt_mock["cmd.run_all"].assert_called_with(
-                        ["snapper", "--no-dbus", "list", "--columns", "number"]
+                        ["snapper", "--no-dbus", "list", "--columns", "number"],
+                        env={"SYSTEMD_IGNORE_CHROOT": 1},
                     )
 
     def test_pending_transaction_in_transaction(self):
@@ -402,7 +410,8 @@ class TransactionalUpdateTestCase(TestCase, LoaderModuleMockMixin):
                     "quiet",
                     "--",
                     "test.ping",
-                ]
+                ],
+                env={"SYSTEMD_IGNORE_CHROOT": 1},
             )
             utils_mock["files.rm_rf"].assert_called_once()
 
@@ -458,7 +467,8 @@ class TransactionalUpdateTestCase(TestCase, LoaderModuleMockMixin):
                     "quiet",
                     "--",
                     "test.ping",
-                ]
+                ],
+                env={"SYSTEMD_IGNORE_CHROOT": 1},
             )
             utils_mock["files.rm_rf"].assert_called_once()
 
@@ -508,7 +518,8 @@ class TransactionalUpdateTestCase(TestCase, LoaderModuleMockMixin):
                     "quiet",
                     "--",
                     "test.ping",
-                ]
+                ],
+                env={"SYSTEMD_IGNORE_CHROOT": 1},
             )
             utils_mock["files.rm_rf"].assert_called_once()
 
@@ -564,7 +575,8 @@ class TransactionalUpdateTestCase(TestCase, LoaderModuleMockMixin):
                     "quiet",
                     "--",
                     "transactional_update.dup",
-                ]
+                ],
+                env={"SYSTEMD_IGNORE_CHROOT": 1},
             )
             utils_mock["files.rm_rf"].assert_called_once()
             pending_transaction.assert_called_once()
@@ -617,7 +629,8 @@ class TransactionalUpdateTestCase(TestCase, LoaderModuleMockMixin):
                     "--",
                     "module.function",
                     "key=value",
-                ]
+                ],
+                env={"SYSTEMD_IGNORE_CHROOT": 1},
             )
             utils_mock["files.rm_rf"].assert_called_once()
 


### PR DESCRIPTION
### What does this PR do?

This PR prevents the wrong behavior of `systemd_service` module when it's called by "transactional_update" module. The problem is that "systemctl" is raising an error due the chrooted environment, and that confuses Salt completely, leading into inconsistent states reports due the retcode of systemctl:

```
# systemctl is-active osad
Running in chroot, ignoring command 'is-active'
# echo $?
0

# SYSTEMD_IGNORE_CHROOT=1 systemctl is-active osad
inactive
# echo $?
3
```