### PR TITLE
Fix inspector module export function (bsc#1097531) - 3000.3

### DIFF
--- a/salt/modules/inspectlib/kiwiproc.py
+++ b/salt/modules/inspectlib/kiwiproc.py
@@ -75,7 +75,7 @@ class KiwiExporter(object):
         self._set_packages(root)
 
         return '\n'.join([line for line in minidom.parseString(
-            etree.tostring(root, encoding='UTF-8', pretty_print=True)).toprettyxml(indent="  ").split("\n")
+            etree.tostring(root, encoding='UTF-8')).toprettyxml(indent="  ").split("\n")
                           if line.strip()])
 
     def _get_package_manager(self):

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -72,7 +72,7 @@ class SysInfo(object):
         for dev, dev_data in salt.utils.fsutils._blkid().items():
             dev = self._get_disk_size(dev)
             device = dev.pop('device')
-            dev['type'] = dev_data['type']
+            dev['type'] = dev_data.get('type', 'UNKNOWN')
             data[device] = dev
 
         return data


### PR DESCRIPTION
### What does this PR do?

Port of https://github.com/openSUSE/salt/pull/478 to `3000.3`

Fixes the tracebacks on calling `inspector.export`:
```
manager:~ # salt sm3.wp.suse.com inspector.export  local=True path=/tmp format=kiwi
sm3.wp.suse.com:
    The minion function caused an exception: Traceback (most recent call last):
      File "/usr/lib/python2.7/site-packages/salt/minion.py", line 1455, in _thread_return
        return_data = executor.execute()
      File "/usr/lib/python2.7/site-packages/salt/executors/direct_call.py", line 28, in execute
        return self.func(*self.args, **self.kwargs)
      File "/usr/lib/python2.7/site-packages/salt/modules/inspector.py", line 226, in export
        raise Exception(ex)
    Exception: tostring() got an unexpected keyword argument 'pretty_print'
```

The other traceback is possible if FS type was not detected on the partition.

### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/8481

### Previous Behavior
Tracebacks on calling `inspector.export`

### New Behavior
Normal module behavior
