### PR TITLE
Fix inspector module export function (bsc#1097531) - 3002.2

### DIFF
--- a/salt/modules/inspectlib/fsdb.py
+++ b/salt/modules/inspectlib/fsdb.py
@@ -140,7 +140,7 @@ class CsvDB(object):
         return self._tables.keys()
 
     def _load_table(self, table_name):
-        with gzip.open(os.path.join(self.db_path, table_name), "rb") as table:
+        with gzip.open(os.path.join(self.db_path, table_name), "rt") as table:
             return OrderedDict(
                 [tuple(elm.split(":")) for elm in next(csv.reader(table))]
             )
@@ -187,7 +187,7 @@ class CsvDB(object):
         """
         get_type = lambda item: str(type(item)).split("'")[1]
         if not os.path.exists(os.path.join(self.db_path, obj._TABLE)):
-            with gzip.open(os.path.join(self.db_path, obj._TABLE), "wb") as table_file:
+            with gzip.open(os.path.join(self.db_path, obj._TABLE), "wt") as table_file:
                 csv.writer(table_file).writerow(
                     [
                         "{col}:{type}".format(col=elm[0], type=get_type(elm[1]))
@@ -215,7 +215,7 @@ class CsvDB(object):
             db_obj = self.get(obj.__class__, eq=fields)
             if db_obj and distinct:
                 raise Exception("Object already in the database.")
-        with gzip.open(os.path.join(self.db_path, obj._TABLE), "a") as table:
+        with gzip.open(os.path.join(self.db_path, obj._TABLE), "at") as table:
             csv.writer(table).writerow(self._validate_object(obj))
 
     def update(self, obj, matches=None, mt=None, lt=None, eq=None):
@@ -321,7 +321,7 @@ class CsvDB(object):
         :return:
         """
         objects = []
-        with gzip.open(os.path.join(self.db_path, obj._TABLE), "rb") as table:
+        with gzip.open(os.path.join(self.db_path, obj._TABLE), "rt") as table:
             header = None
             for data in csv.reader(table):
                 if not header:

--- a/salt/modules/inspectlib/kiwiproc.py
+++ b/salt/modules/inspectlib/kiwiproc.py
@@ -82,7 +82,7 @@ class KiwiExporter(object):
             [
                 line
                 for line in minidom.parseString(
-                    etree.tostring(root, encoding="UTF-8", pretty_print=True)
+                    etree.tostring(root, encoding="UTF-8")
                 )
                 .toprettyxml(indent="  ")
                 .split("\n")

--- a/salt/modules/inspectlib/query.py
+++ b/salt/modules/inspectlib/query.py
@@ -78,7 +78,7 @@ class SysInfo(object):
         for dev, dev_data in salt.utils.fsutils._blkid().items():
             dev = self._get_disk_size(dev)
             device = dev.pop("device")
-            dev["type"] = dev_data["type"]
+            dev["type"] = dev_data.get("type", "UNKNOWN")
             data[device] = dev
 
         return data


### PR DESCRIPTION
### What does this PR do?

Port of https://github.com/openSUSE/salt/pull/478 to `3002.2` with adjusting `gzip.open` function calls to Python 3

Upstream PR: https://github.com/saltstack/salt/pull/61530

Fixes the tracebacks on calling `inspector.export`:
```
manager:~ # salt sm3.wp.suse.com inspector.export  local=True path=/tmp format=kiwi
sm3.wp.suse.com:
    The minion function caused an exception: Traceback (most recent call last):
      File "/usr/lib/python2.7/site-packages/salt/minion.py", line 1455, in _thread_return
        return_data = executor.execute()
      File "/usr/lib/python2.7/site-packages/salt/executors/direct_call.py", line 28, in execute
        return self.func(*self.args, **self.kwargs)
      File "/usr/lib/python2.7/site-packages/salt/modules/inspector.py", line 226, in export
        raise Exception(ex)
    Exception: tostring() got an unexpected keyword argument 'pretty_print'
```

The other traceback is possible if FS type was not detected on the partition.

### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/8481

### Previous Behavior
Tracebacks on calling `inspector.export`

### New Behavior
Normal module behavior
