### PR TITLE
Save log from docker.build

### DIFF
--- a/salt/modules/dockermod.py
+++ b/salt/modules/dockermod.py
@@ -4104,6 +4104,7 @@ def build(
     fileobj=None,
     dockerfile=None,
     buildargs=None,
+    logfile=None,
 ):
     """
     .. versionchanged:: 2018.3.0
@@ -4156,6 +4157,9 @@ def build(
 
     buildargs
         A dictionary of build arguments provided to the docker build process.
+
+    logfile
+        Path to log file. Output from build is written to this file if not None.
 
 
     **RETURN DATA**
@@ -4232,6 +4236,20 @@ def build(
     stream_data = []
     for line in response:
         stream_data.extend(salt.utils.json.loads(line, cls=DockerJSONDecoder))
+
+    if logfile:
+        try:
+            with salt.utils.files.fopen(logfile, "a") as f:
+                for item in stream_data:
+                    try:
+                        item_type = next(iter(item))
+                    except StopIteration:
+                        continue
+                    if item_type == "stream":
+                        f.write(item[item_type])
+        except OSError:
+            log.error("Unable to write logfile '%s'", logfile)
+
     errors = []
     # Iterate through API response and collect information
     for item in stream_data:


### PR DESCRIPTION
### What does this PR do?

For easier debugging of docker.build, I need to save the docker output in human readable form. This is important especially when the building fails with exception, so the normal return can't be used.

### What issues does this PR fix or reference?
Upstream PR:
https://github.com/saltstack/salt/pull/61984

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
