### PR TITLE
Prevent pkg plugins errors on missing cookie path (bsc#1186738) - 3000

### DIFF
--- a/scripts/suse/dpkg/dpkgnotify
+++ b/scripts/suse/dpkg/dpkgnotify
@@ -1,10 +1,12 @@
-#!/usr/bin/python3
+#!/usr/bin/python
 
 import os
 import hashlib
+import sys
 
 CK_PATH = "/var/cache/salt/minion/dpkg.cookie"
 DPKG_PATH = "/var/lib/dpkg/status"
+
 
 def _get_mtime():
     """
@@ -35,9 +37,19 @@ def dpkg_post_invoke():
     """
     Hook after the package installation transaction.
     """
-    if 'SALT_RUNNING' not in os.environ:
-        with open(CK_PATH, 'w') as ck_fh:
-            ck_fh.write('{chksum} {mtime}\n'.format(chksum=_get_checksum(), mtime=_get_mtime()))
+    if "SALT_RUNNING" not in os.environ:
+        try:
+            ck_dir = os.path.dirname(CK_PATH)
+            if not os.path.exists(ck_dir):
+                os.makedirs(ck_dir)
+            with open(CK_PATH, "w") as ck_fh:
+                ck_fh.write(
+                    "{chksum} {mtime}\n".format(
+                        chksum=_get_checksum(), mtime=_get_mtime()
+                    )
+                )
+        except (IOError, OSError) as e:
+            sys.stderr.write("Unable to save the cookie file: %s\n" % (e))
 
 
 if __name__ == "__main__":

--- a/scripts/suse/yum/plugins/README.md
+++ b/scripts/suse/yum/plugins/README.md
@@ -11,7 +11,7 @@ Configuration files are going to:
 
 Plugin itself goes to:
 
-	`/usr/share/yum-plugins/[name].conf`
+	`/usr/share/yum-plugins/[name].py`
 
 ## Permissions
 

--- a/scripts/suse/yum/plugins/yumnotify.py
+++ b/scripts/suse/yum/plugins/yumnotify.py
@@ -3,15 +3,17 @@
 #
 # Author: Bo Maryniuk <bo@suse.de>
 
-from yum.plugins import TYPE_CORE
-from yum import config
-import os
 import hashlib
+import os
+import sys
+
+from yum import config
+from yum.plugins import TYPE_CORE
 
 CK_PATH = "/var/cache/salt/minion/rpmdb.cookie"
 RPM_PATH = "/var/lib/rpm/Packages"
 
-requires_api_version = '2.5'
+requires_api_version = "2.5"
 plugin_type = TYPE_CORE
 
 
@@ -50,6 +52,16 @@ def posttrans_hook(conduit):
     :return:
     """
     # Integrate Yum with Salt
-    if 'SALT_RUNNING' not in os.environ:
-        with open(CK_PATH, 'w') as ck_fh:
-            ck_fh.write('{chksum} {mtime}\n'.format(chksum=_get_checksum(), mtime=_get_mtime()))
+    if "SALT_RUNNING" not in os.environ:
+        try:
+            ck_dir = os.path.dirname(CK_PATH)
+            if not os.path.exists(ck_dir):
+                os.makedirs(ck_dir)
+            with open(CK_PATH, "w") as ck_fh:
+                ck_fh.write(
+                    "{chksum} {mtime}\n".format(
+                        chksum=_get_checksum(), mtime=_get_mtime()
+                    )
+                )
+        except (IOError, OSError) as e:
+            sys.stderr.write("Unable to save the cookie file: %s\n" % (e))

--- a/scripts/suse/zypper/plugins/commit/zyppnotify
+++ b/scripts/suse/zypper/plugins/commit/zyppnotify
@@ -5,9 +5,9 @@
 #
 # Author: Bo Maryniuk <bo@suse.de>
 
-import sys
-import os
 import hashlib
+import os
+import sys
 
 from zypp_plugin import Plugin
 
@@ -16,6 +16,7 @@ class DriftDetector(Plugin):
     """
     Return diff of the installed packages outside the Salt.
     """
+
     def __init__(self):
         Plugin.__init__(self)
         self.ck_path = "/var/cache/salt/minion/rpmdb.cookie"
@@ -24,19 +25,21 @@ class DriftDetector(Plugin):
             self.rpm_path = "/var/lib/rpm/Packages"
 
     def _get_mtime(self):
-        '''
+        """
         Get the modified time of the RPM Database.
         Returns:
             Unix ticks
-        '''
-        return os.path.exists(self.rpm_path) and int(os.path.getmtime(self.rpm_path)) or 0
+        """
+        return (
+            os.path.exists(self.rpm_path) and int(os.path.getmtime(self.rpm_path)) or 0
+        )
 
     def _get_checksum(self):
-        '''
+        """
         Get the checksum of the RPM Database.
         Returns:
             hexdigest
-        '''
+        """
         digest = hashlib.sha256()
         with open(self.rpm_path, "rb") as rpm_db_fh:
             while True:
@@ -49,11 +52,21 @@ class DriftDetector(Plugin):
 
     def PLUGINEND(self, headers, body):
         """
-        Hook when plugin closes Zypper's transaction.        
+        Hook when plugin closes Zypper's transaction.
         """
-        if 'SALT_RUNNING' not in os.environ:
-            with open(self.ck_path, 'w') as ck_fh:
-                ck_fh.write('{chksum} {mtime}\n'.format(chksum=self._get_checksum(), mtime=self._get_mtime()))
+        if "SALT_RUNNING" not in os.environ:
+            try:
+                ck_dir = os.path.dirname(self.ck_path)
+                if not os.path.exists(ck_dir):
+                    os.makedirs(ck_dir)
+                with open(self.ck_path, "w") as ck_fh:
+                    ck_fh.write(
+                        "{chksum} {mtime}\n".format(
+                            chksum=self._get_checksum(), mtime=self._get_mtime()
+                        )
+                    )
+            except (IOError, OSError) as e:
+                sys.stderr.write("Unable to save the cookie file: %s\n" % (e))
 
         self.ack()
 


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/openSUSE/salt/pull/415 to `3000`

### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/15079

### Previous Behavior
Exceptions in case if salt-minion cache path does not exist yet, mosty relevant for Debian/Ubuntu as cache path is created only on salt-minion start.

### New Behavior
No exceptions.
