### PR TITLE
Remove wrong _parse_cpe_name from grains.core (bsc#1191956) - 3000.3

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1660,34 +1660,6 @@ def _parse_cpe_name(cpe):
     return ret
 
 
-def _parse_cpe_name(cpe):
-    '''
-    Parse CPE_NAME data from the os-release
-
-    Info: https://csrc.nist.gov/projects/security-content-automation-protocol/scap-specifications/cpe
-
-    :param cpe:
-    :return:
-    '''
-    part = {
-        'o': 'operating system',
-        'h': 'hardware',
-        'a': 'application',
-    }
-    ret = {}
-    cpe = (cpe or '').split(':')
-    if len(cpe) > 4 and cpe[0] == 'cpe':
-        if cpe[1].startswith('/'):  # WFN to URI
-            ret['vendor'], ret['product'], ret['version'] = cpe[2:5]
-            ret['phase'] = cpe[5] if len(cpe) > 5 else None
-            ret['part'] = part.get(cpe[1][1:])
-        elif len(cpe) == 13 and cpe[1] == '2.3':  # WFN to a string
-            ret['vendor'], ret['product'], ret['version'], ret['phase'] = [x if x != '*' else None for x in cpe[3:7]]
-            ret['part'] = part.get(cpe[2])
-
-    return ret
-
-
 def os_data():
     '''
     Return grains pertaining to the operating system

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -109,16 +109,49 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Parse correct CPE_NAME data v2.3 formatted
         :return:
-        '''
-        for cpe, cpe_ret in [('cpe:2.3:o:microsoft:windows_xp:5.1.601:beta:*:*:*:*:*:*',
-                              {'phase': 'beta', 'version': '5.1.601', 'product': 'windows_xp',
-                               'vendor': 'microsoft', 'part': 'operating system'}),
-                             ('cpe:2.3:h:corellian:millenium_falcon:1.0:*:*:*:*:*:*:*',
-                              {'phase': None, 'version': '1.0', 'product': 'millenium_falcon',
-                               'vendor': 'corellian', 'part': 'hardware'}),
-                             ('cpe:2.3:*:dark_empire:light_saber:3.0:beta:*:*:*:*:*:*',
-                              {'phase': 'beta', 'version': '3.0', 'product': 'light_saber',
-                               'vendor': 'dark_empire', 'part': None})]:
+        """
+        for cpe, cpe_ret in [
+            (
+                "cpe:2.3:o:microsoft:windows_xp:5.1.601:beta:*:*:*:*:*:*",
+                {
+                    "phase": "beta",
+                    "version": "5.1.601",
+                    "product": "windows_xp",
+                    "vendor": "microsoft",
+                    "part": "operating system",
+                },
+            ),
+            (
+                "cpe:2.3:h:corellian:millenium_falcon:1.0:*:*:*:*:*:*:*",
+                {
+                    "phase": None,
+                    "version": "1.0",
+                    "product": "millenium_falcon",
+                    "vendor": "corellian",
+                    "part": "hardware",
+                },
+            ),
+            (
+                "cpe:2.3:*:dark_empire:light_saber:3.0:beta:*:*:*:*:*:*",
+                {
+                    "phase": "beta",
+                    "version": "3.0",
+                    "product": "light_saber",
+                    "vendor": "dark_empire",
+                    "part": None,
+                },
+            ),
+            (
+                "cpe:2.3:o:amazon:amazon_linux:2",
+                {
+                    "phase": None,
+                    "version": "2",
+                    "product": "amazon_linux",
+                    "vendor": "amazon",
+                    "part": "operating system",
+                },
+            ),
+        ]:
             ret = core._parse_cpe_name(cpe)
             for key in cpe_ret:
                 assert key in ret


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/openSUSE/salt/pull/452 to `3000.3`

### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/16237

### Previous Behavior
Wrong result on parsing:
```
CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2"
```

### New Behavior
Expected result
