### PR TITLE
Fix traceback.*_exc() calls

### DIFF
--- a/changelog/60330.fixed
+++ b/changelog/60330.fixed
@@ -1,0 +1,1 @@
+Avoid exceptions when handling some exception cases.

--- a/salt/modules/zcbuildout.py
+++ b/salt/modules/zcbuildout.py
@@ -120,7 +120,7 @@ def _salt_callback(func, **kwargs):
                                              comment=out.get('comment', ''),
                                              out=out.get('out', out))
         except Exception:  # pylint: disable=broad-except
-            trace = traceback.format_exc(None)
+            trace = traceback.format_exc()
             LOG.error(trace)
             _invalid(status)
         LOG.clear()

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -225,7 +225,7 @@ class OptionParser(optparse.OptionParser, object):
                 logger.exception(err)
                 self.error(
                     'Error while processing {0}: {1}'.format(
-                        process_option_func, traceback.format_exc(err)
+                        process_option_func, traceback.format_exc()
                     )
                 )
 
@@ -237,7 +237,7 @@ class OptionParser(optparse.OptionParser, object):
                 logger.exception(err)
                 self.error(
                     'Error while processing {0}: {1}'.format(
-                        mixin_after_parsed_func, traceback.format_exc(err)
+                        mixin_after_parsed_func, traceback.format_exc()
                     )
                 )
 
@@ -278,7 +278,7 @@ class OptionParser(optparse.OptionParser, object):
                 logger.exception(err)
                 logger.error('Error while processing %s: %s',
                              six.text_type(mixin_before_exit_func),
-                             traceback.format_exc(err))
+                             traceback.format_exc())
         if self._setup_mp_logging_listener_ is True:
             # Stop logging through the queue
             log.shutdown_multiprocessing_logging()

--- a/tests/unit/states/test_pip_state.py
+++ b/tests/unit/states/test_pip_state.py
@@ -346,15 +346,15 @@ class PipStateInstallationErrorTest(TestCase):
             import salt.states.pip_state
             salt.states.pip_state.InstallationError
         except ImportError as exc:
-            traceback.print_exc(exc, file=sys.stdout)
+            traceback.print_exc(file=sys.stdout)
             sys.stdout.flush()
             sys.exit(1)
         except AttributeError as exc:
-            traceback.print_exc(exc, file=sys.stdout)
+            traceback.print_exc(file=sys.stdout)
             sys.stdout.flush()
             sys.exit(2)
         except Exception as exc:
-            traceback.print_exc(exc, file=sys.stdout)
+            traceback.print_exc(file=sys.stdout)
             sys.stdout.flush()
             sys.exit(3)
         sys.exit(0)


### PR DESCRIPTION
### What does this PR do?

Port of https://github.com/openSUSE/salt/pull/429 to `3000`

Fixes some of the tracebacks found during investigating https://github.com/SUSE/spacewalk/issues/14307
`traceback.format_exc()` called with parameter not required there

### Previous Behavior
Tracebacks on handling tracebacks.

### New Behavior
Proper tracebacks handling
