### PR TITLE
Unify logic on using multiple requisites and add onfail_all (bsc#1198738) - 3000.3

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -74,6 +74,7 @@ STATE_REQUISITE_KEYWORDS = frozenset([
     'onchanges_any',
     'onfail',
     'onfail_any',
+    'onfail_all',
     'onfail_stop',
     'prereq',
     'prerequired',
@@ -2496,6 +2497,8 @@ class State(object):
             present = True
         if 'onchanges' in low:
             present = True
+        if 'onfail_all' in low:
+            present = True
         if 'onchanges_any' in low:
             present = True
         if not present:
@@ -2509,6 +2512,7 @@ class State(object):
                 'prereq': [],
                 'onfail': [],
                 'onfail_any': [],
+                'onfail_all': [],
                 'onchanges': [],
                 'onchanges_any': []}
         if pre:
@@ -2597,7 +2601,7 @@ class State(object):
                 else:
                     if run_dict[tag].get('__state_ran__', True):
                         req_stats.add('met')
-            if r_state.endswith('_any'):
+            if r_state.endswith('_any') or r_state == 'onfail':
                 if 'met' in req_stats or 'change' in req_stats:
                     if 'fail' in req_stats:
                         req_stats.remove('fail')
@@ -2607,8 +2611,14 @@ class State(object):
                     if 'fail' in req_stats:
                         req_stats.remove('fail')
                 if 'onfail' in req_stats:
-                    if 'fail' in req_stats:
+                    # a met requisite in this case implies a success
+                    if 'met' in req_stats:
                         req_stats.remove('onfail')
+            if r_state.endswith('_all'):
+                if 'onfail' in req_stats:
+                    # a met requisite in this case implies a failure
+                    if 'met' in req_stats:
+                        req_stats.remove('met')
             fun_stats.update(req_stats)
 
         if 'unmet' in fun_stats:
@@ -2620,8 +2630,8 @@ class State(object):
                 status = 'met'
             else:
                 status = 'pre'
-        elif 'onfail' in fun_stats and 'met' not in fun_stats:
-            status = 'onfail'  # all onfail states are OK
+        elif 'onfail' in fun_stats and 'onchangesmet' not in fun_stats:
+            status = 'onfail'
         elif 'onchanges' in fun_stats and 'onchangesmet' not in fun_stats:
             status = 'onchanges'
         elif 'change' in fun_stats:

--- a/tests/integration/files/file/base/requisites/onfail_all.sls
+++ b/tests/integration/files/file/base/requisites/onfail_all.sls
@@ -1,0 +1,54 @@
+a:
+  cmd.run:
+    - name: exit 0
+
+b:
+  cmd.run:
+    - name: exit 0
+
+c:
+  cmd.run:
+    - name: exit 0
+
+d:
+  cmd.run:
+    - name: exit 1
+
+e:
+  cmd.run:
+    - name: exit 1
+
+f:
+  cmd.run:
+    - name: exit 1
+
+reqs not met:
+  cmd.run:
+    - name: echo itdidntonfail
+    - onfail_all:
+      - cmd: a
+      - cmd: e
+
+reqs also not met:
+  cmd.run:
+    - name: echo italsodidnonfail
+    - onfail_all:
+      - cmd: a
+      - cmd: b
+      - cmd: c
+
+reqs met:
+  cmd.run:
+    - name: echo itonfailed
+    - onfail_all:
+      - cmd: d
+      - cmd: e
+      - cmd: f
+
+reqs also met:
+  cmd.run:
+    - name: echo itonfailed
+    - onfail_all:
+      - cmd: d
+    - require:
+      - cmd: a

--- a/tests/integration/files/file/base/requisites/onfail_multiple_required.sls
+++ b/tests/integration/files/file/base/requisites/onfail_multiple_required.sls
@@ -2,6 +2,10 @@ a:
   cmd.run:
     - name: exit 1
 
+pass:
+  cmd.run:
+    - name: exit 0
+
 b:
   cmd.run:
     - name: echo b
@@ -23,3 +27,19 @@ d:
       - cmd: a
     - require:
       - cmd: c
+
+e:
+  cmd.run:
+    - name: echo e
+    - onfail:
+      - cmd: pass
+    - require:
+      - cmd: c
+
+f:
+  cmd.run:
+    - name: echo f
+    - onfail:
+      - cmd: pass
+    - onchanges:
+      - cmd: b

--- a/tests/integration/modules/test_state.py
+++ b/tests/integration/modules/test_state.py
@@ -1033,6 +1033,81 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
         self.assertReturnNonEmptySaltType(ret)
         self.assertEqual(expected_result, result)
 
+    @skipIf(True, "SLOWTEST skip")
+    def test_requisites_onfail_all(self):
+        """
+        Call sls file containing several onfail-all
+
+        Ensure that some of them are failing and that the order is right.
+        """
+        expected_result = {
+            "cmd_|-a_|-exit 0_|-run": {
+                "__run_num__": 0,
+                "changes": True,
+                "comment": 'Command "exit 0" run',
+                "result": True,
+            },
+            "cmd_|-b_|-exit 0_|-run": {
+                "__run_num__": 1,
+                "changes": True,
+                "comment": 'Command "exit 0" run',
+                "result": True,
+            },
+            "cmd_|-c_|-exit 0_|-run": {
+                "__run_num__": 2,
+                "changes": True,
+                "comment": 'Command "exit 0" run',
+                "result": True,
+            },
+            "cmd_|-d_|-exit 1_|-run": {
+                "__run_num__": 3,
+                "changes": True,
+                "comment": 'Command "exit 1" run',
+                "result": False,
+            },
+            "cmd_|-e_|-exit 1_|-run": {
+                "__run_num__": 4,
+                "changes": True,
+                "comment": 'Command "exit 1" run',
+                "result": False,
+            },
+            "cmd_|-f_|-exit 1_|-run": {
+                "__run_num__": 5,
+                "changes": True,
+                "comment": 'Command "exit 1" run',
+                "result": False,
+            },
+            "cmd_|-reqs also met_|-echo itonfailed_|-run": {
+                "__run_num__": 9,
+                "changes": True,
+                "comment": 'Command "echo itonfailed" run',
+                "result": True,
+            },
+            "cmd_|-reqs also not met_|-echo italsodidnonfail_|-run": {
+                "__run_num__": 7,
+                "changes": False,
+                "comment": "State was not run because onfail req did not change",
+                "result": True,
+            },
+            "cmd_|-reqs met_|-echo itonfailed_|-run": {
+                "__run_num__": 8,
+                "changes": True,
+                "comment": 'Command "echo itonfailed" run',
+                "result": True,
+            },
+            "cmd_|-reqs not met_|-echo itdidntonfail_|-run": {
+                "__run_num__": 6,
+                "changes": False,
+                "comment": "State was not run because onfail req did not change",
+                "result": True,
+            },
+        }
+        ret = self.run_function("state.sls", mods="requisites.onfail_all")
+        result = self.normalize_ret(ret)
+        self.assertReturnNonEmptySaltType(ret)
+        self.assertEqual(expected_result, result)
+
+    @skipIf(True, "SLOWTEST skip")
     def test_requisites_full_sls(self):
         '''
         Teste the sls special command in requisites
@@ -1718,6 +1793,13 @@ class StateModuleTest(ModuleCase, SaltReturnAssertsMixin):
         stdout = state_run['cmd_|-d_|-echo d_|-run']['changes']['stdout']
         self.assertEqual(stdout, 'd')
 
+        comment = state_run["cmd_|-e_|-echo e_|-run"]["comment"]
+        self.assertEqual(comment, "State was not run because onfail req did not change")
+
+        stdout = state_run["cmd_|-f_|-echo f_|-run"]["changes"]["stdout"]
+        self.assertEqual(stdout, "f")
+
+    @skipIf(True, "SLOWTEST skip")
     def test_multiple_onfail_requisite_with_required_no_run(self):
         '''
         test to ensure multiple states are not run


### PR DESCRIPTION
### What does this PR do?

Port of https://github.com/openSUSE/salt/pull/531 to `3000.3`

Backport of https://github.com/saltstack/salt/pull/56831 (https://github.com/saltstack/salt/pull/50264) to align the logic of multiple requisites with `3002.2` and higer versions.

### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/17580

### Previous Behavior
Difference in behavior while using multiple requisites set to a state between `3002.2` and `3000`.

### New Behavior
The same behavior for `3000` and higher versions
