### PR TITLE
add support for gpgautoimport

### DIFF
--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -1395,7 +1395,6 @@ def mod_repo(repo, **kwargs):
         cmd_opt.append("--name='{}'".format(kwargs.get("humanname")))
 
     if kwargs.get("gpgautoimport") is True:
-        global_cmd_opt.append("--gpg-auto-import-keys")
         call_refresh = True
 
     if cmd_opt:
@@ -1407,8 +1406,8 @@ def mod_repo(repo, **kwargs):
         # when used with "zypper ar --refresh" or "zypper mr --refresh"
         # --gpg-auto-import-keys is not doing anything
         # so we need to specifically refresh here with --gpg-auto-import-keys
-        refresh_opts = global_cmd_opt + ["refresh"] + [repo]
-        __zypper__(root=root).xml.call(*refresh_opts)
+        kwargs.update({"repos": repo})
+        refresh_db(root=root, **kwargs)
     elif not added and not cmd_opt:
         comment = "Specified arguments did not result in modification of repo"
 

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -591,7 +591,7 @@ def list_upgrades(refresh=True, root=None, **kwargs):
         salt '*' pkg.list_upgrades
     """
     if refresh:
-        refresh_db(root)
+        refresh_db(root, **kwargs)
 
     ret = dict()
     cmd = ["list-updates"]
@@ -705,7 +705,7 @@ def info_available(*names, **kwargs):
 
     # Refresh db before extracting the latest package
     if kwargs.get("refresh", True):
-        refresh_db(root)
+        refresh_db(root, **kwargs)
 
     pkg_info = []
     batch = names[:]
@@ -1656,7 +1656,7 @@ def install(
                 'arch': '<new-arch>'}}}
     """
     if refresh:
