### PR TITLE
Normalize package names once with pkg.installed/removed using yum (bsc#1195895) - 3000

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1390,7 +1390,9 @@ def install(name=None,
 
     try:
         pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](
-            name, pkgs, sources, saltenv=saltenv, normalize=normalize, **kwargs
+            name, pkgs, sources, saltenv=saltenv,
+            normalize=normalize and kwargs.get("split_arch", True),
+            **kwargs
         )
     except MinionError as exc:
         raise CommandExecutionError(exc)
@@ -1533,14 +1535,15 @@ def install(name=None,
                     if ignore_epoch is True:
                         version_num = version_num.split(':', 1)[-1]
                 arch = ''
-                try:
-                    namepart, archpart = pkgname.rsplit('.', 1)
-                except ValueError:
-                    pass
-                else:
-                    if archpart in salt.utils.pkg.rpm.ARCHES:
-                        arch = '.' + archpart
-                        pkgname = namepart
+                if kwargs.get("split_arch", True):
+                    try:
+                        namepart, archpart = pkgname.rsplit('.', 1)
+                    except ValueError:
+                        pass
+                    else:
+                        if archpart in salt.utils.pkg.rpm.ARCHES:
+                            arch = '.' + archpart
+                            pkgname = namepart
 
                 if '*' in version_num:
                     # Resolve wildcard matches
@@ -2030,14 +2033,15 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=W0613
         elif target in old and version_to_remove in installed_versions:
             arch = ''
             pkgname = target
-            try:
-                namepart, archpart = target.rsplit('.', 1)
-            except ValueError:
-                pass
-            else:
-                if archpart in salt.utils.pkg.rpm.ARCHES:
-                    arch = '.' + archpart
-                    pkgname = namepart
+            if kwargs.get("split_arch", True):
+                try:
+                    namepart, archpart = pkgname.rsplit('.', 1)
+                except ValueError:
+                    pass
+                else:
+                    if archpart in salt.utils.pkg.rpm.ARCHES:
+                        arch = '.' + archpart
+                        pkgname = namepart
             # Since we don't always have the arch info, epoch information has to parsed out. But
             # a version check was already performed, so we are removing the right version.
             targets.append(

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1535,15 +1535,17 @@ def install(name=None,
                     if ignore_epoch is True:
                         version_num = version_num.split(':', 1)[-1]
                 arch = ''
-                if kwargs.get("split_arch", True):
-                    try:
-                        namepart, archpart = pkgname.rsplit('.', 1)
-                    except ValueError:
-                        pass
-                    else:
-                        if archpart in salt.utils.pkg.rpm.ARCHES:
-                            arch = '.' + archpart
-                            pkgname = namepart
+                try:
+                    namepart, archpart = pkgname.rsplit('.', 1)
+                except ValueError:
+                    pass
+                else:
+                    if archpart in salt.utils.pkg.rpm.ARCHES and (
+                        archpart != __grains__["osarch"]
+                        or kwargs.get("split_arch", True)
+                    ):
+                        arch = '.' + archpart
+                        pkgname = namepart
 
                 if '*' in version_num:
                     # Resolve wildcard matches
@@ -2033,15 +2035,16 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=W0613
         elif target in old and version_to_remove in installed_versions:
             arch = ''
             pkgname = target
-            if kwargs.get("split_arch", True):
-                try:
-                    namepart, archpart = pkgname.rsplit('.', 1)
-                except ValueError:
-                    pass
-                else:
-                    if archpart in salt.utils.pkg.rpm.ARCHES:
-                        arch = '.' + archpart
-                        pkgname = namepart
+            try:
+                namepart, archpart = pkgname.rsplit('.', 1)
+            except ValueError:
+                pass
+            else:
+                if archpart in salt.utils.pkg.rpm.ARCHES and (
+                    archpart != __grains__["osarch"] or kwargs.get("split_arch", True)
+                ):
+                    arch = '.' + archpart
+                    pkgname = namepart
             # Since we don't always have the arch info, epoch information has to parsed out. But
             # a version check was already performed, so we are removing the right version.
             targets.append(

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1785,6 +1785,7 @@ def installed(
                                               normalize=normalize,
                                               update_holds=update_holds,
                                               ignore_epoch=ignore_epoch,
+                                              split_arch=False,
                                               **kwargs)
         except CommandExecutionError as exc:
             ret = {'name': name, 'result': False}
@@ -2743,7 +2744,9 @@ def _uninstall(
                 'comment': 'The following packages will be {0}d: '
                            '{1}.'.format(action, ', '.join(targets))}
 
-    changes = __salt__['pkg.{0}'.format(action)](name, pkgs=pkgs, version=version, **kwargs)
+    changes = __salt__['pkg.{0}'.format(action)](
+        name, pkgs=pkgs, version=version, split_arch=False, **kwargs
+    )
     new = __salt__['pkg.list_pkgs'](versions_as_list=True, **kwargs)
     failed = []
     for param in pkg_params:


### PR DESCRIPTION
### What does this PR do?

On calling `pkg.installed` or `pkg.removed` the package name normalisation is performing few timess.
As the result it leads to removing `.ARCH` if used in the name of the package as suffix, but actually a part of the name.

### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/16974
Upstream PR: https://github.com/saltstack/salt/pull/62029

### Previous Behavior
Error on trying to install/remove the packages with such names:
`uptrack-updates-4.14.35-2047.502.4.el7uek.x86_64` (`x86_64` is not an arch there, but a part of the name, the arch of this package is `noarch`)
`weird-name-1.2.3-1234.5.6.test7tst.x86_64-20220214-2.1.noarch` (where `noarch` the real package arch and `x86_64` is a part of the name)

### New Behavior
No errors on installing/removing the package

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
