### PR TITLE
3000.3: Retry if RPM lock is temporarily unavailable

### DIFF
--- a/changelog/62204.fixed
+++ b/changelog/62204.fixed
@@ -1,0 +1,1 @@
+Fixed Zypper module failing on RPM lock file being temporarily unavailable.

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -14,6 +14,8 @@ Package support for openSUSE via the zypper package manager
 
 # Import python libs
 from __future__ import absolute_import, print_function, unicode_literals
+
+import errno
 import fnmatch
 import logging
 import re
@@ -45,6 +47,9 @@ import salt.utils.versions
 from salt.utils.versions import LooseVersion
 import salt.utils.environment
 from salt.exceptions import CommandExecutionError, MinionError, SaltInvocationError
+
+if salt.utils.files.is_fcntl_available():
+    import fcntl
 
 log = logging.getLogger(__name__)
 
@@ -103,6 +108,7 @@ class _Zypper(object):
     XML_DIRECTIVES = ['-x', '--xmlout']
     # ZYPPER_LOCK is not affected by --root
     ZYPPER_LOCK = '/var/run/zypp.pid'
+    RPM_LOCK = "/var/lib/rpm/.rpm.lock"
     TAG_RELEASED = 'zypper/released'
     TAG_BLOCKED = 'zypper/blocked'
 
@@ -268,13 +274,30 @@ class _Zypper(object):
 
         return self.exit_code not in self.SUCCESS_EXIT_CODES and self.exit_code not in self.WARNING_EXIT_CODES
 
-    def _is_lock(self):
-        '''
+    def _is_zypper_lock(self):
+        """
         Is this is a lock error code?
 
         :return:
-        '''
+        """
         return self.exit_code == self.LOCK_EXIT_CODE
+
+    def _is_rpm_lock(self):
+        """
+        Is this an RPM lock error?
+        """
+        if salt.utils.files.is_fcntl_available():
+            if self.exit_code > 0 and os.path.exists(self.RPM_LOCK):
+                with salt.utils.files.fopen(self.RPM_LOCK, mode="w+") as rfh:
+                    try:
+                        fcntl.lockf(rfh, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    except OSError as err:
+                        if err.errno == errno.EAGAIN:
+                            return True
+                    else:
+                        fcntl.lockf(rfh, fcntl.LOCK_UN)
+
+        return False
 
     def _is_xml_mode(self):
         '''
@@ -296,7 +319,7 @@ class _Zypper(object):
             raise CommandExecutionError('No output result from Zypper?')
 
         self.exit_code = self.__call_result['retcode']
-        if self._is_lock():
+        if self._is_zypper_lock() or self._is_rpm_lock():
             return False
 
         if self._is_error():
@@ -369,32 +392,11 @@ class _Zypper(object):
             if self._check_result():
                 break
 
-            if os.path.exists(self.ZYPPER_LOCK):
-                try:
-                    with salt.utils.files.fopen(self.ZYPPER_LOCK) as rfh:
-                        data = __salt__['ps.proc_info'](int(rfh.readline()),
-                                                        attrs=['pid', 'name', 'cmdline', 'create_time'])
-                        data['cmdline'] = ' '.join(data['cmdline'])
-                        data['info'] = 'Blocking process created at {0}.'.format(
-                            datetime.datetime.utcfromtimestamp(data['create_time']).isoformat())
-                        data['success'] = True
-                except Exception as err:  # pylint: disable=broad-except
-                    data = {'info': 'Unable to retrieve information about blocking process: {0}'.format(err.message),
-                            'success': False}
-            else:
-                data = {'info': 'Zypper is locked, but no Zypper lock has been found.', 'success': False}
-
-            if not data['success']:
-                log.debug("Unable to collect data about blocking process.")
-            else:
-                log.debug("Collected data about blocking process.")
-
-            __salt__['event.fire_master'](data, self.TAG_BLOCKED)
-            log.debug("Fired a Zypper blocked event to the master with the data: %s", data)
-            log.debug("Waiting 5 seconds for Zypper gets released...")
-            time.sleep(5)
-            if not was_blocked:
-                was_blocked = True
+            if self._is_zypper_lock():
+                self._handle_zypper_lock_file()
+            if self._is_rpm_lock():
+                self._handle_rpm_lock_file()
+            was_blocked = True
 
         if was_blocked:
             __salt__['event.fire_master']({'success': not self.error_msg,
@@ -408,6 +410,50 @@ class _Zypper(object):
             dom.parseString(salt.utils.stringutils.to_str(self.__call_result['stdout'])) or
             self.__call_result['stdout']
         )
+
+    def _handle_zypper_lock_file(self):
+        if os.path.exists(self.ZYPPER_LOCK):
+            try:
+                with salt.utils.files.fopen(self.ZYPPER_LOCK) as rfh:
+                    data = __salt__["ps.proc_info"](
+                        int(rfh.readline()),
+                        attrs=["pid", "name", "cmdline", "create_time"],
+                    )
+                    data["cmdline"] = " ".join(data["cmdline"])
+                    data["info"] = "Blocking process created at {}.".format(
+                        datetime.datetime.utcfromtimestamp(
+                            data["create_time"]
+                        ).isoformat()
+                    )
+                    data["success"] = True
+            except Exception as err:  # pylint: disable=broad-except
+                data = {
+                    "info": (
+                        "Unable to retrieve information about "
+                        "blocking process: {}".format(err)
+                    ),
+                    "success": False,
+                }
+        else:
+            data = {
+                "info": "Zypper is locked, but no Zypper lock has been found.",
+                "success": False,
+            }
+        if not data["success"]:
+            log.debug("Unable to collect data about blocking process.")
+        else:
+            log.debug("Collected data about blocking process.")
+        __salt__["event.fire_master"](data, self.TAG_BLOCKED)
+        log.debug("Fired a Zypper blocked event to the master with the data: %s", data)
+        log.debug("Waiting 5 seconds for Zypper gets released...")
+        time.sleep(5)
+
+    def _handle_rpm_lock_file(self):
+        data = {"info": "RPM is temporarily locked.", "success": True}
+        __salt__["event.fire_master"](data, self.TAG_BLOCKED)
+        log.debug("Fired an RPM blocked event to the master with the data: %s", data)
+        log.debug("Waiting 5 seconds for RPM to get released...")
+        time.sleep(5)
 
 
 __zypper__ = _Zypper()


### PR DESCRIPTION
Backport of https://github.com/openSUSE/salt/pull/547 to `openSUSE-3000.3` branch