### PR TITLE
Fix the regression with invalid syntax in test_parse_cpe_name_v23

### DIFF
--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -109,7 +109,7 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
         '''
         Parse correct CPE_NAME data v2.3 formatted
         :return:
-        """
+        '''
         for cpe, cpe_ret in [
             (
                 "cpe:2.3:o:microsoft:windows_xp:5.1.601:beta:*:*:*:*:*:*",


### PR DESCRIPTION
### What does this PR do?

Fixes the regression in `test_parse_cpe_name_v23` from https://github.com/openSUSE/salt/pull/453
