### PR TITLE
Align Amazon EC2 (Nitro) grains with upstream PR (bsc#1203685)

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -864,6 +864,10 @@ def _virtual(osdata):
                 grains["virtual"] = "container"
                 grains["virtual_subtype"] = "LXC"
                 break
+            elif "amazon" in output:
+                grains["virtual"] = "Nitro"
+                grains["virtual_subtype"] = "Amazon EC2"
+                break
         elif command == "virt-what":
             for line in output.splitlines():
                 if line in ("kvm", "qemu", "uml", "xen"):
@@ -1176,7 +1180,7 @@ def _virtual(osdata):
         grains["virtual"] = "virtual"
 
     # Try to detect if the instance is running on Amazon EC2
-    if grains["virtual"] in ("qemu", "kvm", "xen"):
+    if grains["virtual"] in ("qemu", "kvm", "xen", "amazon"):
         dmidecode = salt.utils.path.which("dmidecode")
         if dmidecode:
             ret = __salt__["cmd.run_all"](
@@ -1184,6 +1188,8 @@ def _virtual(osdata):
             )
             output = ret["stdout"]
             if "Manufacturer: Amazon EC2" in output:
+                if grains["virtual"] != "xen":
+                    grains["virtual"] = "Nitro"
                 grains["virtual_subtype"] = "Amazon EC2"
                 product = re.match(
                     r".*Product Name: ([^\r\n]*).*", output, flags=re.DOTALL

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -2846,6 +2846,17 @@ def test_virtual_set_virtual_ec2():
         ]
     )
 
+    def _mock_is_file(filename):
+        if filename in (
+            "/proc/1/cgroup",
+            "/proc/cpuinfo",
+            "/sys/devices/virtual/dmi/id/product_name",
+            "/proc/xen/xsd_kva",
+            "/proc/xen/capabilities",
+        ):
+            return False
+        return True
+
     with patch("salt.utils.path.which", which_mock), patch.dict(
         core.__salt__,
         {
@@ -2854,6 +2865,8 @@ def test_virtual_set_virtual_ec2():
             "cmd.retcode": salt.modules.cmdmod.retcode,
             "smbios.get": salt.modules.smbios.get,
         },
+    ), patch("os.path.isfile", _mock_is_file), patch(
+        "os.path.isdir", return_value=False
     ):
 
         virtual_grains = core._virtual(osdata.copy())

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -2863,7 +2863,7 @@ def test_virtual_set_virtual_ec2():
 
         virtual_grains = core._virtual(osdata.copy())
 
-        assert virtual_grains["virtual"] == "kvm"
+        assert virtual_grains["virtual"] == "Nitro"
         assert virtual_grains["virtual_subtype"] == "Amazon EC2 (m5.large)"
 
         virtual_grains = core._virtual(osdata.copy())

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -2785,6 +2785,11 @@ def test_virtual_set_virtual_ec2():
             "/usr/bin/systemd-detect-virt",
             None,
             None,
+            # Check with systemd-detect-virt returning amazon and no dmidecode available
+            None,
+            "/usr/bin/systemd-detect-virt",
+            None,
+            None,
         ]
     )
     cmd_run_all_mock = MagicMock(
@@ -2843,6 +2848,8 @@ def test_virtual_set_virtual_ec2():
             },
             # Check with systemd-detect-virt when no dmidecode available
             {"retcode": 0, "stderr": "", "stdout": "kvm"},
+            # Check with systemd-detect-virt returning amazon and no dmidecode available
+            {"retcode": 0, "stderr": "", "stdout": "amazon"},
         ]
     )
 
@@ -2883,6 +2890,11 @@ def test_virtual_set_virtual_ec2():
 
         assert virtual_grains["virtual"] == "kvm"
         assert "virtual_subtype" not in virtual_grains
+
+        virtual_grains = core._virtual(osdata.copy())
+
+        assert virtual_grains["virtual"] == "Nitro"
+        assert virtual_grains["virtual_subtype"] == "Amazon EC2"
 
 
 @pytest.mark.skip_on_windows


### PR DESCRIPTION
### What does this PR do?

Aligns `openSUSE` `3004` with the latest changes to upstream PR: https://github.com/saltstack/salt/pull/62539

Additionally fixes the test failing while running `salt-toaster` on KVM instance.

### What issues does this PR fix or reference?
Follow up for: https://github.com/openSUSE/salt/pull/555
Upstream PR: https://github.com/saltstack/salt/pull/62539
Fixes: https://github.com/SUSE/spacewalk/issues/19096

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
