### PR TITLE
3003.3: Mock ip_addrs() in utils/minions.py unit test

### DIFF
--- a/tests/pytests/unit/utils/test_minions.py
+++ b/tests/pytests/unit/utils/test_minions.py
@@ -8,15 +8,16 @@ def test_connected_ids():
     test ckminion connected_ids when
     local_port_tcp returns 127.0.0.1
     """
-    opts = {"publish_port": 4505}
+    opts = {"publish_port": 4505, "minion_data_cache": True}
     minion = "minion"
-    ip = salt.utils.network.ip_addrs()
-    mdata = {"grains": {"ipv4": ip, "ipv6": []}}
-    ckminions = salt.utils.minions.CkMinions({"minion_data_cache": True})
+    ips = {"203.0.113.1", "203.0.113.2"}
+    mdata = {"grains": {"ipv4": ips, "ipv6": []}}
+    patch_ip_addrs = patch("salt.utils.network.local_port_tcp", return_value=ips)
     patch_net = patch("salt.utils.network.local_port_tcp", return_value={"127.0.0.1"})
     patch_list = patch("salt.cache.Cache.list", return_value=[minion])
     patch_fetch = patch("salt.cache.Cache.fetch", return_value=mdata)
-    with patch.dict(ckminions.opts, opts):
-        with patch_net, patch_list, patch_fetch:
-            ret = ckminions.connected_ids()
-            assert ret == {minion}
+
+    ckminions = salt.utils.minions.CkMinions(opts)
+    with patch_net, patch_ip_addrs, patch_list, patch_fetch:
+        ret = ckminions.connected_ids()
+        assert ret == {minion}


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/saltstack/salt/pull/60324 before it was rebased. Upstream approved this [commit](https://github.com/saltstack/salt/commit/e144f37f744e25fcc61d957103d2f08fe97cc280) which I cherry-picked for this PR.

Should stop the flakiness in GH Actions


