### PR TITLE
Pass context to pillar ext modules

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -45,6 +45,7 @@ def get_pillar(
     pillar_override=None,
     pillarenv=None,
     extra_minion_data=None,
+    context=None,
 ):
     """
     Return the correct pillar driver based on the file_client option
@@ -79,6 +80,7 @@ def get_pillar(
             functions=funcs,
             pillar_override=pillar_override,
             pillarenv=pillarenv,
+            context=context,
         )
     return ptype(
         opts,
@@ -90,6 +92,7 @@ def get_pillar(
         pillar_override=pillar_override,
         pillarenv=pillarenv,
         extra_minion_data=extra_minion_data,
+        context=context,
     )
 
 
@@ -287,6 +290,7 @@ class RemotePillar(RemotePillarMixin):
         pillar_override=None,
         pillarenv=None,
         extra_minion_data=None,
+        context=None,
     ):
         self.opts = opts
         self.opts["saltenv"] = saltenv
@@ -311,6 +315,7 @@ class RemotePillar(RemotePillarMixin):
             merge_lists=True,
         )
         self._closing = False
+        self.context = context
 
     def compile_pillar(self):
         """
@@ -383,6 +388,7 @@ class PillarCache:
         pillar_override=None,
         pillarenv=None,
         extra_minion_data=None,
+        context=None,
     ):
         # Yes, we need all of these because we need to route to the Pillar object
         # if we have no cache. This is another refactor target.
@@ -408,6 +414,8 @@ class PillarCache:
             minion_cache_path=self._minion_cache_path(minion_id),
         )
 
