### PR TITLE
Prevent pkg plugins errors on missing cookie path (bsc#1186738) - 3002.2

### DIFF
--- a/scripts/suse/dpkg/dpkgnotify
+++ b/scripts/suse/dpkg/dpkgnotify
@@ -35,9 +35,19 @@ def dpkg_post_invoke():
     """
     Hook after the package installation transaction.
     """
-    if 'SALT_RUNNING' not in os.environ:
-        with open(CK_PATH, 'w') as ck_fh:
-            ck_fh.write('{chksum} {mtime}\n'.format(chksum=_get_checksum(), mtime=_get_mtime()))
+    if "SALT_RUNNING" not in os.environ:
+        try:
+            ck_dir = os.path.dirname(CK_PATH)
+            if not os.path.exists(ck_dir):
+                os.makedirs(ck_dir)
+            with open(CK_PATH, "w") as ck_fh:
+                ck_fh.write(
+                    "{chksum} {mtime}\n".format(
+                        chksum=_get_checksum(), mtime=_get_mtime()
+                    )
+                )
+        except Exception:  # pylint: disable=broad-except:
+            pass
 
 
 if __name__ == "__main__":

--- a/scripts/suse/dpkg/dpkgnotify
+++ b/scripts/suse/dpkg/dpkgnotify
@@ -2,6 +2,7 @@
 
 import os
 import hashlib
+import sys
 
 CK_PATH = "/var/cache/salt/minion/dpkg.cookie"
 DPKG_PATH = "/var/lib/dpkg/status"
@@ -46,8 +47,8 @@ def dpkg_post_invoke():
                         chksum=_get_checksum(), mtime=_get_mtime()
                     )
                 )
-        except Exception:  # pylint: disable=broad-except:
-            pass
+        except (IOError, OSError) as e:
+            sys.stderr.write("Unable to save the cookie file: {}\n".format(e))
 
 
 if __name__ == "__main__":

--- a/scripts/suse/dpkg/dpkgnotify
+++ b/scripts/suse/dpkg/dpkgnotify
@@ -7,6 +7,7 @@ import sys
 CK_PATH = "/var/cache/salt/minion/dpkg.cookie"
 DPKG_PATH = "/var/lib/dpkg/status"
 
+
 def _get_mtime():
     """
     Get the modified time of the Package Database.
@@ -47,8 +48,8 @@ def dpkg_post_invoke():
                         chksum=_get_checksum(), mtime=_get_mtime()
                     )
                 )
-        except (IOError, OSError) as e:
-            sys.stderr.write("Unable to save the cookie file: {}\n".format(e))
+        except OSError as e:
+            print("Unable to save the cookie file: %s" % (e), file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/scripts/suse/yum/plugins/README.md
+++ b/scripts/suse/yum/plugins/README.md
@@ -11,7 +11,7 @@ Configuration files are going to:
 
 Plugin itself goes to:
 
-	`/usr/share/yum-plugins/[name].conf`
+	`/usr/share/yum-plugins/[name].py`
 
 ## Permissions
 

--- a/scripts/suse/yum/plugins/yumnotify.py
+++ b/scripts/suse/yum/plugins/yumnotify.py
@@ -5,7 +5,6 @@
 
 import hashlib
 import os
-import sys
 
 from yum import config
 from yum.plugins import TYPE_CORE
@@ -53,15 +52,7 @@ def posttrans_hook(conduit):
     """
     # Integrate Yum with Salt
     if "SALT_RUNNING" not in os.environ:
-        try:
-            ck_dir = os.path.dirname(CK_PATH)
-            if not os.path.exists(ck_dir):
-                os.makedirs(ck_dir)
-            with open(CK_PATH, "w") as ck_fh:
-                ck_fh.write(
-                    "{chksum} {mtime}\n".format(
-                        chksum=_get_checksum(), mtime=_get_mtime()
-                    )
-                )
-        except (IOError, OSError) as e:
-            sys.stderr.write("Unable to save the cookie file: {}\n".format(e))
+        with open(CK_PATH, "w") as ck_fh:
+            ck_fh.write(
+                "{chksum} {mtime}\n".format(chksum=_get_checksum(), mtime=_get_mtime())
+            )

--- a/scripts/suse/yum/plugins/yumnotify.py
+++ b/scripts/suse/yum/plugins/yumnotify.py
@@ -5,6 +5,7 @@
 
 import hashlib
 import os
+import sys
 
 from yum import config
 from yum.plugins import TYPE_CORE
