### PR TITLE
Fix handling of a sign-in response by a syndic node (bsc#1199906)

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -811,11 +811,6 @@ class AsyncAuth(object):
                 )
                 return "retry"
 
-        if self.opts.get("syndic_master", False):  # Is syndic
-            syndic_finger = self.opts.get(
-                "syndic_finger", self.opts.get("master_finger", False)
-            )
-            raise SaltClientError('Invalid master key')
         if self.opts.get('syndic_master', False):  # Is syndic
             syndic_finger = self.opts.get('syndic_finger', self.opts.get('master_finger', False))
             if syndic_finger:


### PR DESCRIPTION
Remove a relic from the backport c56be5236f29 ("Fix multiple security issues (bsc#1197417)") which leads to an incorrect disconnection of a syndic node from the master.