### PR TITLE
3004: Change the delimeters to prevent possible tracebacks on some packages with dpkg_lowpkg

### DIFF
--- a/salt/modules/dpkg_lowpkg.py
+++ b/salt/modules/dpkg_lowpkg.py
@@ -309,9 +309,8 @@ def _get_pkg_info(*packages, **kwargs):
         "origin:${Origin}\\n"
         "homepage:${Homepage}\\n"
         "status:${db:Status-Abbrev}\\n"
-        "======\\n"
         "description:${Description}\\n"
-        "------\\n'"
+        "\\n*/~^\\\\*\\n'"
     )
     cmd += " {}".format(" ".join(packages))
     cmd = cmd.strip()
@@ -325,9 +324,13 @@ def _get_pkg_info(*packages, **kwargs):
         else:
             return ret
 
-    for pkg_info in [elm for elm in re.split(r"------", call["stdout"]) if elm.strip()]:
+    for pkg_info in [
+        elm
+        for elm in re.split(r"\r?\n\*/~\^\\\*(\r?\n|)", call["stdout"])
+        if elm.strip()
+    ]:
         pkg_data = {}
-        pkg_info, pkg_descr = re.split(r"======", pkg_info)
+        pkg_info, pkg_descr = pkg_info.split("\ndescription:", 1)
         for pkg_info_line in [
             el.strip() for el in pkg_info.split(os.linesep) if el.strip()
         ]:
@@ -344,7 +347,7 @@ def _get_pkg_info(*packages, **kwargs):
         if build_date:
             pkg_data["build_date"] = build_date
             pkg_data["build_date_time_t"] = build_date_t
-        pkg_data["description"] = pkg_descr.split(":", 1)[-1]
+        pkg_data["description"] = pkg_descr
         ret.append(pkg_data)
 
     return ret

--- a/tests/unit/modules/test_dpkg_lowpkg.py
+++ b/tests/unit/modules/test_dpkg_lowpkg.py
@@ -290,7 +290,6 @@ class DpkgTestCase(TestCase, LoaderModuleMockMixin):
                         "origin:",
                         "homepage:http://tiswww.case.edu/php/chet/bash/bashtop.html",
                         "status:ii ",
-                        "======",
                         "description:GNU Bourne Again SHell",
                         " Bash is an sh-compatible command language interpreter that"
                         " executes",
@@ -307,7 +306,8 @@ class DpkgTestCase(TestCase, LoaderModuleMockMixin):
                         " The Programmable Completion Code, by Ian Macdonald, is now"
                         " found in",
                         " the bash-completion package.",
-                        "------",
+                        "",
+                        "*/~^\\*",  # pylint: disable=W1401
                     ]
                 ),
             }


### PR DESCRIPTION
### What does this PR do?

`dpkg_lowpkg` is using `------` and `======` as a delimiters while calling `dpkg-query` to get the information about the packages. The problem here that some of the packages have such delimiters in the description field what causing tracebacks on attempt to get the package information.

The packages causing this issues (tested on Ubuntu 20.04): `libencode-eucjpms-perl` and `owncloud-client`.

### What issues does this PR fix or reference?
Fixes: https://github.com/uyuni-project/uyuni/issues/5523
Tracks: https://github.com/SUSE/spacewalk/issues/18142

### Previous Behavior
Possible tracebacks in case if there is a package with `------` or `======`  in the description is installed on the minion.

### New Behavior
Normal behavior

### Upstream PR
https://github.com/saltstack/salt/pull/62519

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
