### PR TITLE
Make Salt 3004 compatible with "pyzmq" >= 23.0.0 (bsc#1201082)

### DIFF
--- a/salt/transport/zeromq.py
+++ b/salt/transport/zeromq.py
@@ -898,7 +898,7 @@ class ZeroMQPubServerChannel(salt.transport.server.PubServerChannel):
         try:
             pub_sock.setsockopt(zmq.HWM, self.opts.get("pub_hwm", 1000))
         # in zmq >= 3.0, there are separate send and receive HWM settings
-        except AttributeError:
+        except (AttributeError, zmq.error.ZMQError):
             # Set the High Water Marks. For more information on HWM, see:
             # http://api.zeromq.org/4-1:zmq-setsockopt
             pub_sock.setsockopt(zmq.SNDHWM, self.opts.get("pub_hwm", 1000))


### PR DESCRIPTION
### What does this PR do?

This PR makes Salt compatible with pyzmq >= 23.0.0

It looks like before release 23.0.0, when trying to access zmq.HWM it was raising ``AttributeError``, which is now wrapped under pyzmq's own `zmq.error.ZMQError`.

Simply caching that, should then set the HWM correctly for zmq >= 3 and therefore fix https://github.com/saltstack/salt/issues/62092

Upstream PR: https://github.com/saltstack/salt/pull/62119
Fixes: https://github.com/openSUSE/salt/issues/542

