### PR TITLE
Detect module.run syntax 3004

### DIFF
--- a/changelog/58763.fixed
+++ b/changelog/58763.fixed
@@ -1,0 +1,1 @@
+Detect new and legacy styles of calling module.run and support them both.

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -4,15 +4,16 @@ Execution of Salt modules from within states
 
 .. note::
 
-    There are two styles of calling ``module.run``. **The legacy style will no
-    longer be available starting in the 3005 release.** To opt-in early to the
-    new style you must add the following to your ``/etc/salt/minion`` config
-    file:
+    As of the 3005 release, you no longer need to opt-in to the new style of
+    calling ``module.run``. The following config can be removed from ``/etc/salt/minion``:
 
     .. code-block:: yaml
 
         use_superseded:
           - module.run
+
+    Both 'new' and 'legacy' styles of calling ``module.run`` are supported.
+
 
 With `module.run` these states allow individual execution module calls to be
 made via states. Here's a contrived example, to show you how it's done:

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -375,7 +375,7 @@ def run(**kwargs):
     # Detect if this call is using legacy or new style syntax.
     legacy_run = False
 
-    keys = list(kwargs.keys())
+    keys = list(kwargs)
     if "name" in keys:
         keys.remove("name")
 
@@ -383,6 +383,8 @@ def run(**kwargs):
     for name in keys:
         if name.find(".") == -1:
             legacy_run = True
+    if not keys and kwargs:
+        legacy_run = True
 
     if legacy_run:
         log.debug("Detected legacy module.run syntax: %s", __low__["__id__"])

--- a/tests/pytests/functional/states/test_module.py
+++ b/tests/pytests/functional/states/test_module.py
@@ -1,0 +1,64 @@
+import logging
+
+import pytest
+from tests.support.helpers import dedent
+
+log = logging.getLogger(__name__)
+
+
+@pytest.mark.slow_test
+def test_issue_58763(tmp_path, modules, state_tree, caplog):
+
+    venv_dir = tmp_path / "issue-2028-pip-installed"
+
+    sls_contents = dedent(
+        """
+    run_old:
+      module.run:
+        - name: test.random_hash
+        - size: 10
+        - hash_type: md5
+
+    run_new:
+      module.run:
+        - test.random_hash:
+          - size: 10
+          - hash_type: md5
+    """
+    )
+    with pytest.helpers.temp_file("issue-58763.sls", sls_contents, state_tree):
+        with caplog.at_level(logging.DEBUG):
+            ret = modules.state.sls(
+                mods="issue-58763",
+            )
+            assert len(ret.raw) == 2
+            for k in ret.raw:
+                assert ret.raw[k]["result"] is True
+            assert "Detected legacy module.run syntax: run_old" in caplog.messages
+            assert "Using new style module.run syntax: run_new" in caplog.messages
+
+
+@pytest.mark.slow_test
+def test_issue_58763_a(tmp_path, modules, state_tree, caplog):
+
+    venv_dir = tmp_path / "issue-2028-pip-installed"
+
+    sls_contents = dedent(
+        """
+    test.random_hash:
+      module.run:
+        - size: 10
+        - hash_type: md5
+    """
+    )
+    with pytest.helpers.temp_file("issue-58763.sls", sls_contents, state_tree):
+        with caplog.at_level(logging.DEBUG):
+            ret = modules.state.sls(
+                mods="issue-58763",
+            )
+            assert len(ret.raw) == 1
+            for k in ret.raw:
+                assert ret.raw[k]["result"] is True
+            assert (
+                "Detected legacy module.run syntax: test.random_hash" in caplog.messages
+            )

--- a/tests/pytests/functional/states/test_module.py
+++ b/tests/pytests/functional/states/test_module.py
@@ -62,3 +62,26 @@ def test_issue_58763_a(tmp_path, modules, state_tree, caplog):
             assert (
                 "Detected legacy module.run syntax: test.random_hash" in caplog.messages
             )
+
+
+@pytest.mark.slow_test
+def test_issue_58763_b(tmp_path, modules, state_tree, caplog):
+
+    venv_dir = tmp_path / "issue-2028-pip-installed"
+
+    sls_contents = dedent(
+        """
+    test.ping:
+      module.run
+    """
+    )
+    with pytest.helpers.temp_file("issue-58763.sls", sls_contents, state_tree):
+        with caplog.at_level(logging.DEBUG):
+            ret = modules.state.sls(
+                mods="issue-58763",
+            )
+            assert len(ret.raw) == 1
+            print(ret)
+            for k in ret.raw:
+                assert ret.raw[k]["result"] is True
+            assert "Detected legacy module.run syntax: test.ping" in caplog.messages

--- a/tests/unit/states/test_module.py
+++ b/tests/unit/states/test_module.py
@@ -107,7 +107,13 @@ class ModuleStateTest(TestCase, LoaderModuleMockMixin):
     """
 
     def setup_loader_modules(self):
-        return {module: {"__opts__": {"test": False}, "__salt__": {CMD: MagicMock()}}}
+        return {
+            module: {
+                "__opts__": {"test": False},
+                "__salt__": {CMD: MagicMock()},
+                "__low__": {"__id__": "test"},
+            },
+        }
 
     @classmethod
     def setUpClass(cls):
@@ -170,7 +176,7 @@ class ModuleStateTest(TestCase, LoaderModuleMockMixin):
         with patch(
             "salt.utils.args.get_function_argspec", MagicMock(return_value=self.bspec)
         ):
-            ret = module._run(CMD, m_names="anyname")
+            ret = module._legacy_run(CMD, m_names="anyname")
         self.assertEqual(ret["comment"], "'names' must be a list.")
 
     def test_run_testmode(self):
@@ -382,7 +388,7 @@ class ModuleStateTest(TestCase, LoaderModuleMockMixin):
         name isn't available
         """
         with patch.dict(module.__salt__, {}, clear=True):
-            ret = module._run(CMD)
+            ret = module._legacy_run(CMD)
         self.assertFalse(ret["result"])
         self.assertEqual(
             ret["comment"], "Module function {} is not available".format(CMD)
@@ -393,7 +399,7 @@ class ModuleStateTest(TestCase, LoaderModuleMockMixin):
         Tests the return of module.run state when test=True is passed in
         """
         with patch.dict(module.__opts__, {"test": True}):
-            ret = module._run(CMD)
+            ret = module._legacy_run(CMD)
         self.assertEqual(
             ret["comment"], "Module function {} is set to execute".format(CMD)
         )
@@ -405,7 +411,7 @@ class ModuleStateTest(TestCase, LoaderModuleMockMixin):
         with patch(
             "salt.utils.args.get_function_argspec", MagicMock(return_value=self.aspec)
         ):
-            ret = module._run(CMD)
+            ret = module._legacy_run(CMD)
         self.assertIn("The following arguments are missing:", ret["comment"])
         self.assertIn("world", ret["comment"])
         self.assertIn("hello", ret["comment"])


### PR DESCRIPTION
### What does this PR do?

Backports upstream PR: https://github.com/saltstack/salt/pull/61772

- Removes deprecation message for `module.run`
- Implements autodetection of used `module.run` syntax

#### IMPORTANT NOTE
PR https://github.com/uyuni-project/uyuni/pull/5494 (and backports to relevant branches) should be merged first, as this change is causing tracebacks due to missing globals injection to `module` state module called with `mgrcompat`

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/17838

### Previous Behavior
Users needed to opt-in to use the new style of calling `module.run` and were not able to mix new and legacy `module.run` calls.

### New Behavior
Users no longer need to opt-in to the new style of calling `module.run`. Both styles are now supported and which style being used is detected automatically.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
