### PR TITLE
Include stdout in error message (backport 3000.3)

### DIFF
--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -325,7 +325,16 @@ class _Zypper(object):
         if self._is_error():
             _error_msg = list()
             if not self._is_xml_mode():
-                msg = self.__call_result['stderr'] and self.__call_result['stderr'].strip() or ""
+                msg = (
+                    self.__call_result["stderr"]
+                    and self.__call_result["stderr"].strip()
+                    or ""
+                )
+                msg += (
+                    self.__call_result["stdout"]
+                    and self.__call_result["stdout"].strip()
+                    or ""
+                )
                 if msg:
                     _error_msg.append(msg)
             else:

--- a/tests/unit/modules/test_zypperpkg.py
+++ b/tests/unit/modules/test_zypperpkg.py
@@ -170,7 +170,10 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
             self.assertEqual(sniffer.calls[5].get('kwargs', {}).get('env', {}).get('SALT_RUNNING'), "1")
 
         # Test exceptions
-        stdout_xml_snippet = '<?xml version="1.0"?><stream><message type="error">Booya!</message></stream>'
+        stdout_xml_snippet = (
+            '<?xml version="1.0"?><stream><message'
+            ' type="error">Booya!</message></stream>'
+        )
         sniffer = RunSniffer(stdout=stdout_xml_snippet, retcode=1)
         with patch.dict(
             "salt.modules.zypperpkg.__salt__", {"cmd.run_all": sniffer}
@@ -180,10 +183,27 @@ class ZypperTestCase(TestCase, LoaderModuleMockMixin):
             ):
                 zypper.__zypper__.xml.call("crashme")
 
-            with self.assertRaisesRegex(CommandExecutionError, "^Zypper command failure: Check Zypper's logs.$"):
-                zypper.__zypper__.call('crashme again')
+        output_to_user_stdout = "Output to user to stdout"
+        output_to_user_stderr = "Output to user to stderr"
+        sniffer = RunSniffer(
+            stdout=output_to_user_stdout, stderr=output_to_user_stderr, retcode=1
+        )
+        with patch.dict(
+            "salt.modules.zypperpkg.__salt__", {"cmd.run_all": sniffer}
+        ), patch.object(zypper.__zypper__, "_is_rpm_lock", return_value=False):
+            with self.assertRaisesRegex(
+                CommandExecutionError,
+                "^Zypper command failure: {}$".format(
+                    output_to_user_stderr + output_to_user_stdout
+                ),
+            ):
+                zypper.__zypper__.call("crashme again")
 
-            zypper.__zypper__.noraise.call('stay quiet')
+        sniffer = RunSniffer(retcode=1)
+        with patch.dict(
+            "salt.modules.zypperpkg.__salt__", {"cmd.run_all": sniffer}
+        ), patch.object(zypper.__zypper__, "_is_rpm_lock", return_value=False):
+            zypper.__zypper__.noraise.call("stay quiet")
             self.assertEqual(zypper.__zypper__.error_msg, "Check Zypper's logs.")
 
     def test_list_upgrades_error_handling(self):


### PR DESCRIPTION
### What does this PR do?

For the zypperpkg module, improves error information to the user if zypper returns with an error code.
This is the backport to OpenSUSE Salt 3000.3.

Backported from https://github.com/saltstack/salt/pull/62750
Fixes: https://github.com/SUSE/spacewalk/issues/17746