### PR TITLE
Fix file.find tracebacks with non utf8 file names (bsc#1190114) - 3000.3

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1078,6 +1078,10 @@ def find(path, *args, **kwargs):
         return 'error: {0}'.format(ex)
 
     ret = [item for i in [finder.find(p) for p in glob.glob(os.path.expanduser(path))] for item in i]
+    if six.PY2:
+        ret = [i.decode('utf-8', 'replace') if isinstance(i, str) else i for i in ret]
+    else:
+        ret = [i.encode('utf-8', 'replace').decode('utf-8') for i in ret]
     ret.sort()
     return ret
 

--- a/salt/utils/find.py
+++ b/salt/utils/find.py
@@ -648,7 +648,10 @@ class Finder(object):
             depth = path_depth(relpath) + 1
             if depth >= self.mindepth and (self.maxdepth is None or self.maxdepth >= depth):
                 for name in dirs + files:
-                    fullpath = os.path.join(dirpath, name)
+                    try:
+                        fullpath = os.path.join(dirpath, name)
+                    except UnicodeDecodeError:
+                        fullpath = os.path.join(dirpath.encode('utf-8'), name)
                     match, fstat = self._check_criteria(dirpath, name, fullpath)
                     if match:
                         for result in self._perform_actions(fullpath, fstat=fstat):

--- a/salt/utils/path.py
+++ b/salt/utils/path.py
@@ -453,4 +453,4 @@ def os_walk(top, *args, **kwargs):
     else:
         top_query = salt.utils.stringutils.to_str(top)
     for item in os.walk(top_query, *args, **kwargs):
-        yield salt.utils.data.decode(item, preserve_tuples=True)
+        yield salt.utils.data.decode(item, keep=True, preserve_tuples=True)


### PR DESCRIPTION
### What does this PR do?

Fixes tracebacks on calling `file.find` if the directory contains non utf8 characters
Port of https://github.com/openSUSE/salt/pull/427 to `3000.3`

### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/15792

### Previous Behavior
Tracebacks if `file.find` called for firectory containing non utf8 characters in the file names inside directory.
`3002.2` has no such issue

### New Behavior
Normal output on calling `file.find`.
