### PR TITLE
Ignore erros on reading license files with dpkg_lowpkg (bsc#1197288) - 3004

### DIFF
--- a/salt/modules/dpkg_lowpkg.py
+++ b/salt/modules/dpkg_lowpkg.py
@@ -361,7 +361,7 @@ def _get_pkg_license(pkg):
     licenses = set()
     cpr = "/usr/share/doc/{}/copyright".format(pkg)
     if os.path.exists(cpr):
-        with salt.utils.files.fopen(cpr) as fp_:
+        with salt.utils.files.fopen(cpr, errors="ignore") as fp_:
             for line in salt.utils.stringutils.to_unicode(fp_.read()).split(os.linesep):
                 if line.startswith("License:"):
                     licenses.add(line.split(":", 1)[1].strip())

--- a/tests/pytests/unit/modules/test_dpkg_lowpkg.py
+++ b/tests/pytests/unit/modules/test_dpkg_lowpkg.py
@@ -1,0 +1,18 @@
+import os
+
+import salt.modules.dpkg_lowpkg as dpkg
+from tests.support.mock import MagicMock, mock_open, patch
+
+
+def test_get_pkg_license():
+    """
+    Test _get_pkg_license for ignore errors on reading license from copyright files
+    """
+    license_read_mock = mock_open(read_data="")
+    with patch.object(os.path, "exists", MagicMock(return_value=True)), patch(
+        "salt.utils.files.fopen", license_read_mock
+    ):
+        dpkg._get_pkg_license("bash")
+
+        assert license_read_mock.calls[0].args[0] == "/usr/share/doc/bash/copyright"
+        assert license_read_mock.calls[0].kwargs["errors"] == "ignore"


### PR DESCRIPTION
### What does this PR do?

Port of https://github.com/openSUSE/salt/pull/499 to `3004`

Some symbols in `/usr/share/doc/*/copyright` could cause tracebacks on reading.
It's safe just to ignore them.

### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/17301

### Previous Behavior
Tracebacks on getting packages information for some of the packages on Debian based distros.

### New Behavior
No tracebacks

### Tracks
Upstream PR: https://github.com/saltstack/salt/pull/61827

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
