### PR TITLE
[skip] Check only ssh-rsa encyption for set_known_host - 3000

### DIFF
--- a/tests/integration/modules/test_ssh.py
+++ b/tests/integration/modules/test_ssh.py
@@ -136,7 +136,9 @@ class SSHModuleTest(ModuleCase):
         '''
         Check that known host information is returned from remote host
         '''
-        ret = self.run_function('ssh.recv_known_host_entries', ['github.com'])
+        ret = self.run_function(
+            "ssh.recv_known_host_entries", ["github.com"], enc="ssh-rsa"
+        )
         try:
             self.assertNotEqual(ret, None)
             self.assertEqual(ret[0]['enc'], 'ssh-rsa')
@@ -217,8 +219,12 @@ class SSHModuleTest(ModuleCase):
         ssh.set_known_host
         '''
         # add item
-        ret = self.run_function('ssh.set_known_host', ['root', 'github.com'],
-                                config=self.known_hosts)
+        ret = self.run_function(
+            "ssh.set_known_host",
+            ["root", "github.com"],
+            enc="ssh-rsa",
+            config=self.known_hosts,
+        )
         try:
             self.assertEqual(ret['status'], 'updated')
             self.assertEqual(ret['old'], None)

--- a/tests/integration/states/test_ssh_known_hosts.py
+++ b/tests/integration/states/test_ssh_known_hosts.py
@@ -19,8 +19,8 @@ from tests.support.helpers import skip_if_binaries_missing
 # Import 3rd-party libs
 from salt.ext import six
 
-GITHUB_FINGERPRINT = '9d:38:5b:83:a9:17:52:92:56:1a:5e:c4:d4:81:8e:0a:ca:51:a2:64:f1:74:20:11:2e:f8:8a:c3:a1:39:49:8f'
-GITHUB_IP = '192.30.253.113'
+GITHUB_FINGERPRINT = "9d:38:5b:83:a9:17:52:92:56:1a:5e:c4:d4:81:8e:0a:ca:51:a2:64:f1:74:20:11:2e:f8:8a:c3:a1:39:49:8f"
+GITHUB_IP = "140.82.121.4"
 
 
 @skip_if_binaries_missing(['ssh', 'ssh-keygen'], check_all=True)
@@ -42,10 +42,11 @@ class SSHKnownHostsStateTest(ModuleCase, SaltReturnAssertsMixin):
         ssh_known_hosts.present
         '''
         kwargs = {
-            'name': 'github.com',
-            'user': 'root',
-            'fingerprint': GITHUB_FINGERPRINT,
-            'config': self.known_hosts
+            "name": "github.com",
+            "user": "root",
+            "enc": "ssh-rsa",
+            "fingerprint": GITHUB_FINGERPRINT,
+            "config": self.known_hosts,
         }
         # test first
         ret = self.run_state('ssh_known_hosts.present', test=True, **kwargs)


### PR DESCRIPTION
### What does this PR do?

This PR fixes some unreliable tests that are randomly failing.

Upstream PR: https://github.com/saltstack/salt/pull/61264