### PR TITLE
Fix regression with depending on psutil (bsc#1197533) - 3004

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -12,7 +12,6 @@ import hashlib
 import logging
 import multiprocessing
 import os
-import psutil
 import queue
 import re
 import shlex
@@ -403,6 +402,16 @@ class SSH:
                             self.__parsed_rosters[self.ROSTER_UPDATE_FLAG] = False
                             return
 
+    def _pid_exists(self, pid):
+        """
+        Check if specified pid is alive
+        """
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            return False
+        return True
+
     def _update_roster(self, hostname=None, user=None):
         """
         Update default flat roster with the passed in information.
@@ -623,7 +632,8 @@ class SSH:
                             pid_running = (
                                 False
                                 if cached_session["pid"] == 0
-                                else cached_session.get("running", False) or psutil.pid_exists(cached_session["pid"])
+                                else cached_session.get("running", False)
+                                or self._pid_exists(cached_session["pid"])
                             )
                             if (
                                 pid_running and prev_session_running < self.max_pid_wait


### PR DESCRIPTION
### What does this PR do?

With Salt SSH simultaneous sessions handling a regression was introduced, causing dependency for `psutil` python module on Salt SSH client.
The dependency is indirect and really hard to notice: `salt.modules.saltutils` requires `salt.client.ssh` and it requires `psutil`, but `saltutils` is used on Salt SSH system directly and the traceback on loading this module is masked and only wisible in DEBUG logging level on Salt SSH client.

### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/17375
