### PR TITLE
Backport 3000: extend+exclude interaction

### DIFF
--- a/changelog/62082.fixed
+++ b/changelog/62082.fixed
@@ -1,0 +1,1 @@
+Ignore extend declarations in sls files that are excluded.

--- a/salt/state.py
+++ b/salt/state.py
@@ -1573,6 +1573,25 @@ class State(object):
                     else:
                         name = ids[0][0]
 
+                sls_excludes = []
+                # excluded sls are plain list items or dicts with an "sls" key
+                for exclude in high.get("__exclude__", []):
+                    if isinstance(exclude, str):
+                        sls_excludes.append(exclude)
+                    elif exclude.get("sls"):
+                        sls_excludes.append(exclude["sls"])
+
+                if body.get("__sls__") in sls_excludes:
+                    log.debug(
+                        "Cannot extend ID '%s' in '%s:%s' because '%s:%s' is excluded.",
+                        name,
+                        body.get("__env__", "base"),
+                        body.get("__sls__", "base"),
+                        body.get("__env__", "base"),
+                        body.get("__sls__", "base"),
+                    )
+                    continue
+
                 for state, run in six.iteritems(body):
                     if state.startswith('__'):
                         continue


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/saltstack/salt/pull/62862
SUMA issue: https://github.com/SUSE/spacewalk/issues/19152

**NOTE**: Backporting the tests would be a lot of work due to the changes to the test environment. Given we're about to drop Salt 3000 soon, it's not worth spending that much work on the tests.