### PR TITLE
Fix traceback.*_exc() calls

### DIFF
--- a/changelog/60330.fixed
+++ b/changelog/60330.fixed
@@ -1,0 +1,1 @@
+Avoid exceptions when handling some exception cases.

--- a/salt/modules/zcbuildout.py
+++ b/salt/modules/zcbuildout.py
@@ -121,7 +121,7 @@ def _salt_callback(func, **kwargs):
                             out=out.get("out", out),
                         )
         except Exception:  # pylint: disable=broad-except
-            trace = traceback.format_exc(None)
+            trace = traceback.format_exc()
             LOG.error(trace)
             _invalid(status)
         LOG.clear()

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -894,7 +894,7 @@ def hypermedia_handler(*args, **kwargs):
 
         ret = {
             "status": cherrypy.response.status,
-            "return": "{}".format(traceback.format_exc(exc))
+            "return": "{}".format(traceback.format_exc())
             if cherrypy.config["debug"]
             else "An unexpected error occurred",
         }

--- a/salt/states/zcbuildout.py
+++ b/salt/states/zcbuildout.py
@@ -58,7 +58,7 @@ def __virtual__():
     return (False, "buildout module could not be loaded")
 
 
-INVALID_RESPONSE = "We did not get any expectable answer from docker"
+INVALID_RESPONSE = "Unexpected response from docker"
 VALID_RESPONSE = ""
 NOTSET = object()
 MAPPING_CACHE = {}

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -200,7 +200,7 @@ class OptionParser(optparse.OptionParser):
                 logger.exception(err)
                 self.error(
                     "Error while processing {}: {}".format(
-                        process_option_func, traceback.format_exc(err)
+                        process_option_func, traceback.format_exc()
                     )
                 )
 
@@ -214,7 +214,7 @@ class OptionParser(optparse.OptionParser):
                 logger.exception(err)
                 self.error(
                     "Error while processing {}: {}".format(
-                        mixin_after_parsed_func, traceback.format_exc(err)
+                        mixin_after_parsed_func, traceback.format_exc()
                     )
                 )
 
@@ -260,7 +260,7 @@ class OptionParser(optparse.OptionParser):
                 logger.error(
                     "Error while processing %s: %s",
                     str(mixin_before_exit_func),
-                    traceback.format_exc(err),
+                    traceback.format_exc(),
                 )
         if self._setup_mp_logging_listener_ is True:
             # Stop logging through the queue

--- a/tests/unit/modules/test_zcbuildout.py
+++ b/tests/unit/modules/test_zcbuildout.py
@@ -199,11 +199,7 @@ class BuildoutTestCase(Base):
         ret2 = buildout._salt_callback(callback2)(2, b=6)
         self.assertEqual(ret2["status"], False)
         self.assertTrue(ret2["logs_by_level"]["error"][0].startswith("Traceback"))
-        self.assertTrue(
-            "We did not get any "
-            "expectable answer "
-            "from buildout" in ret2["comment"]
-        )
+        self.assertTrue("Unexpected response from buildout" in ret2["comment"])
         self.assertEqual(ret2["out"], None)
         for l in buildout.LOG.levels:
             self.assertTrue(0 == len(buildout.LOG.by_level[l]))

--- a/tests/unit/states/test_pip_state.py
+++ b/tests/unit/states/test_pip_state.py
@@ -450,15 +450,15 @@ class PipStateInstallationErrorTest(TestCase):
             import salt.states.pip_state
             salt.states.pip_state.InstallationError
         except ImportError as exc:
-            traceback.print_exc(exc, file=sys.stdout)
+            traceback.print_exc(file=sys.stdout)
             sys.stdout.flush()
             sys.exit(1)
         except AttributeError as exc:
-            traceback.print_exc(exc, file=sys.stdout)
+            traceback.print_exc(file=sys.stdout)
             sys.stdout.flush()
             sys.exit(2)
         except Exception as exc:
-            traceback.print_exc(exc, file=sys.stdout)
+            traceback.print_exc(file=sys.stdout)
             sys.stdout.flush()
             sys.exit(3)
         sys.exit(0)

--- a/tests/unit/states/test_zcbuildout.py
+++ b/tests/unit/states/test_zcbuildout.py
@@ -56,9 +56,7 @@ class BuildoutTestCase(Base):
     def test_error(self):
         b_dir = os.path.join(self.tdir, "e")
         ret = buildout.installed(b_dir, python=self.py_st)
-        self.assertTrue(
-            "We did not get any expectable answer from buildout" in ret["comment"]
-        )
+        self.assertTrue("Unexpected response from buildout" in ret["comment"])
         self.assertFalse(ret["result"])
 
     @slowTest


### PR DESCRIPTION
### What does this PR do?

Fixes some of the tracebacks found during investigating https://github.com/SUSE/spacewalk/issues/14307
`traceback.format_exc()` called with parameter not required there

### Previous Behavior
Tracebacks on handling tracebacks.

### New Behavior
Proper tracebacks handling
