### PR TITLE
Fix the regression for yumnotify plugin

### DIFF
--- a/scripts/suse/yum/plugins/yumnotify.py
+++ b/scripts/suse/yum/plugins/yumnotify.py
@@ -64,4 +64,4 @@ def posttrans_hook(conduit):
                     )
                 )
         except OSError as e:
-            print("Unable to save the cookie file: %s" % (e), file=sys.stderr)
+            sys.stderr.write("Unable to save the cookie file: %s\n" % (e))


### PR DESCRIPTION
### What does this PR do?

Fixes the regression in `yumnotify` plugin from https://github.com/openSUSE/salt/pull/415

The plugin is invoked by yum with platform python, but not the bundled python version.
This change is only relevant for Salt Bundle and CentOS 7