### PR TITLE
Fix possible traceback on ip6_interface grain (bsc#1193565) - 3000.3

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2377,7 +2377,7 @@ def ip6_interfaces():
                 try:
                     socket.inet_pton(socket.AF_INET6, secondary["address"])
                     iface_ips.append(secondary["address"])
-                except OSError:
+                except (OSError, socket.error):
                     pass
         ret[face] = iface_ips
     return {'ip6_interfaces': ret}


### PR DESCRIPTION
### What does this PR do?

Port of https://github.com/openSUSE/salt/pull/464 to `3000.3`
Fixes possible traceback on `ip6_interface` at `grains.core` in case of having multiple IP addresses assigned.
Python 2 has `socket.error` which is not inherited from `OSError` as in Python 3

### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/16516
Appears in: https://github.com/openSUSE/salt/commit/a5fb276e3a925f6dab4f97e3df9163c72c9818b2

### Previous Behavior
Possible traceback on `ip6_interface` at `grain.core` in case of having multiple IP addresses assigned.

### New Behavior
Handling exception with no traceback.