### PR TITLE
Wipe NOTIFY_SOCKET from env in cmdmod (bsc#1193357) - 3002.2

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -606,6 +606,9 @@ def _run(
     if prepend_path:
         run_env["PATH"] = ":".join((prepend_path, run_env["PATH"]))
 
+    if "NOTIFY_SOCKET" not in env:
+        run_env.pop("NOTIFY_SOCKET", None)
+
     if python_shell is None:
         python_shell = False
 

--- a/tests/unit/modules/test_cmdmod.py
+++ b/tests/unit/modules/test_cmdmod.py
@@ -351,6 +351,48 @@ class CMDMODTestCase(TestCase, LoaderModuleMockMixin):
                     if not salt.utils.platform.is_darwin():
                         getpwnam_mock.assert_called_with("foobar")
 
+    @skipIf(salt.utils.platform.is_windows(), "Do not run on Windows")
+    def test_os_environment_do_not_pass_notify_socket(self):
+        """
+        Make sure NOTIFY_SOCKET environment variable is not passed
+        to the command if not explicitly set with env parameter.
+        """
+        with patch("pwd.getpwnam") as getpwnam_mock:
+            new_env = os.environ.copy()
+            new_env.update({"NOTIFY_SOCKET": "/run/systemd/notify"})
+            with patch("subprocess.Popen") as popen_mock, patch(
+                "os.environ.copy", return_value=new_env
+            ):
+                popen_mock.return_value = Mock(
+                    communicate=lambda *args, **kwags: [b"", None],
+                    pid=lambda: 1,
+                    retcode=0,
+                )
+
+                with patch.dict(cmdmod.__grains__, {"os": "SUSE", "os_family": "Suse"}):
+                    if sys.platform.startswith(("freebsd", "openbsd")):
+                        shell = "/bin/sh"
+                    else:
+                        shell = "/bin/bash"
+
+                    cmdmod._run("ls", cwd=tempfile.gettempdir(), shell=shell)
+
+                    self.assertTrue(
+                        "NOTIFY_SOCKET" not in popen_mock.call_args_list[0][1]["env"]
+                    )
+
+                    cmdmod._run(
+                        "ls",
+                        cwd=tempfile.gettempdir(),
+                        shell=shell,
+                        env={"NOTIFY_SOCKET": "/run/systemd/notify.new"},
+                    )
+
+                    self.assertEqual(
+                        popen_mock.call_args_list[1][1]["env"]["NOTIFY_SOCKET"],
+                        "/run/systemd/notify.new",
+                    )
+
     @skipIf(not salt.utils.platform.is_darwin(), "applicable to macOS only")
     def test_shell_properly_handled_on_macOS(self):
         """


### PR DESCRIPTION
### What does this PR do?

`NOTIFY_SOCKET` environment variable is used by `systemd` to send the notifications about the state of the service.
In some cases using scripts like `apache2ctl` under salt-minion service could affect the state of `salt-minion` service itself.
Calling `apache2ctl -M` directly with `cmd.run` or with `apache.modules` leads to getting stuck `salt-minion` service in reloading state with no affecting the process, but in some cases `systemd` could  kill the process as unresponsive.

### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/16494
Upstream PR: https://github.com/saltstack/salt/pull/61393

### Previous Behavior
Possible side effects on `salt-minion` when calling `apache2ctl` or some other scripts using `NOTIFY_SOCKET` environment variable.

### New Behavior
`NOTIFY_SOCKET` is not passed to child processes created with `cmdmod` unless it's set explicitly for such call.
