### PR TITLE
Remove wrong _parse_cpe_name from grains.core (bsc#1191956) - 3002.2

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1748,36 +1748,6 @@ def _parse_cpe_name(cpe):
     return ret
 
 
-def _parse_cpe_name(cpe):
-    """
-    Parse CPE_NAME data from the os-release
-
-    Info: https://csrc.nist.gov/projects/security-content-automation-protocol/scap-specifications/cpe
-
-    :param cpe:
-    :return:
-    """
-    part = {
-        "o": "operating system",
-        "h": "hardware",
-        "a": "application",
-    }
-    ret = {}
-    cpe = (cpe or "").split(":")
-    if len(cpe) > 4 and cpe[0] == "cpe":
-        if cpe[1].startswith("/"):  # WFN to URI
-            ret["vendor"], ret["product"], ret["version"] = cpe[2:5]
-            ret["phase"] = cpe[5] if len(cpe) > 5 else None
-            ret["part"] = part.get(cpe[1][1:])
-        elif len(cpe) == 13 and cpe[1] == "2.3":  # WFN to a string
-            ret["vendor"], ret["product"], ret["version"], ret["phase"] = [
-                x if x != "*" else None for x in cpe[3:7]
-            ]
-            ret["part"] = part.get(cpe[2])
-
-    return ret
-
-
 def os_data():
     """
     Return grains pertaining to the operating system

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -151,6 +151,16 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
                     "part": None,
                 },
             ),
+            (
+                "cpe:2.3:o:amazon:amazon_linux:2",
+                {
+                    "phase": None,
+                    "version": "2",
+                    "product": "amazon_linux",
+                    "vendor": "amazon",
+                    "part": "operating system",
+                },
+            ),
         ]:
             ret = core._parse_cpe_name(cpe)
             for key in cpe_ret:


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/16237

### Previous Behavior
Wrong result on parsing:
```
CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2"
```

### New Behavior
Expected result
