### PR TITLE
Fix traceback.print_exc calls for test_pip_state

### DIFF
--- a/tests/unit/states/test_pip_state.py
+++ b/tests/unit/states/test_pip_state.py
@@ -439,15 +439,15 @@ class PipStateInstallationErrorTest(TestCase):
             import salt.states.pip_state
             salt.states.pip_state.InstallationError
         except ImportError as exc:
-            traceback.print_exc(exc, file=sys.stdout)
+            traceback.print_exc(file=sys.stdout)
             sys.stdout.flush()
             sys.exit(1)
         except AttributeError as exc:
-            traceback.print_exc(exc, file=sys.stdout)
+            traceback.print_exc(file=sys.stdout)
             sys.stdout.flush()
             sys.exit(2)
         except Exception as exc:
-            traceback.print_exc(exc, file=sys.stdout)
+            traceback.print_exc(file=sys.stdout)
             sys.stdout.flush()
             sys.exit(3)
         sys.exit(0)


### PR DESCRIPTION
Rest part of porting https://github.com/openSUSE/salt/pull/429 to `3003.3`