### PR TITLE
Fixes for Python 3.10

### DIFF
--- a/salt/_compat.py
+++ b/salt/_compat.py
@@ -11,19 +11,23 @@ if sys.version_info >= (3, 9, 5):
 else:
     import salt.ext.ipaddress as ipaddress
 
+if sys.version_info >= (3, 10):
+    # Python 3.10 will include a fix in importlib.metadata which allows us to
+    # get the distribution of a loaded entry-point
+    import importlib.metadata  # pylint: disable=no-member,no-name-in-module
+else:
+    # importlib_metadata before version 3.3.0 does not include the functionality we need.
+    try:
+        import importlib_metadata
 
-# importlib_metadata before version 3.3.0 does not include the functionality we need.
-try:
-    import importlib_metadata
-
-    importlib_metadata_version = [
-        int(part)
-        for part in importlib_metadata.version("importlib_metadata").split(".")
-        if part.isdigit()
-    ]
-    if tuple(importlib_metadata_version) < (3, 3, 0):
+        importlib_metadata_version = [
+            int(part)
+            for part in importlib_metadata.version("importlib_metadata").split(".")
+            if part.isdigit()
+        ]
+        if tuple(importlib_metadata_version) < (3, 3, 0):
+            # Use the vendored importlib_metadata
+            import salt.ext.importlib_metadata as importlib_metadata
+    except ImportError:
         # Use the vendored importlib_metadata
         import salt.ext.importlib_metadata as importlib_metadata
-except ImportError:
-    # Use the vendored importlib_metadata
-    import salt.ext.importlib_metadata as importlib_metadata

--- a/salt/state.py
+++ b/salt/state.py
@@ -12,7 +12,6 @@ The data sent to the state calls is as follows:
 """
 
 
-import collections
 import copy
 import datetime
 import fnmatch
@@ -25,6 +24,8 @@ import site
 import sys
 import time
 import traceback
+
+from collections.abc import Mapping
 
 import salt.fileclient
 import salt.loader
@@ -3276,7 +3277,7 @@ class State:
         """
         for chunk in high:
             state = high[chunk]
-            if not isinstance(state, collections.Mapping):
+            if not isinstance(state, Mapping):
                 continue
             for state_ref in state:
                 needs_default = True


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/saltstack/salt/pull/61064 for `openSUSE-3004`

Use the same logic in _compat.py and entrypoints.py to load
the same importlib.metadata. Python's built in implementation for
Python >= 3.10 and the Salt one for others.

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
Tracebacks on starting the service with Python 3.10

### New Behavior
Normal behavior

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
