### PR TITLE
Clear network interfaces cache (bsc#1196050) - 3002.2

### DIFF
--- a/changelog/59490.fixed
+++ b/changelog/59490.fixed
@@ -1,0 +1,1 @@
+Clear the cached network interface grains during minion init and grains refresh

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -43,7 +43,7 @@ import salt.utils.platform
 import salt.utils.stringutils
 import salt.utils.versions
 from salt.ext.six.moves import range
-from salt.utils.network import _get_interfaces
+from salt.utils.network import _clear_interfaces, _get_interfaces
 
 # pylint: disable=import-error
 try:
@@ -109,6 +109,10 @@ HAS_UNAME = hasattr(os, "uname")
 # Possible value for h_errno defined in netdb.h
 HOST_NOT_FOUND = 1
 NO_DATA = 4
+
+
+def __init__(opts):
+    _clear_interfaces()
 
 
 def _windows_cpudata():

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -46,18 +46,25 @@ except (ImportError, OSError, AttributeError, TypeError):
     pass
 
 
-_INTERFACES = {}
+class Interfaces:
+    __slots__ = ("interfaces",)
+
+    def __init__(self, interfaces=None):
+        if interfaces is None:
+            interfaces = {}
+        self.interfaces = interfaces
+
+    def __call__(self, *args, **kwargs):
+        if not self.interfaces:
+            self.interfaces = interfaces()
+        return self.interfaces
+
+    def clear(self):
+        self.interfaces = {}
 
 
-def _get_interfaces():  #! function
-    """
-    Provide a dict of the connected interfaces and their ip addresses
-    """
-
-    global _INTERFACES
-    if not _INTERFACES:
-        _INTERFACES = interfaces()
-    return _INTERFACES
+_get_interfaces = Interfaces()
+_clear_interfaces = _get_interfaces.clear
 
 
 def sanitize_host(host):

--- a/tests/unit/grains/test_core.py
+++ b/tests/unit/grains/test_core.py
@@ -6,6 +6,7 @@ import logging
 import os
 import platform
 import socket
+import tempfile
 import textwrap
 
 import salt.grains.core as core
@@ -21,6 +22,7 @@ from salt._compat import ipaddress
 from salt.ext import six
 from tests.support.mixins import LoaderModuleMockMixin
 from tests.support.mock import MagicMock, Mock, mock_open, patch
+from tests.support.runtests import RUNTIME_VARS
 from tests.support.unit import TestCase, skipIf
 
 try:
@@ -2336,3 +2338,91 @@ class CoreGrainsTestCase(TestCase, LoaderModuleMockMixin):
 
         with patch.dict(core.__opts__, {"id": "otherid"}):
             assert core.get_server_id() != expected
+
+    def test_network_grains_cache(self):
+        """
+        Network interfaces are cache is cleared by the loader
+        """
+        call_1 = {
+            "lo": {
+                "up": True,
+                "hwaddr": "00:00:00:00:00:00",
+                "inet": [
+                    {
+                        "address": "127.0.0.1",
+                        "netmask": "255.0.0.0",
+                        "broadcast": None,
+                        "label": "lo",
+                    }
+                ],
+                "inet6": [],
+            },
+            "wlo1": {
+                "up": True,
+                "hwaddr": "29:9f:9f:e9:67:f4",
+                "inet": [
+                    {
+                        "address": "172.16.13.85",
+                        "netmask": "255.255.248.0",
+                        "broadcast": "172.16.15.255",
+                        "label": "wlo1",
+                    }
+                ],
+                "inet6": [],
+            },
+        }
+        call_2 = {
+            "lo": {
+                "up": True,
+                "hwaddr": "00:00:00:00:00:00",
+                "inet": [
+                    {
+                        "address": "127.0.0.1",
+                        "netmask": "255.0.0.0",
+                        "broadcast": None,
+                        "label": "lo",
+                    }
+                ],
+                "inet6": [],
+            },
+            "wlo1": {
+                "up": True,
+                "hwaddr": "29:9f:9f:e9:67:f4",
+                "inet": [
+                    {
+                        "address": "172.16.13.86",
+                        "netmask": "255.255.248.0",
+                        "broadcast": "172.16.15.255",
+                        "label": "wlo1",
+                    }
+                ],
+                "inet6": [],
+            },
+        }
+        tmp_path = tempfile.mkdtemp(dir=RUNTIME_VARS.TMP)
+        cache_dir = os.path.join(tmp_path, "cache")
+        extmods = os.path.join(tmp_path, "extmods")
+        opts = {
+            "cachedir": str(cache_dir),
+            "extension_modules": str(extmods),
+            "optimization_order": [0],
+        }
+        with patch(
+            "salt.utils.network.interfaces", side_effect=[call_1, call_2]
+        ) as interfaces:
+            grains = salt.loader.grain_funcs(opts)
+            assert interfaces.call_count == 0
+            ret = grains["core.ip_interfaces"]()
+            # interfaces has been called
+            assert interfaces.call_count == 1
+            assert ret["ip_interfaces"]["wlo1"] == ["172.16.13.85"]
+            # interfaces has been cached
+            ret = grains["core.ip_interfaces"]()
+            assert interfaces.call_count == 1
+            assert ret["ip_interfaces"]["wlo1"] == ["172.16.13.85"]
+
+            grains = salt.loader.grain_funcs(opts)
+            ret = grains["core.ip_interfaces"]()
+            # A new loader clears the cache and interfaces is called again
+            assert interfaces.call_count == 2
+            assert ret["ip_interfaces"]["wlo1"] == ["172.16.13.86"]


### PR DESCRIPTION
Backport of upstream https://github.com/saltstack/salt/pull/60130
Not relevant for `3004` as it's there already.

The list of interfaces populated only once on requesting and storing in global list.
In case of adding network interface during salt-minion running grains returns only old data and not refreshing the list.
This PR forcing interfaces list refresh on refreshing the grains.