### PR TITLE
Control the collection of lvm grains via config

### DIFF
--- a/salt/grains/lvm.py
+++ b/salt/grains/lvm.py
@@ -17,6 +17,10 @@ __salt__ = {
 log = logging.getLogger(__name__)
 
 
+def __virtual__():
+    return __opts__.get("enable_lvm_grains", True)
+
+
 def lvm():
     """
     Return list of LVM devices


### PR DESCRIPTION
lvm grain collection can take a long time on systems with a lot of volumes and volume groups. On one server we measured ~3 minutes, which is way too long for grains.

This change is backwards-compatible, leaving the lvm grain collection enabled by default. Users with a lot of lvm volumes/volume groups can disable these grains in the minion config by setting

    enable_lvm_grains: False

### What does this PR do?

Backport of original version of https://github.com/saltstack/salt/pull/63115/files. That PR has grown into a more general approach, we will backport the new approach once it's final. For now we need to be able to disable lvm grains somehow.

Fixes https://github.com/SUSE/spacewalk/issues/19373