### PR TITLE
[skip] adjust github workflows after branch renaming

### DIFF
--- a/.github/workflows/integration-opensuse-leap.yml
+++ b/.github/workflows/integration-opensuse-leap.yml
@@ -3,10 +3,10 @@ name: integration-opensuse-leap
 on:
   push:
     branches:
-      - openSUSE-3004
+      - openSUSE/release/3004
   pull_request:
     branches:
-      - openSUSE-3004
+      - openSUSE/release/3004
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/unit-opensuse-leap.yml
+++ b/.github/workflows/unit-opensuse-leap.yml
@@ -3,10 +3,10 @@ name: unit-opensuse-leap
 on:
   push:
     branches:
-      - openSUSE-3004
+      - openSUSE/release/3004
   pull_request:
     branches:
-      - openSUSE-3004
+      - openSUSE/release/3004
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
### What does this PR do?

This PR fixes the GitHub actions for `openSUSE/release/3004` after so they run after branch renaming.

### Commits signed with GPG?
Yes
