### PR TITLE
 Include stdout in error message for zypperpkg

### DIFF
--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -339,6 +339,11 @@ class _Zypper:
                     and self.__call_result["stderr"].strip()
                     or ""
                 )
+                msg += (
+                    self.__call_result["stdout"]
+                    and self.__call_result["stdout"].strip()
+                    or ""
+                )
                 if msg:
                     _error_msg.append(msg)
             else:

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -207,11 +207,26 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
             ):
                 zypper.__zypper__.xml.call("crashme")
 
+        output_to_user_stdout = "Output to user to stdout"
+        output_to_user_stderr = "Output to user to stderr"
+        sniffer = RunSniffer(
+            stdout=output_to_user_stdout, stderr=output_to_user_stderr, retcode=1
+        )
+        with patch.dict(
+            "salt.modules.zypperpkg.__salt__", {"cmd.run_all": sniffer}
+        ), patch.object(zypper.__zypper__, "_is_rpm_lock", return_value=False):
             with self.assertRaisesRegex(
-                CommandExecutionError, "^Zypper command failure: Check Zypper's logs.$"
+                CommandExecutionError,
+                "^Zypper command failure: {}$".format(
+                    output_to_user_stderr + output_to_user_stdout
+                ),
             ):
                 zypper.__zypper__.call("crashme again")
 
+        sniffer = RunSniffer(retcode=1)
+        with patch.dict(
+            "salt.modules.zypperpkg.__salt__", {"cmd.run_all": sniffer}
+        ), patch.object(zypper.__zypper__, "_is_rpm_lock", return_value=False):
             zypper.__zypper__.noraise.call("stay quiet")
             self.assertEqual(zypper.__zypper__.error_msg, "Check Zypper's logs.")
 


### PR DESCRIPTION
### What does this PR do?
For the zypperpkg module, improves error information to the user if zypper returns with an error code.

Backported from https://github.com/saltstack/salt/pull/62750
Fixes: https://github.com/SUSE/spacewalk/issues/17746