### PR TITLE
Add missing "ansible" module functions to whitelist in Salt 3004 (bsc#1195625)

### DIFF
--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -45,7 +45,14 @@ hosts:
 """
 DEFAULT_TIMEOUT = 1200  # seconds (20 minutes)
 
-__load__ = __non_ansible_functions__ = ["help", "list_", "call", "playbooks"][:]
+__load__ = __non_ansible_functions__ = [
+    "help",
+    "list_",
+    "call",
+    "playbooks",
+    "discover_playbooks",
+    "targets",
+][:]
 
 
 def _set_callables(modules):

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -45,14 +45,16 @@ hosts:
 """
 DEFAULT_TIMEOUT = 1200  # seconds (20 minutes)
 
-__load__ = __non_ansible_functions__ = [
+__non_ansible_functions__ = []
+
+__load__ = __non_ansible_functions__[:] = [
     "help",
     "list_",
     "call",
     "playbooks",
     "discover_playbooks",
     "targets",
-][:]
+]
 
 
 def _set_callables(modules):


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue with `ansiblegate` module in Salt 3004. There is a new whitelist for the exposed commands coming from "ansiblegate" module.

Some of the latest implemented functions are missing there: `ansible.targets` and `ansible.discover_playbooks`.

Therefore, if we call any of these functions we will get:

```
2022-02-07 11:12:46,223 [salt.utils.lazy  :103 ][DEBUG   ][19401] Could not LazyLoad ansible.targets: 'ansible.targets' is not available.
```
