### PR TITLE
Prevent shell injection via pre_flight_script_args and use RLock - 3004

### DIFF
--- a/salt/_logging/impl.py
+++ b/salt/_logging/impl.py
@@ -92,7 +92,7 @@ MODNAME_PATTERN = re.compile(r"(?P<name>%%\(name\)(?:\-(?P<digits>[\d]+))?s)")
 
 # LOG_LOCK is used to prevent deadlocks on using logging
 # in combination with multiprocessing with salt-api
-LOG_LOCK = threading.Lock()
+LOG_LOCK = threading.RLock()
 
 
 # ----- REMOVE ME ON REFACTOR COMPLETE ------------------------------------------------------------------------------>

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -15,6 +15,7 @@ import os
 import psutil
 import queue
 import re
+import shlex
 import subprocess
 import sys
 import tarfile
@@ -1458,11 +1459,9 @@ ARGS = {arguments}\n'''.format(
         """
         args = ""
         if script_args:
-            args = " {}".format(
-                " ".join([str(el) for el in script_args])
-                if isinstance(script_args, (list, tuple))
-                else script_args
-            )
+            if not isinstance(script_args, (list, tuple)):
+                script_args = shlex.split(str(script_args))
+            args = " {}".format(" ".join([shlex.quote(str(el)) for el in script_args]))
         if extension == "ps1":
             ret = self.shell.exec_cmd('"powershell {}"'.format(script))
         else:


### PR DESCRIPTION
### What does this PR do?

This PR fixes two issues we found on the latest changes introduced by: https://github.com/openSUSE/salt/pull/493

- Prevent shell injection via pre_flight_script_args
- Use reentrant lock to avoid issues when same threads aquire lock multiple times
