### PR TITLE
3000: Prevent double executions of GH actions

### DIFF
--- a/.github/workflows/integration-opensuse-leap-15-1.yml
+++ b/.github/workflows/integration-opensuse-leap-15-1.yml
@@ -1,5 +1,13 @@
 name: integration-opensuse-leap-15-1
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - openSUSE/release/3000
+  pull_request:
+    branches:
+      - openSUSE/release/3000
+  workflow_dispatch:
+
 jobs:
   integration-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-opensuse-leap-15-1.yml
+++ b/.github/workflows/unit-opensuse-leap-15-1.yml
@@ -1,5 +1,14 @@
 name: unit-opensuse-leap-15-1
-on: [push, pull_request]
+
+on:
+  push:
+    branches:
+      - openSUSE/release/3000
+  pull_request:
+    branches:
+      - openSUSE/release/3000
+  workflow_dispatch:
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What does this PR do?
This PR fixes the GH actions for the `openSUSE/release/3000` branch to avoid double executions of tests on the PRs.

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
