### PR TITLE
Drop serial from event.unpack in cli.batch_async

### DIFF
--- a/salt/cli/batch_async.py
+++ b/salt/cli/batch_async.py
@@ -9,7 +9,6 @@ import logging
 
 import salt.client
 import salt.ext.tornado
-import tornado
 from salt.cli.batch import batch_get_eauth, batch_get_opts, get_bnum
 
 log = logging.getLogger(__name__)
@@ -109,7 +108,7 @@ class BatchAsync:
         if not self.event:
             return
         try:
-            mtag, data = self.event.unpack(raw, self.event.serial)
+            mtag, data = self.event.unpack(raw)
             for (pattern, op) in self.patterns:
                 if mtag.startswith(pattern[:-1]):
                     minion = data["id"]


### PR DESCRIPTION
### What does this PR do?

Don't pass `serial` to `event.unpack` in `batch_async`. `event.unpack` does not accept that argument anymore.


