### PR TITLE
Fix salt-ssh opts poisoning (bsc#1197637) - 3004

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -558,7 +558,6 @@ class SSH:
         """
         LOG_LOCK.release()
         salt.loader.LOAD_LOCK.release()
-        opts = copy.deepcopy(opts)
         single = Single(
             opts,
             opts["argv"],

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -340,7 +340,7 @@ class SSH:
         self.session_flock_file = os.path.join(
             self.opts["cachedir"], "salt-ssh.session.lock"
         )
-        self.ssh_session_grace_time = int(self.opts.get("ssh_session_grace_time", 3))
+        self.ssh_session_grace_time = int(self.opts.get("ssh_session_grace_time", 1))
 
     @property
     def parse_tgt(self):
@@ -595,6 +595,7 @@ class SSH:
         Spin up the needed threads or processes and execute the subsequent
         routines
         """
+        opts = copy.deepcopy(self.opts)
         que = multiprocessing.Queue()
         running = {}
         targets_queue = deque(self.targets.keys())
@@ -605,7 +606,7 @@ class SSH:
             if not self.targets:
                 log.error("No matching targets found in roster.")
                 break
-            if len(running) < self.opts.get("ssh_max_procs", 25) and not init:
+            if len(running) < opts.get("ssh_max_procs", 25) and not init:
                 if targets_queue:
                     host = targets_queue.popleft()
                 else:
@@ -623,7 +624,7 @@ class SSH:
                             pid_running = (
                                 False
                                 if cached_session["pid"] == 0
-                                else psutil.pid_exists(cached_session["pid"])
+                                else cached_session.get("running", False) or psutil.pid_exists(cached_session["pid"])
                             )
                             if (
                                 pid_running and prev_session_running < self.max_pid_wait
@@ -638,9 +639,10 @@ class SSH:
                         "salt-ssh/session",
                         host,
                         {
-                            "pid": 0,
+                            "pid": os.getpid(),
                             "master_id": self.master_id,
                             "ts": time.time(),
+                            "running": True,
                         },
                     )
                 for default in self.defaults:
@@ -668,7 +670,7 @@ class SSH:
                     continue
                 args = (
                     que,
-                    self.opts,
+                    opts,
                     host,
                     self.targets[host],
                     mine,
@@ -704,6 +706,7 @@ class SSH:
                             "pid": routine.pid,
                             "master_id": self.master_id,
                             "ts": time.time(),
+                            "running": True,
                         },
                     )
                 continue
@@ -755,12 +758,13 @@ class SSH:
                                 "pid": 0,
                                 "master_id": self.master_id,
                                 "ts": time.time(),
+                                "running": False,
                             },
                         )
             if len(rets) >= len(self.targets):
                 break
             # Sleep when limit or all threads started
-            if len(running) >= self.opts.get("ssh_max_procs", 25) or len(
+            if len(running) >= opts.get("ssh_max_procs", 25) or len(
                 self.targets
             ) >= len(running):
                 time.sleep(0.1)

--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -622,7 +622,12 @@ def roster(opts, runner=None, utils=None, whitelist=None, context=None):
         opts,
         tag="roster",
         whitelist=whitelist,
-        pack={"__runner__": runner, "__utils__": utils, "__context__": context},
+        pack={
+            "__runner__": runner,
+            "__utils__": utils,
+            "__context__": context,
+            "__opts__": opts,
+        },
         extra_module_dirs=utils.module_dirs if utils else None,
     )
 


### PR DESCRIPTION
### What does this PR do?

Port of https://github.com/openSUSE/salt/pull/500 for `3004`

Fix salt-ssh opts poisoning.

### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/17290

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