@@ -52,7 +53,15 @@ def posttrans_hook(conduit):
     """
     # Integrate Yum with Salt
     if "SALT_RUNNING" not in os.environ:
-        with open(CK_PATH, "w") as ck_fh:
-            ck_fh.write(
-                "{chksum} {mtime}\n".format(chksum=_get_checksum(), mtime=_get_mtime())
-            )
+        try:
+            ck_dir = os.path.dirname(CK_PATH)
+            if not os.path.exists(ck_dir):
+                os.makedirs(ck_dir)
+            with open(CK_PATH, "w") as ck_fh:
+                ck_fh.write(
+                    "{chksum} {mtime}\n".format(
+                        chksum=_get_checksum(), mtime=_get_mtime()
+                    )
+                )
+        except OSError as e:
+            print("Unable to save the cookie file: %s" % (e), file=sys.stderr)

--- a/scripts/suse/yum/plugins/yumnotify.py
+++ b/scripts/suse/yum/plugins/yumnotify.py
@@ -5,6 +5,7 @@
 
 import hashlib
 import os
+import sys
 
 from yum import config
 from yum.plugins import TYPE_CORE
@@ -62,5 +63,5 @@ def posttrans_hook(conduit):
                         chksum=_get_checksum(), mtime=_get_mtime()
                     )
                 )
-        except Exception:  # pylint: disable=broad-except:
-            pass
+        except (IOError, OSError) as e:
+            sys.stderr.write("Unable to save the cookie file: {}\n".format(e))

--- a/scripts/suse/yum/plugins/yumnotify.py
+++ b/scripts/suse/yum/plugins/yumnotify.py
@@ -52,7 +52,15 @@ def posttrans_hook(conduit):
     """
     # Integrate Yum with Salt
     if "SALT_RUNNING" not in os.environ:
-        with open(CK_PATH, "w") as ck_fh:
-            ck_fh.write(
-                "{chksum} {mtime}\n".format(chksum=_get_checksum(), mtime=_get_mtime())
-            )
+        try:
+            ck_dir = os.path.dirname(CK_PATH)
+            if not os.path.exists(ck_dir):
+                os.makedirs(ck_dir)
+            with open(CK_PATH, "w") as ck_fh:
+                ck_fh.write(
+                    "{chksum} {mtime}\n".format(
+                        chksum=_get_checksum(), mtime=_get_mtime()
+                    )
+                )
+        except Exception:  # pylint: disable=broad-except:
+            pass

--- a/scripts/suse/zypper/plugins/commit/zyppnotify
+++ b/scripts/suse/zypper/plugins/commit/zyppnotify
@@ -65,8 +65,8 @@ class DriftDetector(Plugin):
                             chksum=self._get_checksum(), mtime=self._get_mtime()
                         )
                     )
-            except Exception:  # pylint: disable=broad-except:
-                pass
+            except (IOError, OSError) as e:
+                sys.stderr.write("Unable to save the cookie file: {}\n".format(e))
 
         self.ack()
 

--- a/scripts/suse/zypper/plugins/commit/zyppnotify
+++ b/scripts/suse/zypper/plugins/commit/zyppnotify
@@ -52,15 +52,21 @@ class DriftDetector(Plugin):
 
     def PLUGINEND(self, headers, body):
         """
-        Hook when plugin closes Zypper's transaction.        
+        Hook when plugin closes Zypper's transaction.
         """
         if "SALT_RUNNING" not in os.environ:
-            with open(self.ck_path, "w") as ck_fh:
-                ck_fh.write(
-                    "{chksum} {mtime}\n".format(
-                        chksum=self._get_checksum(), mtime=self._get_mtime()
+            try:
+                ck_dir = os.path.dirname(self.ck_path)
+                if not os.path.exists(ck_dir):
+                   os.makedirs(ck_dir)
+                with open(self.ck_path, "w") as ck_fh:
+                    ck_fh.write(
+                        "{chksum} {mtime}\n".format(
+                            chksum=self._get_checksum(), mtime=self._get_mtime()
+                        )
                     )
-                )
+            except Exception:  # pylint: disable=broad-except:
+                pass
 
         self.ack()
 

--- a/scripts/suse/zypper/plugins/commit/zyppnotify
+++ b/scripts/suse/zypper/plugins/commit/zyppnotify
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 #
 # Copyright (c) 2016 SUSE Linux LLC
 # All Rights Reserved.
@@ -58,15 +58,15 @@ class DriftDetector(Plugin):
             try:
                 ck_dir = os.path.dirname(self.ck_path)
                 if not os.path.exists(ck_dir):
-                   os.makedirs(ck_dir)
+                    os.makedirs(ck_dir)
                 with open(self.ck_path, "w") as ck_fh:
                     ck_fh.write(
                         "{chksum} {mtime}\n".format(
                             chksum=self._get_checksum(), mtime=self._get_mtime()
                         )
                     )
-            except (IOError, OSError) as e:
-                sys.stderr.write("Unable to save the cookie file: {}\n".format(e))
+            except OSError as e:
+                print("Unable to save the cookie file: %s" % (e), file=sys.stderr)
 
         self.ack()
 


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/15079

### Previous Behavior
Exceptions in case if salt-minion cache path does not exist yet, mosty relevant for Debian/Ubuntu as cache path is created only on salt-minion start.

### New Behavior
No exceptions.
