### PR TITLE
Consolidate some state requisites (#55974) (bsc#1188641) - 3000

### DIFF
--- a/doc/ref/states/requisites.rst
+++ b/doc/ref/states/requisites.rst
@@ -1039,8 +1039,40 @@ if the gluster commands return a 0 ret value.
                 - /etc/crontab
                 - 'entry1'
 
-runas
-~~~~~
+.. _creates-requisite:
+
+Creates
+-------
+
+.. versionadded:: Sodium
+
+The ``creates`` requisite specifies that a state should only run when any of
+the specified files do not already exist. Like ``unless``, ``creates`` requisite
+operates as NAND and is useful in giving more granular control over when a state
+should execute. This was previously used by the :mod:`cmd <salt.states.cmd>` and
+:mod:`docker_container <salt.states.docker_container>` states.
+
+    .. code-block:: yaml
+
+      contrived creates example:
+        file.touch:
+          - name: /path/to/file
+          - creates: /path/to/file
+
+``creates`` also accepts a list of files, in which case this state will
+run if **any** of the files do not exist:
+
+    .. code-block:: yaml
+
+      creates list:
+        file.cmd:
+          - name: /path/to/command
+          - creates:
+              - /path/file
+              - /path/file2
+
+listen
+~~~~~~
 
 .. versionadded:: 2014.7.0
 

--- a/doc/topics/releases/sodium.rst
+++ b/doc/topics/releases/sodium.rst
@@ -27,3 +27,14 @@ in the salt mine function definition itself (or when calling :py:func:`mine.send
 This targeting works the same as the generic minion targeting as specified
 :ref:`here <targeting>`. The parameters used are ``allow_tgt`` and ``allow_tgt_type``.
 See also :ref:`the documentation of the Salt Mine <mine_minion-side-acl>`.
+
+
+State updates
+=============
+
+The ``creates`` state requisite has been migrated from the
+:mod:`docker_container <salt.states.docker_container>` and :mod:`cmd <salt.states.cmd>`
+states to become a global option. This acts similar to an equivalent
+``unless: test -f filename`` but can also accept a list of filenames. This allows
+all states to take advantage of the enhanced functionality released in Neon, of allowing
+salt execution modules for requisite checks.

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -343,7 +343,7 @@ def orchestrate(mods,
     .. seealso:: More Orchestrate documentation
 
         * :ref:`Full Orchestrate Tutorial <orchestrate-runner>`
-        * :py:mod:`Docs for the ``salt`` state module <salt.states.saltmod>`
+        * Docs for the salt state module :py:mod:`salt.states.saltmod`
 
     CLI Examples:
 

--- a/salt/state.py
+++ b/salt/state.py
@@ -915,9 +915,9 @@ class State(object):
                     }
                 )
                 return False
-            else:
+            elif cmd == 0:
                 ret.update({"comment": "onlyif condition is true", "result": False})
-                return True
+            return True
 
         for entry in low_data_onlyif:
             if isinstance(entry, six.string_types):

--- a/salt/state.py
+++ b/salt/state.py
@@ -979,7 +979,7 @@ class State(object):
                 except CommandExecutionError:
                     # Command failed, so notify unless to skip the item
                     cmd = 0
-                if not _check_cmd(cmd):
+                if _check_cmd(cmd):
                     return ret
             elif isinstance(entry, dict):
                 if 'fun' not in entry:
@@ -988,8 +988,8 @@ class State(object):
                     return ret
 
                 result = self._run_check_function(entry)
-                if self.state_con.get('retcode', 0):
-                    if not _check_cmd(self.state_con['retcode']):
+                if self.state_con.get("retcode", 0):
+                    if _check_cmd(self.state_con["retcode"]):
                         return ret
                 elif result:
                     ret.update({'comment': 'unless condition is true',

--- a/salt/states/docker_container.py
+++ b/salt/states/docker_container.py
@@ -48,7 +48,6 @@ configuration remains unchanged.
 from __future__ import absolute_import, print_function, unicode_literals
 import copy
 import logging
-import os
 
 # Import Salt libs
 from salt.exceptions import CommandExecutionError
@@ -2096,21 +2095,20 @@ def running(name,
     return _format_comments(ret, comments)
 
 
-def run(name,
-        image=None,
-        onlyif=None,
-        unless=None,
-        creates=None,
-        bg=False,
-        failhard=True,
-        replace=False,
-        force=False,
-        skip_translate=None,
-        ignore_collisions=False,
-        validate_ip_addrs=True,
-        client_timeout=salt.utils.docker.CLIENT_TIMEOUT,
-        **kwargs):
-    '''
+def run(
+    name,
+    image=None,
+    bg=False,
+    failhard=True,
+    replace=False,
+    force=False,
+    skip_translate=None,
+    ignore_collisions=False,
+    validate_ip_addrs=True,
+    client_timeout=salt.utils.dockermod.CLIENT_TIMEOUT,
+    **kwargs
+):
+    """
     .. versionadded:: 2018.3.0
 
     .. note::
@@ -2134,15 +2132,6 @@ def run(name,
     control how logs are returned.
 
     Additionally, the following arguments are supported:
-
-    onlyif
-        A command or list of commands to run as a check. The container will
-        only run if any of the specified commands returns a zero exit status.
-
-    unless
-        A command or list of commands to run as a check. The container will
-        only run if any of the specified commands returns a non-zero exit
-        status.
 
     creates
         A path or list of paths. Only run if one or more of the specified paths
@@ -2200,7 +2189,7 @@ def run(name,
               - mynet
             - require:
               - docker_network: mynet
-    '''
+    """
     ret = {'name': name,
            'changes': {},
            'result': True,
@@ -2222,11 +2211,6 @@ def run(name,
     elif not isinstance(image, six.string_types):
         image = six.text_type(image)
 
-    cret = mod_run_check(onlyif, unless, creates)
-    if isinstance(cret, dict):
-        ret.update(cret)
-        return ret
-
     try:
         if 'networks' in kwargs and kwargs['networks'] is not None:
             kwargs['networks'] = _parse_networks(kwargs['networks'])
@@ -2239,15 +2223,10 @@ def run(name,
             ret['comment'] = exc.__str__()
             return ret
 
-    cret = mod_run_check(onlyif, unless, creates)
-    if isinstance(cret, dict):
-        ret.update(cret)
-        return ret
-
-    if __opts__['test']:
-        ret['result'] = None
-        ret['comment'] = 'Container would be run{0}'.format(
-            ' in the background' if bg else ''
+    if __opts__["test"]:
+        ret["result"] = None
+        ret["comment"] = "Container would be run{0}".format(
+            " in the background" if bg else ""
         )
         return ret
 
@@ -2546,72 +2525,6 @@ def absent(name, force=False):
         ret['comment'] = '{0} removed container \'{1}\''.format(method, name)
         ret['result'] = True
     return ret
-
-
-def mod_run_check(onlyif, unless, creates):
-    '''
-    Execute the onlyif/unless/creates logic. Returns a result dict if any of
-    the checks fail, otherwise returns True
-    '''
-    cmd_kwargs = {'use_vt': False, 'bg': False}
-
-    if onlyif is not None:
-        if isinstance(onlyif, six.string_types):
-            onlyif = [onlyif]
-        if not isinstance(onlyif, list) \
-                or not all(isinstance(x, six.string_types) for x in onlyif):
-            return {'comment': 'onlyif is not a string or list of strings',
-                    'skip_watch': True,
-                    'result': True}
-        for entry in onlyif:
-            retcode = __salt__['cmd.retcode'](
-                entry,
-                ignore_retcode=True,
-                python_shell=True)
-            if retcode != 0:
-                return {
-                    'comment': 'onlyif command {0} returned exit code of {1}'
-                               .format(entry, retcode),
-                    'skip_watch': True,
-                    'result': True
-                }
-
-    if unless is not None:
-        if isinstance(unless, six.string_types):
-            unless = [unless]
-        if not isinstance(unless, list) \
-                or not all(isinstance(x, six.string_types) for x in unless):
-            return {'comment': 'unless is not a string or list of strings',
-                    'skip_watch': True,
-                    'result': True}
-        for entry in unless:
-            retcode = __salt__['cmd.retcode'](
-                entry,
-                ignore_retcode=True,
-                python_shell=True)
-            if retcode == 0:
-                return {
-                    'comment': 'unless command {0} returned exit code of {1}'
-                               .format(entry, retcode),
-                    'skip_watch': True,
-                    'result': True
-                }
-
-    if creates is not None:
-        if isinstance(creates, six.string_types):
-            creates = [creates]
-        if not isinstance(creates, list) \
-                or not all(isinstance(x, six.string_types) for x in creates):
-            return {'comment': 'creates is not a string or list of strings',
-                    'skip_watch': True,
-                    'result': True}
-        if all(os.path.exists(x) for x in creates):
-            return {'comment': 'All specified paths in \'creates\' '
-                               'argument exist',
-                    'result': True}
-
-    # No reason to stop, return True
-    return True
 
 
 def mod_watch(name, sfun=None, **kwargs):

--- a/salt/states/macpackage.py
+++ b/salt/states/macpackage.py
@@ -43,12 +43,21 @@ def __virtual__():
     '''
     if salt.utils.platform.is_darwin():
         return __virtualname__
-    return False
+    return (False, "Only supported on Mac OS")
 
 
-def installed(name, target="LocalSystem", dmg=False, store=False, app=False, mpkg=False, user=None, onlyif=None,
-              unless=None, force=False, allow_untrusted=False, version_check=None):
-    '''
+def installed(
+    name,
+    target="LocalSystem",
+    dmg=False,
+    store=False,
+    app=False,
+    mpkg=False,
+    force=False,
+    allow_untrusted=False,
+    version_check=None,
+):
+    """
     Install a Mac OS Package from a pkg or dmg file, if given a dmg file it
     will first be mounted in a temporary location
 
@@ -71,17 +80,6 @@ def installed(name, target="LocalSystem", dmg=False, store=False, app=False, mpk
     mpkg
         Is the file a .mpkg? If so then we'll check all of the .pkg files found are installed
 
-    user
-        Name of the user performing the unless or onlyif checks
-
-    onlyif
-        A command to run as a check, run the named command only if the command
-        passed to the ``onlyif`` option returns true
-
-    unless
-        A command to run as a check, only run the named command if the command
-        passed to the ``unless`` option returns false
-
     force
         Force the package to be installed even if its already been found installed
 
@@ -95,7 +93,7 @@ def installed(name, target="LocalSystem", dmg=False, store=False, app=False, mpk
 
             version_check: python --version_check=2.7.[0-9]
 
-    '''
+    """
     ret = {'name': name,
            'result': True,
            'comment': '',
@@ -104,17 +102,6 @@ def installed(name, target="LocalSystem", dmg=False, store=False, app=False, mpk
     installing = []
 
     real_pkg = name
-
-    # Check onlyif, unless first
-    run_check_cmd_kwargs = {'runas': user, 'python_shell': True}
-    if 'shell' in __grains__:
-        run_check_cmd_kwargs['shell'] = __grains__['shell']
-
-    cret = _mod_run_check(run_check_cmd_kwargs, onlyif, unless)
-
-    if isinstance(cret, dict):
-        ret.update(cret)
-        return ret
 
     # Check version info
     if version_check is not None:
@@ -171,7 +158,7 @@ def installed(name, target="LocalSystem", dmg=False, store=False, app=False, mpk
                 pkg_ids = [os.path.basename(name)]
                 mount_point = os.path.dirname(name)
 
-            if onlyif is None and unless is None and version_check is None:
+            if version_check is None:
                 for p in pkg_ids:
                     if target[-4:] == ".app":
                         install_dir = target
@@ -243,27 +230,3 @@ def installed(name, target="LocalSystem", dmg=False, store=False, app=False, mpk
             __salt__['macpackage.unmount'](mount_point)
 
     return ret
-
-
-def _mod_run_check(cmd_kwargs, onlyif, unless):
-    '''
-    Execute the onlyif and unless logic.
-    Return a result dict if:
-    * onlyif failed (onlyif != 0)
-    * unless succeeded (unless == 0)
-    else return True
-    '''
-    if onlyif:
-        if __salt__['cmd.retcode'](onlyif, **cmd_kwargs) != 0:
-            return {'comment': 'onlyif condition is false',
-                    'skip_watch': True,
-                    'result': True}
-
-    if unless:
-        if __salt__['cmd.retcode'](unless, **cmd_kwargs) == 0:
-            return {'comment': 'unless condition is true',
-                    'skip_watch': True,
-                    'result': True}
-
-    # No reason to stop, return True
-    return True

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1514,10 +1514,20 @@ def installed(
 
     .. seealso:: unless and onlyif
 
-        You can use the :ref:`unless <unless-requisite>` or
-        :ref:`onlyif <onlyif-requisite>` syntax to skip a full package run.
-        This can be helpful in large environments with multiple states that
-        include requisites for packages to be installed.
+        If running pkg commands together with :ref:`aggregate <mod-aggregate-state>`
+        isn't an option, you can use the :ref:`creates <creates-requisite>`,
+        :ref:`unless <unless-requisite>`, or :ref:`onlyif <onlyif-requisite>`
+        syntax to skip a full package run. This can be helpful in large environments
+        with multiple states that include requisites for packages to be installed.
+
+        .. code-block:: yaml
+
+            # Using creates for a simple single-factor check
+            install_nginx:
+              pkg.installed:
+                - name: nginx
+                - creates:
+                  - /etc/nginx/nginx.conf
 
         .. code-block:: yaml
 
@@ -1529,6 +1539,12 @@ def installed(
                   - fun: file.file_exists
                     args:
                       - /etc/nginx/nginx.conf
+
+            # Using unless with a shell test
+            install_nginx:
+              pkg.installed:
+                - name: nginx
+                - unless: test -f /etc/nginx/nginx.conf
 
         .. code-block:: yaml
 
@@ -1542,11 +1558,11 @@ def installed(
                       - /etc/nginx/nginx.conf
                       - 'user www-data;'
 
-        The above examples use two different methods to reasonably ensure
+        The above examples use different methods to reasonably ensure
         that a package has already been installed. First, with checking for a
         file that would be created with the package. Second, by checking for
         specific text within a file that would be created or managed by salt.
-        With these requisists satisfied, unless will return ``True`` and the
+        With these requisists satisfied, creates/unless will return ``True`` and the
         ``pkg.installed`` state will be skipped.
 
         .. code-block:: bash

--- a/tests/integration/files/file/base/issue-35384.sls
+++ b/tests/integration/files/file/base/issue-35384.sls
@@ -2,5 +2,12 @@ cmd_run_unless_multiple:
   cmd.run:
     - name: echo "hello"
     - unless:
+  {% if grains["os"] ==  "Windows" %}
+      - "exit 0"
+      - "exit 1"
+      - "exit 0"
+  {% else %}
       - "$(which true)"
       - "$(which false)"
+      - "$(which true)"
+  {% endif %}

--- a/tests/unit/states/test_macpackage.py
+++ b/tests/unit/states/test_macpackage.py
@@ -22,185 +22,218 @@ class MacPackageTestCase(TestCase, LoaderModuleMockMixin):
         return {macpackage: {}}
 
     def test_installed_pkg(self):
-        '''
+        """
             Test installing a PKG file
-        '''
-        with patch('salt.states.macpackage._mod_run_check') as _mod_run_check_mock:
-            expected = {
-                'changes': {'installed': ['some.other.id']},
-                'comment': '/path/to/file.pkg installed',
-                'name': '/path/to/file.pkg',
-                'result': True
-            }
+        """
+        expected = {
+            "changes": {"installed": ["some.other.id"]},
+            "comment": "/path/to/file.pkg installed",
+            "name": "/path/to/file.pkg",
+            "result": True,
+        }
 
-            installed_mock = MagicMock(return_value=['com.apple.id'])
-            get_pkg_id_mock = MagicMock(return_value=['some.other.id'])
-            install_mock = MagicMock(return_value={'retcode': 0})
-            _mod_run_check_mock.return_value = True
+        installed_mock = MagicMock(return_value=["com.apple.id"])
+        get_pkg_id_mock = MagicMock(return_value=["some.other.id"])
+        install_mock = MagicMock(return_value={"retcode": 0})
 
-            with patch.dict(macpackage.__salt__, {'macpackage.installed_pkgs': installed_mock,
-                                                  'macpackage.get_pkg_id': get_pkg_id_mock,
-                                                  'macpackage.install': install_mock}):
-                out = macpackage.installed('/path/to/file.pkg')
-                installed_mock.assert_called_once_with()
-                get_pkg_id_mock.assert_called_once_with('/path/to/file.pkg')
-                install_mock.assert_called_once_with('/path/to/file.pkg', 'LocalSystem', False, False)
-                self.assertEqual(out, expected)
+        with patch.dict(
+            macpackage.__salt__,
+            {
+                "macpackage.installed_pkgs": installed_mock,
+                "macpackage.get_pkg_id": get_pkg_id_mock,
+                "macpackage.install": install_mock,
+            },
+        ):
+            out = macpackage.installed("/path/to/file.pkg")
+            installed_mock.assert_called_once_with()
+            get_pkg_id_mock.assert_called_once_with("/path/to/file.pkg")
+            install_mock.assert_called_once_with(
+                "/path/to/file.pkg", "LocalSystem", False, False
+            )
+            self.assertEqual(out, expected)
 
     def test_installed_pkg_exists(self):
-        '''
+        """
             Test installing a PKG file where it's already installed
-        '''
-        with patch('salt.states.macpackage._mod_run_check') as _mod_run_check_mock:
-            expected = {
-                'changes': {},
-                'comment': '',
-                'name': '/path/to/file.pkg',
-                'result': True
-            }
+        """
+        expected = {
+            "changes": {},
+            "comment": "",
+            "name": "/path/to/file.pkg",
+            "result": True,
+        }
 
-            installed_mock = MagicMock(return_value=['com.apple.id', 'some.other.id'])
-            get_pkg_id_mock = MagicMock(return_value=['some.other.id'])
-            install_mock = MagicMock(return_value={'retcode': 0})
-            _mod_run_check_mock.return_value = True
+        installed_mock = MagicMock(return_value=["com.apple.id", "some.other.id"])
+        get_pkg_id_mock = MagicMock(return_value=["some.other.id"])
+        install_mock = MagicMock(return_value={"retcode": 0})
 
-            with patch.dict(macpackage.__salt__, {'macpackage.installed_pkgs': installed_mock,
-                                                  'macpackage.get_pkg_id': get_pkg_id_mock,
-                                                  'macpackage.install': install_mock}):
-                out = macpackage.installed('/path/to/file.pkg')
-                installed_mock.assert_called_once_with()
-                get_pkg_id_mock.assert_called_once_with('/path/to/file.pkg')
-                assert not install_mock.called
-                self.assertEqual(out, expected)
+        with patch.dict(
+            macpackage.__salt__,
+            {
+                "macpackage.installed_pkgs": installed_mock,
+                "macpackage.get_pkg_id": get_pkg_id_mock,
+                "macpackage.install": install_mock,
+            },
+        ):
+            out = macpackage.installed("/path/to/file.pkg")
+            installed_mock.assert_called_once_with()
+            get_pkg_id_mock.assert_called_once_with("/path/to/file.pkg")
+            assert not install_mock.called
+            self.assertEqual(out, expected)
 
     def test_installed_pkg_version_succeeds(self):
-        '''
+        """
             Test installing a PKG file where the version number matches the current installed version
-        '''
-        with patch('salt.states.macpackage._mod_run_check') as _mod_run_check_mock:
-            expected = {
-                'changes': {},
-                'comment': 'Version already matches .*5\\.1\\.[0-9]',
-                'name': '/path/to/file.pkg',
-                'result': True
-            }
+        """
+        expected = {
+            "changes": {},
+            "comment": "Version already matches .*5\\.1\\.[0-9]",
+            "name": "/path/to/file.pkg",
+            "result": True,
+        }
 
-            installed_mock = MagicMock(return_value=['com.apple.id', 'some.other.id'])
-            get_pkg_id_mock = MagicMock(return_value=['some.other.id'])
-            install_mock = MagicMock(return_value={'retcode': 0})
-            cmd_mock = MagicMock(return_value='Version of this: 5.1.9')
-            _mod_run_check_mock.return_value = True
+        installed_mock = MagicMock(return_value=["com.apple.id", "some.other.id"])
+        get_pkg_id_mock = MagicMock(return_value=["some.other.id"])
+        install_mock = MagicMock(return_value={"retcode": 0})
+        cmd_mock = MagicMock(return_value="Version of this: 5.1.9")
 
-            with patch.dict(macpackage.__salt__, {'macpackage.installed_pkgs': installed_mock,
-                                                  'macpackage.get_pkg_id': get_pkg_id_mock,
-                                                  'macpackage.install': install_mock,
-                                                  'cmd.run': cmd_mock}):
-                out = macpackage.installed('/path/to/file.pkg', version_check=r'/usr/bin/runme --version=.*5\.1\.[0-9]')
-                cmd_mock.assert_called_once_with('/usr/bin/runme --version', output_loglevel="quiet", ignore_retcode=True)
-                assert not installed_mock.called
-                assert not get_pkg_id_mock.called
-                assert not install_mock.called
-                self.assertEqual(out, expected)
+        with patch.dict(
+            macpackage.__salt__,
+            {
+                "macpackage.installed_pkgs": installed_mock,
+                "macpackage.get_pkg_id": get_pkg_id_mock,
+                "macpackage.install": install_mock,
+                "cmd.run": cmd_mock,
+            },
+        ):
+            out = macpackage.installed(
+                "/path/to/file.pkg",
+                version_check=r"/usr/bin/runme --version=.*5\.1\.[0-9]",
+            )
+            cmd_mock.assert_called_once_with(
+                "/usr/bin/runme --version", output_loglevel="quiet", ignore_retcode=True
+            )
+            assert not installed_mock.called
+            assert not get_pkg_id_mock.called
+            assert not install_mock.called
+            self.assertEqual(out, expected)
 
     def test_installed_pkg_version_fails(self):
-        '''
+        """
             Test installing a PKG file where the version number if different from the expected one
-        '''
-        with patch('salt.states.macpackage._mod_run_check') as _mod_run_check_mock:
-            expected = {
-                'changes': {'installed': ['some.other.id']},
-                'comment': 'Version Version of this: 1.8.9 doesn\'t match .*5\\.1\\.[0-9]. /path/to/file.pkg installed',
-                'name': '/path/to/file.pkg',
-                'result': True
-            }
+        """
+        expected = {
+            "changes": {"installed": ["some.other.id"]},
+            "comment": "Version Version of this: 1.8.9 doesn't match .*5\\.1\\.[0-9]. /path/to/file.pkg installed",
+            "name": "/path/to/file.pkg",
+            "result": True,
+        }
 
-            installed_mock = MagicMock(return_value=['com.apple.id'])
-            get_pkg_id_mock = MagicMock(return_value=['some.other.id'])
-            install_mock = MagicMock(return_value={'retcode': 0})
-            cmd_mock = MagicMock(return_value='Version of this: 1.8.9')
-            _mod_run_check_mock.return_value = True
+        installed_mock = MagicMock(return_value=["com.apple.id"])
+        get_pkg_id_mock = MagicMock(return_value=["some.other.id"])
+        install_mock = MagicMock(return_value={"retcode": 0})
+        cmd_mock = MagicMock(return_value="Version of this: 1.8.9")
 
-            with patch.dict(macpackage.__salt__, {'macpackage.installed_pkgs': installed_mock,
-                                                  'macpackage.get_pkg_id': get_pkg_id_mock,
-                                                  'macpackage.install': install_mock,
-                                                  'cmd.run': cmd_mock}):
-                out = macpackage.installed('/path/to/file.pkg', version_check=r'/usr/bin/runme --version=.*5\.1\.[0-9]')
-                cmd_mock.assert_called_once_with('/usr/bin/runme --version', output_loglevel="quiet", ignore_retcode=True)
-                installed_mock.assert_called_once_with()
-                get_pkg_id_mock.assert_called_once_with('/path/to/file.pkg')
-                install_mock.assert_called_once_with('/path/to/file.pkg', 'LocalSystem', False, False)
-                self.assertEqual(out, expected)
+        with patch.dict(
+            macpackage.__salt__,
+            {
+                "macpackage.installed_pkgs": installed_mock,
+                "macpackage.get_pkg_id": get_pkg_id_mock,
+                "macpackage.install": install_mock,
+                "cmd.run": cmd_mock,
+            },
+        ):
+            out = macpackage.installed(
+                "/path/to/file.pkg",
+                version_check=r"/usr/bin/runme --version=.*5\.1\.[0-9]",
+            )
+            cmd_mock.assert_called_once_with(
+                "/usr/bin/runme --version", output_loglevel="quiet", ignore_retcode=True
+            )
+            installed_mock.assert_called_once_with()
+            get_pkg_id_mock.assert_called_once_with("/path/to/file.pkg")
+            install_mock.assert_called_once_with(
+                "/path/to/file.pkg", "LocalSystem", False, False
+            )
+            self.assertEqual(out, expected)
 
     def test_installed_dmg(self):
-        '''
+        """
             Test installing a DMG file
-        '''
-        with patch('salt.states.macpackage._mod_run_check') as _mod_run_check_mock:
-            expected = {
-                'changes': {'installed': ['some.other.id']},
-                'comment': '/path/to/file.dmg installed',
-                'name': '/path/to/file.dmg',
-                'result': True
-            }
+        """
+        expected = {
+            "changes": {"installed": ["some.other.id"]},
+            "comment": "/path/to/file.dmg installed",
+            "name": "/path/to/file.dmg",
+            "result": True,
+        }
 
-            mount_mock = MagicMock(return_value=['success', '/tmp/dmg-X'])
-            unmount_mock = MagicMock()
-            installed_mock = MagicMock(return_value=['com.apple.id'])
-            get_pkg_id_mock = MagicMock(return_value=['some.other.id'])
-            install_mock = MagicMock(return_value={'retcode': 0})
-            _mod_run_check_mock.return_value = True
+        mount_mock = MagicMock(return_value=["success", "/tmp/dmg-X"])
+        unmount_mock = MagicMock()
+        installed_mock = MagicMock(return_value=["com.apple.id"])
+        get_pkg_id_mock = MagicMock(return_value=["some.other.id"])
+        install_mock = MagicMock(return_value={"retcode": 0})
 
-            with patch.dict(macpackage.__salt__, {'macpackage.mount': mount_mock,
-                                                  'macpackage.unmount': unmount_mock,
-                                                  'macpackage.installed_pkgs': installed_mock,
-                                                  'macpackage.get_pkg_id': get_pkg_id_mock,
-                                                  'macpackage.install': install_mock}):
-                out = macpackage.installed('/path/to/file.dmg', dmg=True)
-                mount_mock.assert_called_once_with('/path/to/file.dmg')
-                unmount_mock.assert_called_once_with('/tmp/dmg-X')
-                installed_mock.assert_called_once_with()
-                get_pkg_id_mock.assert_called_once_with('/tmp/dmg-X/*.pkg')
-                install_mock.assert_called_once_with('/tmp/dmg-X/*.pkg', 'LocalSystem', False, False)
-                self.assertEqual(out, expected)
+        with patch.dict(
+            macpackage.__salt__,
+            {
+                "macpackage.mount": mount_mock,
+                "macpackage.unmount": unmount_mock,
+                "macpackage.installed_pkgs": installed_mock,
+                "macpackage.get_pkg_id": get_pkg_id_mock,
+                "macpackage.install": install_mock,
+            },
+        ):
+            out = macpackage.installed("/path/to/file.dmg", dmg=True)
+            mount_mock.assert_called_once_with("/path/to/file.dmg")
+            unmount_mock.assert_called_once_with("/tmp/dmg-X")
+            installed_mock.assert_called_once_with()
+            get_pkg_id_mock.assert_called_once_with("/tmp/dmg-X/*.pkg")
+            install_mock.assert_called_once_with(
+                "/tmp/dmg-X/*.pkg", "LocalSystem", False, False
+            )
+            self.assertEqual(out, expected)
 
     def test_installed_dmg_exists(self):
-        '''
+        """
             Test installing a DMG file when the package already exists
-        '''
-        with patch('salt.states.macpackage._mod_run_check') as _mod_run_check_mock:
-            expected = {
-                'changes': {},
-                'comment': '',
-                'name': '/path/to/file.dmg',
-                'result': True
-            }
+        """
+        expected = {
+            "changes": {},
+            "comment": "",
+            "name": "/path/to/file.dmg",
+            "result": True,
+        }
 
-            mount_mock = MagicMock(return_value=['success', '/tmp/dmg-X'])
-            unmount_mock = MagicMock()
-            installed_mock = MagicMock(return_value=['com.apple.id', 'some.other.id'])
-            get_pkg_id_mock = MagicMock(return_value=['some.other.id'])
-            install_mock = MagicMock(return_value={'retcode': 0})
-            _mod_run_check_mock.return_value = True
+        mount_mock = MagicMock(return_value=["success", "/tmp/dmg-X"])
+        unmount_mock = MagicMock()
+        installed_mock = MagicMock(return_value=["com.apple.id", "some.other.id"])
+        get_pkg_id_mock = MagicMock(return_value=["some.other.id"])
+        install_mock = MagicMock(return_value={"retcode": 0})
 
-            with patch.dict(macpackage.__salt__, {'macpackage.mount': mount_mock,
-                                                  'macpackage.unmount': unmount_mock,
-                                                  'macpackage.installed_pkgs': installed_mock,
-                                                  'macpackage.get_pkg_id': get_pkg_id_mock,
-                                                  'macpackage.install': install_mock}):
-                out = macpackage.installed('/path/to/file.dmg', dmg=True)
-                mount_mock.assert_called_once_with('/path/to/file.dmg')
-                unmount_mock.assert_called_once_with('/tmp/dmg-X')
-                installed_mock.assert_called_once_with()
-                get_pkg_id_mock.assert_called_once_with('/tmp/dmg-X/*.pkg')
-                assert not install_mock.called
-                self.assertEqual(out, expected)
+        with patch.dict(
+            macpackage.__salt__,
+            {
+                "macpackage.mount": mount_mock,
+                "macpackage.unmount": unmount_mock,
+                "macpackage.installed_pkgs": installed_mock,
+                "macpackage.get_pkg_id": get_pkg_id_mock,
+                "macpackage.install": install_mock,
+            },
+        ):
+            out = macpackage.installed("/path/to/file.dmg", dmg=True)
+            mount_mock.assert_called_once_with("/path/to/file.dmg")
+            unmount_mock.assert_called_once_with("/tmp/dmg-X")
+            installed_mock.assert_called_once_with()
+            get_pkg_id_mock.assert_called_once_with("/tmp/dmg-X/*.pkg")
+            assert not install_mock.called
+            self.assertEqual(out, expected)
 
     def test_installed_app(self):
-        '''
+        """
             Test installing an APP file
-        '''
-        with patch('salt.states.macpackage._mod_run_check') as _mod_run_check_mock, \
-                patch('os.path.exists') as exists_mock:
+        """
+        with patch("os.path.exists") as exists_mock:
             expected = {
                 'changes': {'installed': ['file.app']},
                 'comment': 'file.app installed',
@@ -209,7 +242,6 @@ class MacPackageTestCase(TestCase, LoaderModuleMockMixin):
             }
 
             install_mock = MagicMock()
-            _mod_run_check_mock.return_value = True
             exists_mock.return_value = False
 
             with patch.dict(macpackage.__salt__, {'macpackage.install_app': install_mock}):
@@ -219,11 +251,10 @@ class MacPackageTestCase(TestCase, LoaderModuleMockMixin):
                 self.assertEqual(out, expected)
 
     def test_installed_app_exists(self):
-        '''
+        """
             Test installing an APP file that already exists
-        '''
-        with patch('salt.states.macpackage._mod_run_check') as _mod_run_check_mock, \
-                patch('os.path.exists') as exists_mock:
+        """
+        with patch("os.path.exists") as exists_mock:
             expected = {
                 'changes': {},
                 'comment': '',
@@ -232,7 +263,6 @@ class MacPackageTestCase(TestCase, LoaderModuleMockMixin):
             }
 
             install_mock = MagicMock()
-            _mod_run_check_mock.return_value = True
             exists_mock.return_value = True
 
             with patch.dict(macpackage.__salt__, {'macpackage.install_app': install_mock}):
@@ -242,11 +272,10 @@ class MacPackageTestCase(TestCase, LoaderModuleMockMixin):
                 self.assertEqual(out, expected)
 
     def test_installed_app_dmg(self):
-        '''
+        """
             Test installing an APP file contained in a DMG file
-        '''
-        with patch('salt.states.macpackage._mod_run_check') as _mod_run_check_mock, \
-                patch('os.path.exists') as exists_mock:
+        """
+        with patch("os.path.exists") as exists_mock:
             expected = {
                 'changes': {'installed': ['file.app']},
                 'comment': 'file.app installed',
@@ -257,8 +286,7 @@ class MacPackageTestCase(TestCase, LoaderModuleMockMixin):
             install_mock = MagicMock()
             mount_mock = MagicMock(return_value=['success', '/tmp/dmg-X'])
             unmount_mock = MagicMock()
-            cmd_mock = MagicMock(return_value='file.app')
-            _mod_run_check_mock.return_value = True
+            cmd_mock = MagicMock(return_value="file.app")
             exists_mock.return_value = False
 
             with patch.dict(macpackage.__salt__, {'macpackage.install_app': install_mock,
@@ -274,11 +302,10 @@ class MacPackageTestCase(TestCase, LoaderModuleMockMixin):
                 self.assertEqual(out, expected)
 
     def test_installed_app_dmg_exists(self):
-        '''
+        """
             Test installing an APP file contained in a DMG file where the file exists
-        '''
-        with patch('salt.states.macpackage._mod_run_check') as _mod_run_check_mock, \
-                patch('os.path.exists') as exists_mock:
+        """
+        with patch("os.path.exists") as exists_mock:
             expected = {
                 'changes': {},
                 'comment': '',
@@ -289,8 +316,7 @@ class MacPackageTestCase(TestCase, LoaderModuleMockMixin):
             install_mock = MagicMock()
             mount_mock = MagicMock(return_value=['success', '/tmp/dmg-X'])
             unmount_mock = MagicMock()
-            cmd_mock = MagicMock(return_value='file.app')
-            _mod_run_check_mock.return_value = True
+            cmd_mock = MagicMock(return_value="file.app")
             exists_mock.return_value = True
 
             with patch.dict(macpackage.__salt__, {'macpackage.install_app': install_mock,
@@ -329,40 +355,4 @@ class MacPackageTestCase(TestCase, LoaderModuleMockMixin):
             installed_mock.assert_called_once_with()
             get_pkg_id_mock.assert_called_once_with('/path/to/file.pkg')
             install_mock.assert_called_once_with('/path/to/file.pkg', 'LocalSystem', False, False)
-            self.assertEqual(out, expected)
-
-    def test_installed_pkg_onlyif_fail(self,):
-        '''
-            Test installing a PKG file where the onlyif call fails
-        '''
-        expected = {
-            'changes': {},
-            'comment': 'onlyif condition is false',
-            'skip_watch': True,
-            'result': True,
-            'name': '/path/to/file.pkg',
-        }
-
-        mock = MagicMock(return_value=1)
-
-        with patch.dict(macpackage.__salt__, {'cmd.retcode': mock}):
-            out = macpackage.installed('/path/to/file.pkg', onlyif='some command')
-            self.assertEqual(out, expected)
-
-    def test_installed_pkg_unless_fail(self,):
-        '''
-            Test installing a PKG file where the unless run fails
-        '''
-        expected = {
-            'changes': {},
-            'comment': 'unless condition is true',
-            'skip_watch': True,
-            'result': True,
-            'name': '/path/to/file.pkg',
-        }
-
-        mock = MagicMock(return_value=0)
-
-        with patch.dict(macpackage.__salt__, {'cmd.retcode': mock}):
-            out = macpackage.installed('/path/to/file.pkg', unless='some command')
             self.assertEqual(out, expected)

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -118,7 +118,7 @@ class StateCompilerTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
     def test_verify_onlyif_cmd_error(self):
         """
         Simulates a failure in cmd.retcode from onlyif
-        This could occur is runas is specified with a user that does not exist
+        This could occur if runas is specified with a user that does not exist
         """
         low_data = {
             "onlyif": "somecommand",
@@ -150,7 +150,7 @@ class StateCompilerTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
     def test_verify_unless_cmd_error(self):
         """
         Simulates a failure in cmd.retcode from unless
-        This could occur is runas is specified with a user that does not exist
+        This could occur if runas is specified with a user that does not exist
         """
         low_data = {
             "unless": "somecommand",
@@ -178,6 +178,166 @@ class StateCompilerTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                     low_data, {"runas": "doesntexist"}
                 )
                 self.assertEqual(expected_result, return_result)
+
+    def test_verify_unless_list_cmd(self):
+        """
+        If any of the unless commands return False (non 0) then the state should
+        run (no skip_watch).
+        """
+        low_data = {
+            "state": "cmd",
+            "name": 'echo "something"',
+            "__sls__": "tests.cmd",
+            "__env__": "base",
+            "__id__": "check unless",
+            "unless": ["exit 0", "exit 1"],
+            "order": 10001,
+            "fun": "run",
+        }
+        expected_result = {
+            "comment": "unless condition is false",
+            "result": False,
+        }
+        with patch("salt.state.State._gather_pillar") as state_patch:
+            minion_opts = self.get_temp_config("minion")
+            state_obj = salt.state.State(minion_opts)
+            return_result = state_obj._run_check_unless(low_data, {})
+            self.assertEqual(expected_result, return_result)
+
+    def test_verify_unless_list_cmd_different_order(self):
+        """
+        If any of the unless commands return False (non 0) then the state should
+        run (no skip_watch). The order shouldn't matter.
+        """
+        low_data = {
+            "state": "cmd",
+            "name": 'echo "something"',
+            "__sls__": "tests.cmd",
+            "__env__": "base",
+            "__id__": "check unless",
+            "unless": ["exit 1", "exit 0"],
+            "order": 10001,
+            "fun": "run",
+        }
+        expected_result = {
+            "comment": "unless condition is false",
+            "result": False,
+        }
+        with patch("salt.state.State._gather_pillar") as state_patch:
+            minion_opts = self.get_temp_config("minion")
+            state_obj = salt.state.State(minion_opts)
+            return_result = state_obj._run_check_unless(low_data, {})
+            self.assertEqual(expected_result, return_result)
+
+    def test_verify_onlyif_list_cmd_different_order(self):
+        low_data = {
+            "state": "cmd",
+            "name": 'echo "something"',
+            "__sls__": "tests.cmd",
+            "__env__": "base",
+            "__id__": "check onlyif",
+            "onlyif": ["exit 1", "exit 0"],
+            "order": 10001,
+            "fun": "run",
+        }
+        expected_result = {
+            "comment": "onlyif condition is false",
+            "result": True,
+            "skip_watch": True,
+        }
+        with patch("salt.state.State._gather_pillar") as state_patch:
+            minion_opts = self.get_temp_config("minion")
+            state_obj = salt.state.State(minion_opts)
+            return_result = state_obj._run_check_onlyif(low_data, {})
+            self.assertEqual(expected_result, return_result)
+
+    def test_verify_unless_list_cmd_valid(self):
+        """
+        If any of the unless commands return False (non 0) then the state should
+        run (no skip_watch). This tests all commands return False.
+        """
+        low_data = {
+            "state": "cmd",
+            "name": 'echo "something"',
+            "__sls__": "tests.cmd",
+            "__env__": "base",
+            "__id__": "check unless",
+            "unless": ["exit 1", "exit 1"],
+            "order": 10001,
+            "fun": "run",
+        }
+        expected_result = {"comment": "unless condition is false", "result": False}
+        with patch("salt.state.State._gather_pillar") as state_patch:
+            minion_opts = self.get_temp_config("minion")
+            state_obj = salt.state.State(minion_opts)
+            return_result = state_obj._run_check_unless(low_data, {})
+            self.assertEqual(expected_result, return_result)
+
+    def test_verify_onlyif_list_cmd_valid(self):
+        low_data = {
+            "state": "cmd",
+            "name": 'echo "something"',
+            "__sls__": "tests.cmd",
+            "__env__": "base",
+            "__id__": "check onlyif",
+            "onlyif": ["exit 0", "exit 0"],
+            "order": 10001,
+            "fun": "run",
+        }
+        expected_result = {"comment": "onlyif condition is true", "result": False}
+        with patch("salt.state.State._gather_pillar") as state_patch:
+            minion_opts = self.get_temp_config("minion")
+            state_obj = salt.state.State(minion_opts)
+            return_result = state_obj._run_check_onlyif(low_data, {})
+            self.assertEqual(expected_result, return_result)
+
+    def test_verify_unless_list_cmd_invalid(self):
+        """
+        If any of the unless commands return False (non 0) then the state should
+        run (no skip_watch). This tests all commands return True
+        """
+        low_data = {
+            "state": "cmd",
+            "name": 'echo "something"',
+            "__sls__": "tests.cmd",
+            "__env__": "base",
+            "__id__": "check unless",
+            "unless": ["exit 0", "exit 0"],
+            "order": 10001,
+            "fun": "run",
+        }
+        expected_result = {
+            "comment": "unless condition is true",
+            "result": True,
+            "skip_watch": True,
+        }
+        with patch("salt.state.State._gather_pillar") as state_patch:
+            minion_opts = self.get_temp_config("minion")
+            state_obj = salt.state.State(minion_opts)
+            return_result = state_obj._run_check_unless(low_data, {})
+            self.assertEqual(expected_result, return_result)
+
+    def test_verify_onlyif_list_cmd_invalid(self):
+        low_data = {
+            "state": "cmd",
+            "name": 'echo "something"',
+            "__sls__": "tests.cmd",
+            "__env__": "base",
+            "__id__": "check onlyif",
+            "onlyif": ["exit 1", "exit 1"],
+            "order": 10001,
+            "fun": "run",
+        }
+        expected_result = {
+            "comment": "onlyif condition is false",
+            "result": True,
+            "skip_watch": True,
+        }
+        with patch("salt.state.State._gather_pillar") as state_patch:
+            minion_opts = self.get_temp_config("minion")
+            state_obj = salt.state.State(minion_opts)
+            return_result = state_obj._run_check_onlyif(low_data, {})
+            self.assertEqual(expected_result, return_result)
 
     def test_verify_unless_parse(self):
         low_data = {

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -25,6 +25,16 @@ from salt.utils.odict import OrderedDict
 from salt.utils.decorators import state as statedecorators
 import salt.utils.files
 import salt.utils.platform
+from salt.exceptions import CommandExecutionError
+from salt.utils.decorators import state as statedecorators
+from salt.utils.odict import OrderedDict
+from tests.support.helpers import with_tempfile
+from tests.support.mixins import AdaptedConfigurationTestCaseMixin
+from tests.support.mock import MagicMock, patch
+from tests.support.runtests import RUNTIME_VARS
+
+# Import Salt Testing libs
+from tests.support.unit import TestCase, skipIf
 
 try:
     import pytest
@@ -105,6 +115,70 @@ class StateCompilerTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             return_result = state_obj._run_check_onlyif(low_data, '')
             self.assertEqual(expected_result, return_result)
 
+    def test_verify_onlyif_cmd_error(self):
+        """
+        Simulates a failure in cmd.retcode from onlyif
+        This could occur is runas is specified with a user that does not exist
+        """
+        low_data = {
+            "onlyif": "somecommand",
+            "runas" "doesntexist" "name": "echo something",
+            "state": "cmd",
+            "__id__": "this is just a test",
+            "fun": "run",
+            "__env__": "base",
+            "__sls__": "sometest",
+            "order": 10000,
+        }
+        expected_result = {
+            "comment": "onlyif condition is false",
+            "result": True,
+            "skip_watch": True,
+        }
+
+        with patch("salt.state.State._gather_pillar") as state_patch:
+            minion_opts = self.get_temp_config("minion")
+            state_obj = salt.state.State(minion_opts)
+            mock = MagicMock(side_effect=CommandExecutionError("Boom!"))
+            with patch.dict(state_obj.functions, {"cmd.retcode": mock}):
+                #  The mock handles the exception, but the runas dict is being passed as it would actually be
+                return_result = state_obj._run_check_onlyif(
+                    low_data, {"runas": "doesntexist"}
+                )
+                self.assertEqual(expected_result, return_result)
+
+    def test_verify_unless_cmd_error(self):
+        """
+        Simulates a failure in cmd.retcode from unless
+        This could occur is runas is specified with a user that does not exist
+        """
+        low_data = {
+            "unless": "somecommand",
+            "runas" "doesntexist" "name": "echo something",
+            "state": "cmd",
+            "__id__": "this is just a test",
+            "fun": "run",
+            "__env__": "base",
+            "__sls__": "sometest",
+            "order": 10000,
+        }
+        expected_result = {
+            "comment": "unless condition is true",
+            "result": True,
+            "skip_watch": True,
+        }
+
+        with patch("salt.state.State._gather_pillar") as state_patch:
+            minion_opts = self.get_temp_config("minion")
+            state_obj = salt.state.State(minion_opts)
+            mock = MagicMock(side_effect=CommandExecutionError("Boom!"))
+            with patch.dict(state_obj.functions, {"cmd.retcode": mock}):
+                #  The mock handles the exception, but the runas dict is being passed as it would actually be
+                return_result = state_obj._run_check_unless(
+                    low_data, {"runas": "doesntexist"}
+                )
+                self.assertEqual(expected_result, return_result)
+
     def test_verify_unless_parse(self):
         low_data = {
             "unless": [
@@ -137,6 +211,72 @@ class StateCompilerTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             state_obj = salt.state.State(minion_opts)
             return_result = state_obj._run_check_unless(low_data, '')
             self.assertEqual(expected_result, return_result)
+
+    def test_verify_creates(self):
+        low_data = {
+            "state": "cmd",
+            "name": 'echo "something"',
+            "__sls__": "tests.creates",
+            "__env__": "base",
+            "__id__": "do_a_thing",
+            "creates": "/tmp/thing",
+            "order": 10000,
+            "fun": "run",
+        }
+
+        with patch("salt.state.State._gather_pillar") as state_patch:
+            minion_opts = self.get_temp_config("minion")
+            state_obj = salt.state.State(minion_opts)
+            with patch("os.path.exists") as path_mock:
+                path_mock.return_value = True
+                expected_result = {
+                    "comment": "/tmp/thing exists",
+                    "result": True,
+                    "skip_watch": True,
+                }
+                return_result = state_obj._run_check_creates(low_data)
+                self.assertEqual(expected_result, return_result)
+
+                path_mock.return_value = False
+                expected_result = {
+                    "comment": "Creates files not found",
+                    "result": False,
+                }
+                return_result = state_obj._run_check_creates(low_data)
+                self.assertEqual(expected_result, return_result)
+
+    def test_verify_creates_list(self):
+        low_data = {
+            "state": "cmd",
+            "name": 'echo "something"',
+            "__sls__": "tests.creates",
+            "__env__": "base",
+            "__id__": "do_a_thing",
+            "creates": ["/tmp/thing", "/tmp/thing2"],
+            "order": 10000,
+            "fun": "run",
+        }
+
+        with patch("salt.state.State._gather_pillar") as state_patch:
+            minion_opts = self.get_temp_config("minion")
+            state_obj = salt.state.State(minion_opts)
+            with patch("os.path.exists") as path_mock:
+                path_mock.return_value = True
+                expected_result = {
+                    "comment": "All files in creates exist",
+                    "result": True,
+                    "skip_watch": True,
+                }
+                return_result = state_obj._run_check_creates(low_data)
+                self.assertEqual(expected_result, return_result)
+
+                path_mock.return_value = False
+                expected_result = {
+                    "comment": "Creates files not found",
+                    "result": False,
+                }
+                return_result = state_obj._run_check_creates(low_data)
+                self.assertEqual(expected_result, return_result)
 
     def _expand_win_path(self, path):
         """
@@ -183,6 +323,28 @@ class StateCompilerTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             minion_opts = self.get_temp_config('minion')
             state_obj = salt.state.State(minion_opts)
             return_result = state_obj._run_check_onlyif(low_data, '')
+            self.assertEqual(expected_result, return_result)
+
+    def test_verify_onlyif_list_cmd(self):
+        low_data = {
+            "state": "cmd",
+            "name": 'echo "something"',
+            "__sls__": "tests.cmd",
+            "__env__": "base",
+            "__id__": "check onlyif",
+            "onlyif": ["/bin/true", "/bin/false"],
+            "order": 10001,
+            "fun": "run",
+        }
+        expected_result = {
+            "comment": "onlyif condition is false",
+            "result": True,
+            "skip_watch": True,
+        }
+        with patch("salt.state.State._gather_pillar") as state_patch:
+            minion_opts = self.get_temp_config("minion")
+            state_obj = salt.state.State(minion_opts)
+            return_result = state_obj._run_check_onlyif(low_data, {})
             self.assertEqual(expected_result, return_result)
 
     @with_tempfile()

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -179,166 +179,6 @@ class StateCompilerTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
                 )
                 self.assertEqual(expected_result, return_result)
 
-    def test_verify_unless_list_cmd(self):
-        """
-        If any of the unless commands return False (non 0) then the state should
-        run (no skip_watch).
-        """
-        low_data = {
-            "state": "cmd",
-            "name": 'echo "something"',
-            "__sls__": "tests.cmd",
-            "__env__": "base",
-            "__id__": "check unless",
-            "unless": ["exit 0", "exit 1"],
-            "order": 10001,
-            "fun": "run",
-        }
-        expected_result = {
-            "comment": "unless condition is false",
-            "result": False,
-        }
-        with patch("salt.state.State._gather_pillar") as state_patch:
-            minion_opts = self.get_temp_config("minion")
-            state_obj = salt.state.State(minion_opts)
-            return_result = state_obj._run_check_unless(low_data, {})
-            self.assertEqual(expected_result, return_result)
-
-    def test_verify_unless_list_cmd_different_order(self):
-        """
-        If any of the unless commands return False (non 0) then the state should
-        run (no skip_watch). The order shouldn't matter.
-        """
-        low_data = {
-            "state": "cmd",
-            "name": 'echo "something"',
-            "__sls__": "tests.cmd",
-            "__env__": "base",
-            "__id__": "check unless",
-            "unless": ["exit 1", "exit 0"],
-            "order": 10001,
-            "fun": "run",
-        }
-        expected_result = {
-            "comment": "unless condition is false",
-            "result": False,
-        }
-        with patch("salt.state.State._gather_pillar") as state_patch:
-            minion_opts = self.get_temp_config("minion")
-            state_obj = salt.state.State(minion_opts)
-            return_result = state_obj._run_check_unless(low_data, {})
-            self.assertEqual(expected_result, return_result)
-
-    def test_verify_onlyif_list_cmd_different_order(self):
-        low_data = {
-            "state": "cmd",
-            "name": 'echo "something"',
-            "__sls__": "tests.cmd",
-            "__env__": "base",
-            "__id__": "check onlyif",
-            "onlyif": ["exit 1", "exit 0"],
-            "order": 10001,
-            "fun": "run",
-        }
-        expected_result = {
-            "comment": "onlyif condition is false",
-            "result": True,
-            "skip_watch": True,
-        }
-        with patch("salt.state.State._gather_pillar") as state_patch:
-            minion_opts = self.get_temp_config("minion")
-            state_obj = salt.state.State(minion_opts)
-            return_result = state_obj._run_check_onlyif(low_data, {})
-            self.assertEqual(expected_result, return_result)
-
-    def test_verify_unless_list_cmd_valid(self):
-        """
-        If any of the unless commands return False (non 0) then the state should
-        run (no skip_watch). This tests all commands return False.
-        """
-        low_data = {
-            "state": "cmd",
-            "name": 'echo "something"',
-            "__sls__": "tests.cmd",
-            "__env__": "base",
-            "__id__": "check unless",
-            "unless": ["exit 1", "exit 1"],
-            "order": 10001,
-            "fun": "run",
-        }
-        expected_result = {"comment": "unless condition is false", "result": False}
-        with patch("salt.state.State._gather_pillar") as state_patch:
-            minion_opts = self.get_temp_config("minion")
-            state_obj = salt.state.State(minion_opts)
-            return_result = state_obj._run_check_unless(low_data, {})
-            self.assertEqual(expected_result, return_result)
-
-    def test_verify_onlyif_list_cmd_valid(self):
-        low_data = {
-            "state": "cmd",
-            "name": 'echo "something"',
-            "__sls__": "tests.cmd",
-            "__env__": "base",
-            "__id__": "check onlyif",
-            "onlyif": ["exit 0", "exit 0"],
-            "order": 10001,
-            "fun": "run",
-        }
-        expected_result = {"comment": "onlyif condition is true", "result": False}
-        with patch("salt.state.State._gather_pillar") as state_patch:
-            minion_opts = self.get_temp_config("minion")
-            state_obj = salt.state.State(minion_opts)
-            return_result = state_obj._run_check_onlyif(low_data, {})
-            self.assertEqual(expected_result, return_result)
-
-    def test_verify_unless_list_cmd_invalid(self):
-        """
-        If any of the unless commands return False (non 0) then the state should
-        run (no skip_watch). This tests all commands return True
-        """
-        low_data = {
-            "state": "cmd",
-            "name": 'echo "something"',
-            "__sls__": "tests.cmd",
-            "__env__": "base",
-            "__id__": "check unless",
-            "unless": ["exit 0", "exit 0"],
-            "order": 10001,
-            "fun": "run",
-        }
-        expected_result = {
-            "comment": "unless condition is true",
-            "result": True,
-            "skip_watch": True,
-        }
-        with patch("salt.state.State._gather_pillar") as state_patch:
-            minion_opts = self.get_temp_config("minion")
-            state_obj = salt.state.State(minion_opts)
-            return_result = state_obj._run_check_unless(low_data, {})
-            self.assertEqual(expected_result, return_result)
-
-    def test_verify_onlyif_list_cmd_invalid(self):
-        low_data = {
-            "state": "cmd",
-            "name": 'echo "something"',
-            "__sls__": "tests.cmd",
-            "__env__": "base",
-            "__id__": "check onlyif",
-            "onlyif": ["exit 1", "exit 1"],
-            "order": 10001,
-            "fun": "run",
-        }
-        expected_result = {
-            "comment": "onlyif condition is false",
-            "result": True,
-            "skip_watch": True,
-        }
-        with patch("salt.state.State._gather_pillar") as state_patch:
-            minion_opts = self.get_temp_config("minion")
-            state_obj = salt.state.State(minion_opts)
-            return_result = state_obj._run_check_onlyif(low_data, {})
-            self.assertEqual(expected_result, return_result)
-
     def test_verify_unless_parse(self):
         low_data = {
             "unless": [
@@ -544,20 +384,23 @@ class StateCompilerTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             self.assertEqual(expected_result, return_result)
 
     def test_verify_unless_list_cmd(self):
+        """
+        If any of the unless commands return False (non 0) then the state should
+        run (no skip_watch).
+        """
         low_data = {
             "state": "cmd",
             "name": 'echo "something"',
             "__sls__": "tests.cmd",
             "__env__": "base",
             "__id__": "check unless",
-            "unless": ["/bin/true", "/bin/false"],
+            "unless": ["exit 0", "exit 1"],
             "order": 10001,
             "fun": "run",
         }
         expected_result = {
-            "comment": "unless condition is true",
-            "result": True,
-            "skip_watch": True,
+            "comment": "unless condition is false",
+            "result": False,
         }
         with patch("salt.state.State._gather_pillar") as state_patch:
             minion_opts = self.get_temp_config("minion")
@@ -566,20 +409,23 @@ class StateCompilerTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             self.assertEqual(expected_result, return_result)
 
     def test_verify_unless_list_cmd_different_order(self):
+        """
+        If any of the unless commands return False (non 0) then the state should
+        run (no skip_watch). The order shouldn't matter.
+        """
         low_data = {
             "state": "cmd",
             "name": 'echo "something"',
             "__sls__": "tests.cmd",
             "__env__": "base",
             "__id__": "check unless",
-            "unless": ["/bin/false", "/bin/true"],
+            "unless": ["exit 1", "exit 0"],
             "order": 10001,
             "fun": "run",
         }
         expected_result = {
-            "comment": "unless condition is true",
-            "result": True,
-            "skip_watch": True,
+            "comment": "unless condition is false",
+            "result": False,
         }
         with patch("salt.state.State._gather_pillar") as state_patch:
             minion_opts = self.get_temp_config("minion")
@@ -594,7 +440,7 @@ class StateCompilerTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             "__sls__": "tests.cmd",
             "__env__": "base",
             "__id__": "check onlyif",
-            "onlyif": ["/bin/false", "/bin/true"],
+            "onlyif": ["exit 1", "exit 0"],
             "order": 10001,
             "fun": "run",
         }
@@ -610,13 +456,17 @@ class StateCompilerTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             self.assertEqual(expected_result, return_result)
 
     def test_verify_unless_list_cmd_valid(self):
+        """
+        If any of the unless commands return False (non 0) then the state should
+        run (no skip_watch). This tests all commands return False.
+        """
         low_data = {
             "state": "cmd",
             "name": 'echo "something"',
             "__sls__": "tests.cmd",
             "__env__": "base",
             "__id__": "check unless",
-            "unless": ["/bin/false", "/bin/false"],
+            "unless": ["exit 1", "exit 1"],
             "order": 10001,
             "fun": "run",
         }
@@ -634,7 +484,7 @@ class StateCompilerTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             "__sls__": "tests.cmd",
             "__env__": "base",
             "__id__": "check onlyif",
-            "onlyif": ["/bin/true", "/bin/true"],
+            "onlyif": ["exit 0", "exit 0"],
             "order": 10001,
             "fun": "run",
         }
@@ -646,13 +496,17 @@ class StateCompilerTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             self.assertEqual(expected_result, return_result)
 
     def test_verify_unless_list_cmd_invalid(self):
+        """
+        If any of the unless commands return False (non 0) then the state should
+        run (no skip_watch). This tests all commands return True
+        """
         low_data = {
             "state": "cmd",
             "name": 'echo "something"',
             "__sls__": "tests.cmd",
             "__env__": "base",
             "__id__": "check unless",
-            "unless": ["/bin/true", "/bin/true"],
+            "unless": ["exit 0", "exit 0"],
             "order": 10001,
             "fun": "run",
         }
@@ -674,7 +528,7 @@ class StateCompilerTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
             "__sls__": "tests.cmd",
             "__env__": "base",
             "__id__": "check onlyif",
-            "onlyif": ["/bin/false", "/bin/false"],
+            "onlyif": ["exit 1", "exit 1"],
             "order": 10001,
             "fun": "run",
         }


### PR DESCRIPTION
### What does this PR do?
Backport of upstream https://github.com/saltstack/salt/pull/55974

### What issues does this PR fix or reference?
Fixes: [bsc#1188641](https://bugzilla.suse.com/show_bug.cgi?id=1188641)

### Previous Behavior
Various exceptions on using state.apply with state containing `onlyif` or `unless` requisites with `fun:` syntax calling for execution modules functions

### New Behavior
No exceptions