+        self.context = context
+
     def _minion_cache_path(self, minion_id):
         """
         Return the path to the cache file for the minion.
@@ -431,6 +439,7 @@ class PillarCache:
             functions=self.functions,
             pillar_override=self.pillar_override,
             pillarenv=self.pillarenv,
+            context=self.context,
         )
         return fresh_pillar.compile_pillar()
 
@@ -504,6 +513,7 @@ class Pillar:
         pillar_override=None,
         pillarenv=None,
         extra_minion_data=None,
+        context=None,
     ):
         self.minion_id = minion_id
         self.ext = ext
@@ -542,7 +552,7 @@ class Pillar:
         if opts.get("pillar_source_merging_strategy"):
             self.merge_strategy = opts["pillar_source_merging_strategy"]
 
-        self.ext_pillars = salt.loader.pillars(ext_pillar_opts, self.functions)
+        self.ext_pillars = salt.loader.pillars(ext_pillar_opts, self.functions, context=context)
         self.ignored_pillars = {}
         self.pillar_override = pillar_override or {}
         if not isinstance(self.pillar_override, dict):

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -261,7 +261,7 @@ class AsyncRemotePillar(RemotePillarMixin):
         raise salt.ext.tornado.gen.Return(ret_pillar)
 
     def destroy(self):
-        if self._closing:
+        if hasattr(self, "_closing") and self._closing:
             return
 
         self._closing = True
@@ -1315,7 +1315,7 @@ class Pillar:
         """
         This method exist in order to be API compatible with RemotePillar
         """
-        if self._closing:
+        if hasattr(self, "_closing") and self._closing:
             return
         self._closing = True
 

--- a/tests/pytests/unit/test_master.py
+++ b/tests/pytests/unit/test_master.py
@@ -1,7 +1,7 @@
 import time
 
 import salt.master
-from tests.support.mock import patch
+from tests.support.mock import MagicMock, patch
 
 
 def test_fileserver_duration():
@@ -14,3 +14,90 @@ def test_fileserver_duration():
         update.called_once()
         # Timeout is 1 second
         assert 2 > end - start > 1
+
+
+def test_mworker_pass_context():
+    """
+    Test of passing the __context__ to pillar ext module loader
+    """
+    req_channel_mock = MagicMock()
+    local_client_mock = MagicMock()
+
+    opts = {
+        "req_server_niceness": None,
+        "mworker_niceness": None,
+        "sock_dir": "/tmp",
+        "conf_file": "/tmp/fake_conf",
+        "transport": "zeromq",
+        "fileserver_backend": ["roots"],
+        "file_client": "local",
+        "pillar_cache": False,
+        "state_top": "top.sls",
+        "pillar_roots": {},
+    }
+
+    data = {
+        "id": "MINION_ID",
+        "grains": {},
+        "saltenv": None,
+        "pillarenv": None,
+        "pillar_override": {},
+        "extra_minion_data": {},
+        "ver": "2",
+        "cmd": "_pillar",
+    }
+
+    test_context = {"testing": 123}
+
+    def mworker_bind_mock():
+        mworker.aes_funcs.run_func(data["cmd"], data)
+
+    with patch("salt.client.get_local_client", local_client_mock), patch(
+        "salt.master.ClearFuncs", MagicMock()
+    ), patch("salt.minion.MasterMinion", MagicMock()), patch(
+        "salt.utils.verify.valid_id", return_value=True
+    ), patch(
+        "salt.loader.matchers", MagicMock()
+    ), patch(
+        "salt.loader.render", MagicMock()
+    ), patch(
+        "salt.loader.utils", MagicMock()
+    ), patch(
+        "salt.loader.fileserver", MagicMock()
+    ), patch(
+        "salt.loader.minion_mods", MagicMock()
+    ), patch(
+        "salt.loader.LazyLoader", MagicMock()
+    ) as loadler_pillars_mock:
+        mworker = salt.master.MWorker(opts, {}, {}, [req_channel_mock])
+
+        with patch.object(mworker, "_MWorker__bind", mworker_bind_mock), patch.dict(
+            mworker.context, test_context
+        ):
+            mworker.run()
+            assert (
+                loadler_pillars_mock.call_args_list[0][1].get("pack").get("__context__")
+                == test_context
+            )
+
+        loadler_pillars_mock.reset_mock()
+
+        opts.update(
+            {
+                "pillar_cache": True,
+                "pillar_cache_backend": "file",
+                "pillar_cache_ttl": 1000,
+                "cachedir": "/tmp",
+            }
+        )
+
+        mworker = salt.master.MWorker(opts, {}, {}, [req_channel_mock])
+
+        with patch.object(mworker, "_MWorker__bind", mworker_bind_mock), patch.dict(
+            mworker.context, test_context
+        ), patch("salt.utils.cache.CacheFactory.factory", MagicMock()):
+            mworker.run()
+            assert (
+                loadler_pillars_mock.call_args_list[0][1].get("pack").get("__context__")
+                == test_context
+            )

--- a/tests/pytests/unit/test_master.py
+++ b/tests/pytests/unit/test_master.py
@@ -67,9 +67,11 @@ def test_mworker_pass_context():
     ), patch(
         "salt.loader.minion_mods", MagicMock()
     ), patch(
+        "salt.loader._module_dirs", MagicMock()
+    ), patch(
         "salt.loader.LazyLoader", MagicMock()
     ) as loadler_pillars_mock:
-        mworker = salt.master.MWorker(opts, {}, {}, [req_channel_mock])
+        mworker = salt.master.MWorker(opts, {}, {}, [req_channel_mock], "MWorker-Test2")
 
         with patch.object(mworker, "_MWorker__bind", mworker_bind_mock), patch.dict(
             mworker.context, test_context
@@ -91,7 +93,7 @@ def test_mworker_pass_context():
             }
         )
 
-        mworker = salt.master.MWorker(opts, {}, {}, [req_channel_mock])
+        mworker = salt.master.MWorker(opts, {}, {}, [req_channel_mock], "MWorker-Test2")
 
         with patch.object(mworker, "_MWorker__bind", mworker_bind_mock), patch.dict(
             mworker.context, test_context


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/saltstack/salt/pull/62898

This change makes it possible to pass the context to pillar ext modules and let them store the values in the context.

Makes sense for `3004` only as required for `master`

### Previous Behavior
The `__context__` passed to the pillar ext modules was always empty.

### New Behavior
It's possibe to store the values to the `__context__` and reuse them.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/19030

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
