### PR TITLE
dnfnotify pkgset plugin implementation - 3002.2

### DIFF
--- a/scripts/suse/dnf/plugins/README.md
+++ b/scripts/suse/dnf/plugins/README.md
@@ -1,0 +1,21 @@
+## What it is
+
+Plugin which provides a notification mechanism to Salt, if DNF is
+used outside of it.
+
+## Installation
+
+Configuration files are going to:
+
+	`/etc/dnf/plugins/[name].conf`
+
+Plugin itself goes to:
+
+	`%{python_sitelib}/dnf-plugins/[name].py`
+	The path to dnf-plugins directory is Python version dependant.
+
+## Permissions
+
+User:  root
+Group: root
+Mode:  644

--- a/scripts/suse/dnf/plugins/dnfnotify.conf
+++ b/scripts/suse/dnf/plugins/dnfnotify.conf
@@ -1,0 +1,2 @@
+[main]
+enabled = 1

--- a/scripts/suse/dnf/plugins/dnfnotify.py
+++ b/scripts/suse/dnf/plugins/dnfnotify.py
@@ -1,0 +1,52 @@
+import dnf
+import hashlib
+import os
+
+
+class DnfNotifyPlugin(dnf.Plugin):
+    def __init__(self, base, cli):
+        super(DnfNotifyPlugin, self).__init__(base, cli)
+        self.base = base
+        self.cookie_file = "/var/cache/salt/minion/rpmdb.cookie"
+        if os.path.exists("/var/lib/rpm/rpmdb.sqlite"):
+            self.rpmdb_file = "/var/lib/rpm/rpmdb.sqlite"
+        else:
+            self.rpmdb_file = "/var/lib/rpm/Packages"
+
+    def transaction(self):
+        if "SALT_RUNNING" not in os.environ:
+            with open(self.cookie_file, "w") as ck_fh:
+                ck_fh.write(
+                    "{chksum} {mtime}\n".format(
+                        chksum=self._get_checksum(), mtime=self._get_mtime()
+                    )
+                )
+
+    def _get_mtime(self):
+        """
+        Get the modified time of the RPM Database.
+
+        Returns:
+            Unix ticks
+        """
+        return (
+            os.path.exists(self.rpmdb_file)
+            and int(os.path.getmtime(self.rpmdb_file))
+            or 0
+        )
+
+    def _get_checksum(self):
+        """
+        Get the checksum of the RPM Database.
+
+        Returns:
+            hexdigest
+        """
+        digest = hashlib.sha256()
+        with open(self.rpmdb_file, "rb") as rpm_db_fh:
+            while True:
+                buff = rpm_db_fh.read(0x1000)
+                if not buff:
+                    break
+                digest.update(buff)
+        return digest.hexdigest()

--- a/scripts/suse/dnf/plugins/dnfnotify.py
+++ b/scripts/suse/dnf/plugins/dnfnotify.py
@@ -1,9 +1,8 @@
-from dnfpluginscore import _, logger
-
 import hashlib
 import os
 
 import dnf
+from dnfpluginscore import _, logger
 
 
 class DnfNotifyPlugin(dnf.Plugin):

--- a/scripts/suse/dnf/plugins/dnfnotify.py
+++ b/scripts/suse/dnf/plugins/dnfnotify.py
@@ -1,11 +1,12 @@
-import dnf
 import hashlib
 import os
+
+import dnf
 
 
 class DnfNotifyPlugin(dnf.Plugin):
     def __init__(self, base, cli):
-        super(DnfNotifyPlugin, self).__init__(base, cli)
+        super().__init__(base, cli)
         self.base = base
         self.cookie_file = "/var/cache/salt/minion/rpmdb.cookie"
         if os.path.exists("/var/lib/rpm/rpmdb.sqlite"):

--- a/scripts/suse/dnf/plugins/dnfnotify.py
+++ b/scripts/suse/dnf/plugins/dnfnotify.py
@@ -1,3 +1,5 @@
+from dnfpluginscore import _, logger
+
 import hashlib
 import os
 
@@ -16,12 +18,15 @@ class DnfNotifyPlugin(dnf.Plugin):
 
     def transaction(self):
         if "SALT_RUNNING" not in os.environ:
-            with open(self.cookie_file, "w") as ck_fh:
-                ck_fh.write(
-                    "{chksum} {mtime}\n".format(
-                        chksum=self._get_checksum(), mtime=self._get_mtime()
+            try:
+                with open(self.cookie_file, "w") as ck_fh:
+                    ck_fh.write(
+                        "{chksum} {mtime}\n".format(
+                            chksum=self._get_checksum(), mtime=self._get_mtime()
+                        )
                     )
-                )
+            except OSError:
+                logger.error(_("Unable to save cookie file: %s"), self.cookie_file)
 
     def _get_mtime(self):
         """

--- a/scripts/suse/dnf/plugins/dnfnotify.py
+++ b/scripts/suse/dnf/plugins/dnfnotify.py
@@ -19,6 +19,9 @@ class DnfNotifyPlugin(dnf.Plugin):
     def transaction(self):
         if "SALT_RUNNING" not in os.environ:
             try:
+                ck_dir = os.path.dirname(self.cookie_file)
+                if not os.path.exists(ck_dir):
+                    os.makedirs(ck_dir)
                 with open(self.cookie_file, "w") as ck_fh:
                     ck_fh.write(
                         "{chksum} {mtime}\n".format(

--- a/scripts/suse/dnf/plugins/dnfnotify.py
+++ b/scripts/suse/dnf/plugins/dnfnotify.py
@@ -28,8 +28,8 @@ class DnfNotifyPlugin(dnf.Plugin):
                             chksum=self._get_checksum(), mtime=self._get_mtime()
                         )
                     )
-            except OSError:
-                logger.error(_("Unable to save cookie file: %s"), self.cookie_file)
+            except OSError as e:
+                logger.error(_("Unable to save cookie file: %s"), e)
 
     def _get_mtime(self):
         """


### PR DESCRIPTION
### What does this PR do?

Implements `dnfnotify` plugin for `pkgset` beacon.
`yumnotify` is not working with DNF as dnf itself is not invoking Yum plugins.

### Previous Behavior
Cookie file is not updated on installed packages list change

### New Behavior
`pkgset` works the same way as Zypper and Yum notify plugins

### Upstream PR
https://github.com/saltstack/salt/pull/61179