### PR TITLE
Wipe NOTIFY_SOCKET from env in cmdmod (bsc#1193357) - 3000

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -595,6 +595,9 @@ def _run(cmd,
     if prepend_path:
         run_env['PATH'] = ':'.join((prepend_path, run_env['PATH']))
 
+    if "NOTIFY_SOCKET" not in env:
+        run_env.pop("NOTIFY_SOCKET", None)
+
     if python_shell is None:
         python_shell = False
 


### PR DESCRIPTION
### What does this PR do?

Port of https://github.com/openSUSE/salt/pull/472 to `3000`

`NOTIFY_SOCKET` environment variable is used by `systemd` to send the notifications about the state of the service.
In some cases using scripts like `apache2ctl` under salt-minion service could affect the state of `salt-minion` service itself.
Calling `apache2ctl -M` directly with `cmd.run` or with `apache.modules` leads to getting stuck `salt-minion` service in reloading state with no affecting the process, but in some cases `systemd` could  kill the process as unresponsive.

### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/16494
Upstream PR: https://github.com/saltstack/salt/pull/61393

### Previous Behavior
Possible side effects on `salt-minion` when calling `apache2ctl` or some other scripts using `NOTIFY_SOCKET` environment variable.

### New Behavior
`NOTIFY_SOCKET` is not passed to child processes created with `cmdmod` unless it's set explicitly for such call.
