### PR TITLE
Fix ownership of salt thin directory when using the bundle

### DIFF
--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -292,7 +292,30 @@ def main(argv):  # pylint: disable=W0613
             os.makedirs(OPTIONS.saltdir)
             cache_dir = os.path.join(OPTIONS.saltdir, "running_data", "var", "cache")
             os.makedirs(os.path.join(cache_dir, "salt"))
-            os.symlink("salt", os.path.relpath(os.path.join(cache_dir, "venv-salt-minion")))
+            os.symlink(
+                "salt", os.path.relpath(os.path.join(cache_dir, "venv-salt-minion"))
+            )
+        if os.path.exists(OPTIONS.saltdir) and (
+            "SUDO_UID" in os.environ or "SUDO_GID" in os.environ
+        ):
+            try:
+                sudo_uid = int(os.environ.get("SUDO_UID", -1))
+            except ValueError:
+                sudo_uid = -1
+            try:
+                sudo_gid = int(os.environ.get("SUDO_GID", -1))
+            except ValueError:
+                sudo_gid = -1
+            dstat = os.stat(OPTIONS.saltdir)
+            if (sudo_uid != -1 and dstat.st_uid != sudo_uid) or (
+                sudo_gid != -1 and dstat.st_gid != sudo_gid
+            ):
+                os.chown(OPTIONS.saltdir, sudo_uid, sudo_gid)
+                for dir_path, dir_names, file_names in os.walk(OPTIONS.saltdir):
+                    for dir_name in dir_names:
+                        os.lchown(os.path.join(dir_path, dir_name), sudo_uid, sudo_gid)
+                    for file_name in file_names:
+                        os.lchown(os.path.join(dir_path, file_name), sudo_uid, sudo_gid)
 
     if venv_salt_call is None:
         # Use Salt thin only if Salt Bundle (venv-salt-minion) is not available


### PR DESCRIPTION
### What does this PR do?

Fixes the ownersheep of salt thin directory on the client when using sudo user for salt ssh.

### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/18089

### Previous Behavior
Errors on performing salt ssh with sudo user

### New Behavior
No errors on using salt ssh with sudo user

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
