### PR TITLE
templates: move the globals up to the Environment (Jinja2 3.0.0)

### DIFF
--- a/changelog/55159.fixed
+++ b/changelog/55159.fixed
@@ -1,0 +1,1 @@
+Jinja renderer resolves wrong relative paths when importing subdirectories

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -151,7 +151,7 @@ class SaltCacheLoader(BaseLoader):
                     'Relative path "%s" cannot be resolved without an environment',
                     template
                 )
-                raise TemplateNotFound
+                raise TemplateNotFound(template)
             base_path = environment.globals['tpldir']
             _template = os.path.normpath('/'.join((base_path, _template)))
             if _template.split('/', 1)[0] == '..':

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -389,9 +389,9 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
             )
             decoded_context[key] = salt.utils.data.decode(value)
 
+    jinja_env.globals.update(decoded_context)
     try:
         template = jinja_env.from_string(tmplstr)
-        template.globals.update(decoded_context)
         output = template.render(**decoded_context)
     except jinja2.exceptions.UndefinedError as exc:
         trace = traceback.extract_tb(sys.exc_info()[2])

--- a/tests/unit/utils/test_jinja.py
+++ b/tests/unit/utils/test_jinja.py
@@ -595,6 +595,22 @@ class TestGetTemplate(TestCase):
             dict(opts=self.local_opts, saltenv='test', salt=self.local_salt)
         )
 
+    def test_relative_include(self):
+        template = "{% include './hello_import' %}"
+        expected = "Hey world !a b !"
+        filename = os.path.join(self.template_dir, "hello_import")
+        with salt.utils.files.fopen(filename) as fp_:
+            out = render_jinja_tmpl(
+                template,
+                dict(
+                    opts=self.local_opts,
+                    saltenv="test",
+                    salt=self.local_salt,
+                    tpldir=self.template_dir,
+                ),
+            )
+        self.assertEqual(out, expected)
+
 
 class TestJinjaDefaultOptions(TestCase):
 


### PR DESCRIPTION
### What does this PR do?
When creating a Jinja2 environment, we populate the globals in the
Template object that we generate from the environment.  This cause a
problem when there is a {% include "./file.sls" %} in the template, as
cannot find in the environment globals information like the "tpldir",
for example, making the relative path to be unresolved.

Seems that in Jinja2 2.X this behaviour is not present, so attaching the
globals to the Template will make the include to work, but since Jinja2
3.0.0 this is not the case.  Maybe related with the re-architecture from
pallets/jinja#295

This patch populate the globals in the Environment level, making this
and other variables reachable by the Jinja templates.

Also fix a wrong call to TemplateNotFound

### What issues does this PR fix or reference?
Fixes: #55159

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Upstream: https://github.com/saltstack/salt/pull/60811