### PR TITLE
Fix error handling in openscap module (bsc#1188647)

### DIFF
--- a/salt/modules/openscap.py
+++ b/salt/modules/openscap.py
@@ -153,7 +153,9 @@ def xccdf_eval(xccdffile, ovalfiles=None, **kwargs):
         tempdir = tempfile.mkdtemp()
         proc = Popen(cmd_opts, stdout=PIPE, stderr=PIPE, cwd=tempdir)
         (stdoutdata, error) = proc.communicate()
-        success = _OSCAP_EXIT_CODES_MAP[proc.returncode]
+        success = _OSCAP_EXIT_CODES_MAP.get(proc.returncode, False)
+        if proc.returncode < 0:
+            error += "\nKilled by signal {}\n".format(proc.returncode).encode('ascii')
         returncode = proc.returncode
         if success:
             __salt__["cp.push_dir"](tempdir)
@@ -202,7 +204,9 @@ def xccdf(params):
         tempdir = tempfile.mkdtemp()
         proc = Popen(shlex.split(cmd), stdout=PIPE, stderr=PIPE, cwd=tempdir)
         (stdoutdata, error) = proc.communicate()
-        success = _OSCAP_EXIT_CODES_MAP[proc.returncode]
+        success = _OSCAP_EXIT_CODES_MAP.get(proc.returncode, False)
+        if proc.returncode < 0:
+            error += "\nKilled by signal {}\n".format(proc.returncode).encode('ascii')
         returncode = proc.returncode
         if success:
             __salt__["cp.push_dir"](tempdir)


### PR DESCRIPTION
### What does this PR do?

This fixes salt return value when openscap is killed (including OOM killer).

### What issues does this PR fix or reference?
Fixes:  https://github.com/SUSE/spacewalk/issues/15516
https://bugzilla.suse.com/show_bug.cgi?id=1188647


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
