### PR TITLE
Add missing aarch64 to rpm package architectures - 3000.3

### DIFF
--- a/salt/utils/pkg/rpm.py
+++ b/salt/utils/pkg/rpm.py
@@ -30,7 +30,7 @@ ARCHES_ALPHA = (
     'alpha', 'alphaev4', 'alphaev45', 'alphaev5', 'alphaev56',
     'alphapca56', 'alphaev6', 'alphaev67', 'alphaev68', 'alphaev7'
 )
-ARCHES_ARM = ('armv5tel', 'armv5tejl', 'armv6l', 'armv7l')
+ARCHES_ARM = ('armv5tel', 'armv5tejl', 'armv6l', 'armv7l', 'aarch64')
 ARCHES_SH = ('sh3', 'sh4', 'sh4a')
 
 ARCHES = ARCHES_64 + ARCHES_32 + ARCHES_PPC + ARCHES_S390 + \

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -2125,3 +2125,23 @@ pattern() = package-c"""
             ret = zypper.list_holds()
             assert len(ret) == 1
             assert "bar-2:2.3.4-2.1.*" in ret
+
+    def test_normalize_name(self):
+        """
+        Test that package is normalized only when it should be
+        """
+        with patch.dict(zypper.__grains__, {"osarch": "x86_64"}):
+            result = zypper.normalize_name("foo")
+            assert result == "foo", result
+            result = zypper.normalize_name("foo.x86_64")
+            assert result == "foo", result
+            result = zypper.normalize_name("foo.noarch")
+            assert result == "foo", result
+
+        with patch.dict(zypper.__grains__, {"osarch": "aarch64"}):
+            result = zypper.normalize_name("foo")
+            assert result == "foo", result
+            result = zypper.normalize_name("foo.aarch64")
+            assert result == "foo", result
+            result = zypper.normalize_name("foo.noarch")
+            assert result == "foo", result


### PR DESCRIPTION
Backport of https://github.com/openSUSE/salt/pull/405 for `3000.3`