### PR TITLE
3004: Fix state apply in test mode with file state module on user/group checking (bsc#1202167)

### DIFF
--- a/changelog/61846.fixed
+++ b/changelog/61846.fixed
@@ -1,0 +1,1 @@
+Fix the reporting of errors for file.directory in test mode

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -379,6 +379,11 @@ def _check_user(user, group):
         gid = __salt__["file.group_to_gid"](group)
         if gid == "":
             err += "Group {} is not available".format(group)
+    if err and __opts__["test"]:
+        # Write the warning with error message, but prevent failing,
+        # in case of applying the state in test mode.
+        log.warning(err)
+        return ""
     return err
 
 

--- a/tests/pytests/unit/states/file/test_copy.py
+++ b/tests/pytests/unit/states/file/test_copy.py
@@ -205,3 +205,38 @@ def test_copy(tmp_path):
                     )
                     res = filestate.copy_(name, source, group=group, preserve=False)
                     assert res == ret
+
+
+def test_copy_test_mode_user_group_not_present():
+    """
+    Test file copy in test mode with no user or group existing
+    """
+    source = "/tmp/src_copy_no_user_group_test_mode"
+    filename = "/tmp/copy_no_user_group_test_mode"
+    with patch.dict(
+        filestate.__salt__,
+        {
+            "file.group_to_gid": MagicMock(side_effect=["1234", "", ""]),
+            "file.user_to_uid": MagicMock(side_effect=["", "4321", ""]),
+            "file.get_mode": MagicMock(return_value="0644"),
+        },
+    ), patch.dict(filestate.__opts__, {"test": True}), patch.object(
+        os.path, "exists", return_value=True
+    ):
+        ret = filestate.copy_(
+            source, filename, group="nonexistinggroup", user="nonexistinguser"
+        )
+        assert ret["result"] is not False
+        assert "is not available" not in ret["comment"]
+
+        ret = filestate.copy_(
+            source, filename, group="nonexistinggroup", user="nonexistinguser"
+        )
+        assert ret["result"] is not False
+        assert "is not available" not in ret["comment"]
+
+        ret = filestate.copy_(
+            source, filename, group="nonexistinggroup", user="nonexistinguser"
+        )
+        assert ret["result"] is not False
+        assert "is not available" not in ret["comment"]

--- a/tests/pytests/unit/states/file/test_filestate.py
+++ b/tests/pytests/unit/states/file/test_filestate.py
@@ -577,3 +577,45 @@ def test_mod_run_check_cmd():
         assert filestate.mod_run_check_cmd(cmd, filename) == ret
 
         assert filestate.mod_run_check_cmd(cmd, filename)
+
+
+def test_recurse_test_mode_user_group_not_present():
+    """
+    Test file recurse in test mode with no user or group existing
+    """
+    filename = "/tmp/recurse_no_user_group_test_mode"
+    source = "salt://tmp/src_recurse_no_user_group_test_mode"
+    mock_l = MagicMock(return_value=[])
+    mock_emt = MagicMock(return_value=["tmp/src_recurse_no_user_group_test_mode"])
+    with patch.dict(
+        filestate.__salt__,
+        {
+            "file.group_to_gid": MagicMock(side_effect=["1234", "", ""]),
+            "file.user_to_uid": MagicMock(side_effect=["", "4321", ""]),
+            "file.get_mode": MagicMock(return_value="0644"),
+            "file.source_list": MagicMock(return_value=[source, ""]),
+            "cp.list_master_dirs": mock_emt,
+            "cp.list_master": mock_l,
+        },
+    ), patch.dict(filestate.__opts__, {"test": True}), patch.object(
+        os.path, "exists", return_value=True
+    ), patch.object(
+        os.path, "isdir", return_value=True
+    ):
+        ret = filestate.recurse(
+            filename, source, group="nonexistinggroup", user="nonexistinguser"
+        )
+        assert ret["result"] is not False
+        assert "is not available" not in ret["comment"]
+
+        ret = filestate.recurse(
+            filename, source, group="nonexistinggroup", user="nonexistinguser"
+        )
+        assert ret["result"] is not False
+        assert "is not available" not in ret["comment"]
+
+        ret = filestate.recurse(
+            filename, source, group="nonexistinggroup", user="nonexistinguser"
+        )
+        assert ret["result"] is not False
+        assert "is not available" not in ret["comment"]

--- a/tests/pytests/unit/states/file/test_managed.py
+++ b/tests/pytests/unit/states/file/test_managed.py
@@ -373,3 +373,34 @@ def test_managed():
                                         filestate.managed(name, user=user, group=group)
                                         == ret
                                     )
+
+
+def test_managed_test_mode_user_group_not_present():
+    """
+    Test file managed in test mode with no user or group existing
+    """
+    filename = "/tmp/managed_no_user_group_test_mode"
+    with patch.dict(
+        filestate.__salt__,
+        {
+            "file.group_to_gid": MagicMock(side_effect=["1234", "", ""]),
+            "file.user_to_uid": MagicMock(side_effect=["", "4321", ""]),
+        },
+    ), patch.dict(filestate.__opts__, {"test": True}):
+        ret = filestate.managed(
+            filename, group="nonexistinggroup", user="nonexistinguser"
+        )
+        assert ret["result"] is not False
+        assert "is not available" not in ret["comment"]
+
+        ret = filestate.managed(
+            filename, group="nonexistinggroup", user="nonexistinguser"
+        )
+        assert ret["result"] is not False
+        assert "is not available" not in ret["comment"]
+
+        ret = filestate.managed(
+            filename, group="nonexistinggroup", user="nonexistinguser"
+        )
+        assert ret["result"] is not False
+        assert "is not available" not in ret["comment"]


### PR DESCRIPTION
### What does this PR do?

This is a follow up PR to https://github.com/saltstack/salt/pull/61847
The PR was fixing only `file.directory` state function while there are 3 more affected functions with the same issue: `file.managed`, `file.copy`, `file.recurse`. All of them are using `_check_user`.

This PR is fixing `_check_user` with writing a warning to the log instead of failing in case if the state is applied in a test mode.

### Previous Behavior
If the state file contains user/group creation and one of the mentioned functions after with setting user/group ownership ot a file or directory, the state is failing while apply in a test mode, but not failing with normal state apply.

### New Behavior
Do not fail on mentioned case, but write a warning to the log.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/18549

### Upstream PR
https://github.com/saltstack/salt/pull/62499

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
