### PR TITLE
Clarify pkg.installed pkg_verify documentation 3004

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1301,14 +1301,15 @@ def installed(
 
         .. versionadded:: 2014.7.0
 
-        For requested packages that are already installed and would not be
-        targeted for upgrade or downgrade, use pkg.verify to determine if any
-        of the files installed by the package have been altered. If files have
-        been altered, the reinstall option of pkg.install is used to force a
-        reinstall. Types to ignore can be passed to pkg.verify. Additionally,
-        ``verify_options`` can be used to modify further the behavior of
-        pkg.verify. See examples below.  Currently, this option is supported
-        for the following pkg providers: :mod:`yumpkg <salt.modules.yumpkg>`.
+        Use pkg.verify to check if already installed packages require
+        reinstallion. Requested packages that are already installed and not
+        targeted for up- or downgrade are verified with pkg.verify to determine
+        if any file installed by the package have been modified or if package
+        dependencies are not fulfilled. ``ignore_types`` and ``verify_options``
+        can be passed to pkg.verify. See examples below. Currently, this option
+        is supported for the following pkg providers:
+        :mod:`yum <salt.modules.yumpkg>`,
+        :mod:`zypperpkg <salt.modules.zypperpkg>`.
 
         Examples:
 


### PR DESCRIPTION
There have been misunderstandings what the pkg_verify parameter does and bug reports that it does not work, based on the wrong assumption that this parameter changes the installation of new packages. The docstring also stated that it was only provided by `yum`, but `zypper` also provides this feature (actually it is `rpm` itself in both cases that does the verification check)

Related issue: https://github.com/saltstack/salt/issues/44878
SUMA issue: https://github.com/SUSE/spacewalk/issues/7775
Backport of https://github.com/saltstack/salt/pull/57426

(cherry picked from commit 2ed5f3c29d3b4313d904b7c081e5a29bf5e309c7)