### PR TITLE
Clear network interface cache (bsc#1196050) - 3000

### DIFF
--- a/changelog/59490.fixed
+++ b/changelog/59490.fixed
@@ -1,0 +1,1 @@
+Clear the cached network interface grains during minion init and grains refresh

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -28,7 +28,7 @@ import warnings
 import time
 import salt.modules.network
 
-from salt.utils.network import _get_interfaces
+from salt.utils.network import _clear_interfaces, _get_interfaces
 
 # pylint: disable=import-error
 try:
@@ -129,6 +129,10 @@ if not hasattr(os, 'uname'):
 # Possible value for h_errno defined in netdb.h
 HOST_NOT_FOUND = 1
 NO_DATA = 4
+
+
+def __init__(opts):
+    _clear_interfaces()
 
 
 def _windows_cpudata():

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -52,16 +52,25 @@ except (ImportError, OSError, AttributeError, TypeError):
     pass
 
 
-_INTERFACES = {}
-def _get_interfaces(): #! function
-    '''
-    Provide a dict of the connected interfaces and their ip addresses
-    '''
+class Interfaces:
+    __slots__ = ("interfaces",)
 
-    global _INTERFACES
-    if not _INTERFACES:
-        _INTERFACES = interfaces()
-    return _INTERFACES
+    def __init__(self, interfaces=None):
+        if interfaces is None:
+            interfaces = {}
+        self.interfaces = interfaces
+
+    def __call__(self, *args, **kwargs):
+        if not self.interfaces:
+            self.interfaces = interfaces()
+        return self.interfaces
+
+    def clear(self):
+        self.interfaces = {}
+
+
+_get_interfaces = Interfaces()
+_clear_interfaces = _get_interfaces.clear
 
 
 def sanitize_host(host):


### PR DESCRIPTION
Backport of upstream https://github.com/saltstack/salt/commit/34c2aa3b0af1d70141ed30bd32bc70f3cdd9ad49

Not relevant for `3004` as it's there already.

The list of interfaces populated only once on requesting and storing in global list.
In case of adding network interface during salt-minion running grains returns only old data and not refreshing the list.
This PR forcing interfaces list refresh on refreshing the grains.