-        refresh_db(root)
+        refresh_db(root, **kwargs)
 
     try:
         pkg_params, pkg_type = __salt__["pkg_resource.parse_targets"](
@@ -1893,7 +1893,7 @@ def upgrade(
         cmd_update.insert(0, "--no-gpg-checks")
 
     if refresh:
-        refresh_db(root)
+        refresh_db(root, **kwargs)
 
     if dryrun:
         cmd_update.append("--dry-run")
@@ -2791,7 +2791,7 @@ def search(criteria, refresh=False, **kwargs):
     root = kwargs.get("root", None)
 
     if refresh:
-        refresh_db(root)
+        refresh_db(root, **kwargs)
 
     cmd = ["search"]
     if kwargs.get("match") == "exact":
@@ -2942,7 +2942,7 @@ def download(*packages, **kwargs):
 
     refresh = kwargs.get("refresh", False)
     if refresh:
-        refresh_db(root)
+        refresh_db(root, **kwargs)
 
     pkg_ret = {}
     for dld_result in (
@@ -3094,7 +3094,7 @@ def list_patches(refresh=False, root=None, **kwargs):
         salt '*' pkg.list_patches
     """
     if refresh:
-        refresh_db(root)
+        refresh_db(root, **kwargs)
 
     return _get_patches(root=root)
 
@@ -3188,7 +3188,7 @@ def resolve_capabilities(pkgs, refresh=False, root=None, **kwargs):
         salt '*' pkg.resolve_capabilities resolve_capabilities=True w3m_ssl
     """
     if refresh:
-        refresh_db(root)
+        refresh_db(root, **kwargs)
 
     ret = list()
     for pkg in pkgs:

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -1419,7 +1419,7 @@ def mod_repo(repo, **kwargs):
     return repo
 
 
-def refresh_db(force=None, root=None):
+def refresh_db(force=None, root=None, **kwargs):
     """
     Trigger a repository refresh by calling ``zypper refresh``. Refresh will run
     with ``--force`` if the "force=True" flag is passed on the CLI or
@@ -1429,6 +1429,17 @@ def refresh_db(force=None, root=None):
     It will return a dict::
 
         {'<database name>': Bool}
+
+    gpgautoimport : False
+        If set to True, automatically trust and import public GPG key for
+        the repository.
+
+        .. versionadded:: 3005
+
+    repos
+        Refresh just the specified repos
+
+        .. versionadded:: 3005
 
     root
         operate on a different root directory.
@@ -1450,11 +1461,18 @@ def refresh_db(force=None, root=None):
     salt.utils.pkg.clear_rtag(__opts__)
     ret = {}
     refresh_opts = ["refresh"]
+    global_opts = []
     if force is None:
         force = __pillar__.get("zypper", {}).get("refreshdb_force", True)
     if force:
         refresh_opts.append("--force")
-    out = __zypper__(root=root).refreshable.call(*refresh_opts)
+    repos = kwargs.get("repos", [])
+    refresh_opts.extend([repos] if not isinstance(repos, list) else repos)
+
+    if kwargs.get("gpgautoimport", False):
+        global_opts.append("--gpg-auto-import-keys")
+
+    out = __zypper__(root=root).refreshable.call(*global_opts, *refresh_opts)
 
     for line in out.splitlines():
         if not line:

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -2104,17 +2104,22 @@ Repository 'DUMMY' not found by its alias, number, or URI.
 
         url = self.new_repo_config["url"]
         name = self.new_repo_config["name"]
-        with zypper_patcher:
+        with zypper_patcher, patch.object(zypper, "refresh_db", Mock()) as refreshmock:
             zypper.mod_repo(name, **{"url": url, "gpgautoimport": True})
             self.assertEqual(
                 zypper.__zypper__(root=None).xml.call.call_args_list,
                 [
                     call("ar", url, name),
-                    call("--gpg-auto-import-keys", "refresh", name),
                 ],
             )
             self.assertTrue(
                 zypper.__zypper__(root=None).refreshable.xml.call.call_count == 0
+            )
+            refreshmock.assert_called_once_with(
+                gpgautoimport=True,
+                repos=name,
+                root=None,
+                url="http://repo.url/some/path",
             )
 
     def test_repo_noadd_nomod_ref(self):
@@ -2134,14 +2139,16 @@ Repository 'DUMMY' not found by its alias, number, or URI.
             "salt.modules.zypperpkg", **self.zypper_patcher_config
         )
 
-        with zypper_patcher:
+        with zypper_patcher, patch.object(zypper, "refresh_db", Mock()) as refreshmock:
             zypper.mod_repo(name, **{"url": url, "gpgautoimport": True})
-            self.assertEqual(
-                zypper.__zypper__(root=None).xml.call.call_args_list,
-                [call("--gpg-auto-import-keys", "refresh", name)],
-            )
             self.assertTrue(
                 zypper.__zypper__(root=None).refreshable.xml.call.call_count == 0
+            )
+            refreshmock.assert_called_once_with(
+                gpgautoimport=True,
+                repos=name,
+                root=None,
+                url="http://repo.url/some/path",
             )
 
     def test_repo_add_mod_ref(self):
@@ -2155,10 +2162,10 @@ Repository 'DUMMY' not found by its alias, number, or URI.
         zypper_patcher = patch.multiple(
             "salt.modules.zypperpkg", **self.zypper_patcher_config
         )
-
         url = self.new_repo_config["url"]
         name = self.new_repo_config["name"]
-        with zypper_patcher:
+
+        with zypper_patcher, patch.object(zypper, "refresh_db", Mock()) as refreshmock:
             zypper.mod_repo(
                 name, **{"url": url, "refresh": True, "gpgautoimport": True}
             )
@@ -2166,11 +2173,17 @@ Repository 'DUMMY' not found by its alias, number, or URI.
                 zypper.__zypper__(root=None).xml.call.call_args_list,
                 [
                     call("ar", url, name),
-                    call("--gpg-auto-import-keys", "refresh", name),
                 ],
             )
             zypper.__zypper__(root=None).refreshable.xml.call.assert_called_once_with(
-                "--gpg-auto-import-keys", "mr", "--refresh", name
+                "mr", "--refresh", name
+            )
+            refreshmock.assert_called_once_with(
+                gpgautoimport=True,
+                refresh=True,
+                repos=name,
+                root=None,
+                url="http://repo.url/some/path",
             )
 
     def test_repo_noadd_mod_ref(self):
@@ -2190,16 +2203,19 @@ Repository 'DUMMY' not found by its alias, number, or URI.
             "salt.modules.zypperpkg", **self.zypper_patcher_config
         )
 
-        with zypper_patcher:
+        with zypper_patcher, patch.object(zypper, "refresh_db", Mock()) as refreshmock:
             zypper.mod_repo(
                 name, **{"url": url, "refresh": True, "gpgautoimport": True}
             )
-            self.assertEqual(
-                zypper.__zypper__(root=None).xml.call.call_args_list,
-                [call("--gpg-auto-import-keys", "refresh", name)],
-            )
             zypper.__zypper__(root=None).refreshable.xml.call.assert_called_once_with(
-                "--gpg-auto-import-keys", "mr", "--refresh", name
+                "mr", "--refresh", name
+            )
+            refreshmock.assert_called_once_with(
+                gpgautoimport=True,
+                refresh=True,
+                repos=name,
+                root=None,
+                url="http://repo.url/some/path",
             )
 
     def test_wildcard_to_query_match_all(self):

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -376,6 +376,73 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
                 zypper_mock.assert_called_with(
                     ["zypper", "--non-interactive", "refresh", "--force"], **call_kwargs
                 )
+                zypper.refresh_db(gpgautoimport=True)
+                zypper_mock.assert_called_with(
+                    [
+                        "zypper",
+                        "--non-interactive",
+                        "--gpg-auto-import-keys",
+                        "refresh",
+                        "--force",
+                    ],
+                    **call_kwargs
+                )
+                zypper.refresh_db(gpgautoimport=True, force=True)
+                zypper_mock.assert_called_with(
+                    [
+                        "zypper",
+                        "--non-interactive",
+                        "--gpg-auto-import-keys",
+                        "refresh",
+                        "--force",
+                    ],
+                    **call_kwargs
+                )
+                zypper.refresh_db(gpgautoimport=True, force=False)
+                zypper_mock.assert_called_with(
+                    [
+                        "zypper",
+                        "--non-interactive",
+                        "--gpg-auto-import-keys",
+                        "refresh",
+                    ],
+                    **call_kwargs
+                )
+                zypper.refresh_db(
+                    gpgautoimport=True,
+                    refresh=True,
+                    repos="mock-repo-name",
+                    root=None,
+                    url="http://repo.url/some/path",
+                )
+                zypper_mock.assert_called_with(
+                    [
+                        "zypper",
+                        "--non-interactive",
+                        "--gpg-auto-import-keys",
+                        "refresh",
+                        "--force",
+                        "mock-repo-name",
+                    ],
+                    **call_kwargs
+                )
+                zypper.refresh_db(
+                    gpgautoimport=True,
+                    repos="mock-repo-name",
+                    root=None,
+                    url="http://repo.url/some/path",
+                )
+                zypper_mock.assert_called_with(
+                    [
+                        "zypper",
+                        "--non-interactive",
+                        "--gpg-auto-import-keys",
+                        "refresh",
+                        "--force",
+                        "mock-repo-name",
+                    ],
+                    **call_kwargs
+                )
 
     def test_info_installed(self):
         """


### PR DESCRIPTION
### What does this PR do?

- add support for gpgautoimport to refresh_db in the zypperpkg module
- call refresh_db function from mod_repo
- call refresh_db with kwargs where possible

Upstream PR https://github.com/saltstack/salt/pull/62209