### PR TITLE
3000: Fix state apply in test mode with file state module on user/group checking (bsc#1202167)

### DIFF
--- a/changelog/61846.fixed
+++ b/changelog/61846.fixed
@@ -1,0 +1,1 @@
+Fix the reporting of errors for file.directory in test mode

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -392,6 +392,11 @@ def _check_user(user, group):
         gid = __salt__['file.group_to_gid'](group)
         if gid == '':
             err += 'Group {0} is not available'.format(group)
+    if err and __opts__["test"]:
+        # Write the warning with error message, but prevent failing,
+        # in case of applying the state in test mode.
+        log.warning(err)
+        return ""
     return err
 
 

--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -2212,6 +2212,60 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
         run_checks(strptime_format=fake_strptime_format)
         run_checks(strptime_format=fake_strptime_format, test=True)
 
+    def test_directory_test_mode_user_group_not_present(self):
+        name = "/etc/testdir"
+        user = "salt"
+        group = "saltstack"
+        if salt.utils.platform.is_windows():
+            name = name.replace("/", "\\")
+
+        ret = {
+            "name": name,
+            "result": None,
+            "comment": "",
+            "changes": {name: {"directory": "new"}},
+        }
+
+        if salt.utils.platform.is_windows():
+            comt = 'The directory "{}" will be changed' "".format(name)
+        else:
+            comt = "The following files will be changed:\n{}:" " directory - new\n".format(
+                name
+            )
+        ret["comment"] = comt
+
+        mock_f = MagicMock(return_value=False)
+        mock_uid = MagicMock(
+            side_effect=[
+                "",
+                "U12",
+                "",
+            ]
+        )
+        mock_gid = MagicMock(
+            side_effect=[
+                "G12",
+                "",
+                "",
+            ]
+        )
+        mock_error = CommandExecutionError
+        with patch.dict(
+            filestate.__salt__,
+            {
+                "file.user_to_uid": mock_uid,
+                "file.group_to_gid": mock_gid,
+                "file.stats": mock_f,
+            },
+        ), patch("salt.utils.win_dacl.get_sid", mock_error), patch.object(
+            os.path, "isdir", mock_f
+        ), patch.dict(
+            filestate.__opts__, {"test": True}
+        ):
+            self.assertDictEqual(filestate.directory(name, user=user, group=group), ret)
+            self.assertDictEqual(filestate.directory(name, user=user, group=group), ret)
+            self.assertDictEqual(filestate.directory(name, user=user, group=group), ret)
+
 
 class TestFindKeepFiles(TestCase):
 

--- a/tests/unit/states/test_file.py
+++ b/tests/unit/states/test_file.py
@@ -2266,6 +2266,111 @@ class TestFileState(TestCase, LoaderModuleMockMixin):
             self.assertDictEqual(filestate.directory(name, user=user, group=group), ret)
             self.assertDictEqual(filestate.directory(name, user=user, group=group), ret)
 
+    def test_copy_test_mode_user_group_not_present(self):
+        """
+        Test file copy in test mode with no user or group existing
+        """
+        source = "/tmp/src_copy_no_user_group_test_mode"
+        filename = "/tmp/copy_no_user_group_test_mode"
+        with patch.dict(
+            filestate.__salt__,
+            {
+                "file.group_to_gid": MagicMock(side_effect=["1234", "", ""]),
+                "file.user_to_uid": MagicMock(side_effect=["", "4321", ""]),
+                "file.get_mode": MagicMock(return_value="0644"),
+            },
+        ), patch.dict(filestate.__opts__, {"test": True}), patch.object(
+            os.path, "exists", return_value=True
+        ):
+            ret = filestate.copy_(
+                source, filename, group="nonexistinggroup", user="nonexistinguser"
+            )
+            assert ret["result"] is not False
+            assert "is not available" not in ret["comment"]
+
+            ret = filestate.copy_(
+                source, filename, group="nonexistinggroup", user="nonexistinguser"
+            )
+            assert ret["result"] is not False
+            assert "is not available" not in ret["comment"]
+
+            ret = filestate.copy_(
+                source, filename, group="nonexistinggroup", user="nonexistinguser"
+            )
+            assert ret["result"] is not False
+            assert "is not available" not in ret["comment"]
+
+    def test_recurse_test_mode_user_group_not_present(self):
+        """
+        Test file recurse in test mode with no user or group existing
+        """
+        filename = "/tmp/recurse_no_user_group_test_mode"
+        source = "salt://tmp/src_recurse_no_user_group_test_mode"
+        mock_l = MagicMock(return_value=[])
+        mock_emt = MagicMock(return_value=["tmp/src_recurse_no_user_group_test_mode"])
+        with patch.dict(
+            filestate.__salt__,
+            {
+                "file.group_to_gid": MagicMock(side_effect=["1234", "", ""]),
+                "file.user_to_uid": MagicMock(side_effect=["", "4321", ""]),
+                "file.get_mode": MagicMock(return_value="0644"),
+                "file.source_list": MagicMock(return_value=[source, ""]),
+                "cp.list_master_dirs": mock_emt,
+                "cp.list_master": mock_l,
+            },
+        ), patch.dict(filestate.__opts__, {"test": True}), patch.object(
+            os.path, "exists", return_value=True
+        ), patch.object(
+            os.path, "isdir", return_value=True
+        ):
+            ret = filestate.recurse(
+                filename, source, group="nonexistinggroup", user="nonexistinguser"
+            )
+            assert ret["result"] is not False
+            assert "is not available" not in ret["comment"]
+
+            ret = filestate.recurse(
+                filename, source, group="nonexistinggroup", user="nonexistinguser"
+            )
+            assert ret["result"] is not False
+            assert "is not available" not in ret["comment"]
+
+            ret = filestate.recurse(
+                filename, source, group="nonexistinggroup", user="nonexistinguser"
+            )
+            assert ret["result"] is not False
+            assert "is not available" not in ret["comment"]
+
+    def test_managed_test_mode_user_group_not_present(self):
+        """
+        Test file managed in test mode with no user or group existing
+        """
+        filename = "/tmp/managed_no_user_group_test_mode"
+        with patch.dict(
+            filestate.__salt__,
+            {
+                "file.group_to_gid": MagicMock(side_effect=["1234", "", ""]),
+                "file.user_to_uid": MagicMock(side_effect=["", "4321", ""]),
+            },
+        ), patch.dict(filestate.__opts__, {"test": True}):
+            ret = filestate.managed(
+                filename, group="nonexistinggroup", user="nonexistinguser"
+            )
+            assert ret["result"] is not False
+            assert "is not available" not in ret["comment"]
+
+            ret = filestate.managed(
+                filename, group="nonexistinggroup", user="nonexistinguser"
+            )
+            assert ret["result"] is not False
+            assert "is not available" not in ret["comment"]
+
+            ret = filestate.managed(
+                filename, group="nonexistinggroup", user="nonexistinguser"
+            )
+            assert ret["result"] is not False
+            assert "is not available" not in ret["comment"]
+
 
 class TestFindKeepFiles(TestCase):
 


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/openSUSE/salt/pull/549 to `3000`

This is a follow up PR to https://github.com/saltstack/salt/pull/61847
The PR was fixing only `file.directory` state function while there are 3 more affected functions with the same issue: `file.managed`, `file.copy`, `file.recurse`. All of them are using `_check_user`.

This PR is fixing `_check_user` with writing a warning to the log instead of failing in case if the state is applied in a test mode.

### Previous Behavior
If the state file contains user/group creation and one of the mentioned functions after with setting user/group ownership ot a file or directory, the state is failing while apply in a test mode, but not failing with normal state apply.

### New Behavior
Do not fail on mentioned case, but write a warning to the log.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/18549

### Upstream PR
https://github.com/saltstack/salt/pull/62499

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
