### PR TITLE
Fix salt-minion.service shown as reloading after calling apache2ctl (bsc#1193357) - 3000

### DIFF
--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -11,6 +11,7 @@ Support for Apache
 
 # Import python libs
 from __future__ import absolute_import, generators, print_function, with_statement, unicode_literals
+import os
 import re
 import logging
 
@@ -121,7 +122,9 @@ def modules():
     ret = {}
     ret['static'] = []
     ret['shared'] = []
-    out = __salt__['cmd.run'](cmd).splitlines()
+    out = __salt__['cmd.run'](
+        cmd, env={'PATH': os.getenv('PATH')}, clean_env=True
+    ).splitlines()
     for line in out:
         comps = line.split()
         if not comps:
@@ -167,7 +170,7 @@ def directives():
     '''
     cmd = '{0} -L'.format(_detect_os())
     ret = {}
-    out = __salt__['cmd.run'](cmd)
+    out = __salt__['cmd.run'](cmd, env={'PATH': os.getenv('PATH')}, clean_env=True)
     out = out.replace('\n\t', '\t')
     for line in out.splitlines():
         if not line:
@@ -195,7 +198,7 @@ def vhosts():
     cmd = '{0} -S'.format(_detect_os())
     ret = {}
     namevhost = ''
-    out = __salt__['cmd.run'](cmd)
+    out = __salt__['cmd.run'](cmd, env={"PATH": os.getenv("PATH")}, clean_env=True)
     for line in out.splitlines():
         if not line:
             continue
@@ -245,7 +248,7 @@ def signal(signal=None):
     else:
         arguments = ' {0}'.format(signal)
     cmd = _detect_os() + arguments
-    out = __salt__['cmd.run_all'](cmd)
+    out = __salt__['cmd.run_all'](cmd, env={'PATH': os.getenv('PATH')}, clean_env=True)
 
     # A non-zero return code means fail
     if out['retcode'] and out['stderr']:


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/openSUSE/salt/pull/467 to `3000`.
No need to port it to `3000.3` as it's not used under systemd unit, but with salt-ssh only.

For some reason on calling `apache2ctl` from `salt-minion` with some `apache` module functions under systemd service, the service shown as reloading, it doesn't affect the `salt-minion` process, but only the service status shown.

The root cause is the side effect on changing some environment variables with `apache2ctl`.

### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/16494

### Previous Behavior
`salt-minion` shown as `reloading` forewer after calling `apache2ctl` with `apache.modules` and some other `apache` module functions

### New Behavior
Normal systemd service behavior
