### PR TITLE
[3005.1] Allow entrypoint compatibility for "importlib-metadata>=5.0.0" (bsc#1207071)

### DIFF
--- a/changelog/62854.fixed
+++ b/changelog/62854.fixed
@@ -1,0 +1,1 @@
+Use select instead of iterating over entrypoints as a dictionary for importlib_metadata>=5.0.0

--- a/salt/utils/entrypoints.py
+++ b/salt/utils/entrypoints.py
@@ -38,13 +38,20 @@ def iter_entry_points(group, name=None):
     entry_points_listing = []
     entry_points = importlib_metadata.entry_points()
 
-    for entry_point_group, entry_points_list in entry_points.items():
-        if entry_point_group != group:
-            continue
-        for entry_point in entry_points_list:
+    try:
+        for entry_point in entry_points.select(group=group):
             if name is not None and entry_point.name != name:
                 continue
             entry_points_listing.append(entry_point)
+    except AttributeError:
+        # importlib-metadata<5.0.0
+        for entry_point_group, entry_points_list in entry_points.items():
+            if entry_point_group != group:
+                continue
+            for entry_point in entry_points_list:
+                if name is not None and entry_point.name != name:
+                    continue
+                entry_points_listing.append(entry_point)
 
     return entry_points_listing
 

--- a/tests/pytests/functional/loader/test_loader.py
+++ b/tests/pytests/functional/loader/test_loader.py
@@ -1,5 +1,4 @@
 import json
-import sys
 
 import pytest
 import salt.utils.versions
@@ -143,11 +142,69 @@ def test_utils_loader_does_not_load_extensions(
     assert "foobar.echo" not in loader_functions
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 6),
-    reason="importlib-metadata>=3.3.0 does not exist for Py3.5",
-)
 def test_extension_discovery_without_reload_with_importlib_metadata_installed(
+    venv, salt_extension, salt_minion_factory
+):
+    # Install our extension into the virtualenv
+    installed_packages = venv.get_installed_packages()
+    assert salt_extension.name not in installed_packages
+    venv.install("importlib-metadata>=3.3.0")
+    code = """
+    import sys
+    import json
+    import subprocess
+    import salt._logging
+    import salt.loader
+
+    extension_path = "{}"
+
+    minion_config = json.loads(sys.stdin.read())
+    salt._logging.set_logging_options_dict(minion_config)
+    salt._logging.setup_logging()
+    loader = salt.loader.minion_mods(minion_config)
+
+    if "foobar.echo1" in loader:
+        sys.exit(1)
+
+    # Install the extension
+    proc = subprocess.run(
+        [sys.executable, "-m", "pip", "install", extension_path],
+        check=False,
+        shell=False,
+        stdout=subprocess.PIPE,
+    )
+    if proc.returncode != 0:
+        sys.exit(2)
+
+    loader = salt.loader.minion_mods(minion_config)
+    if "foobar.echo1" not in loader:
+        sys.exit(3)
+
+    print(json.dumps(list(loader)))
+    """.format(
+        salt_extension.srcdir
+    )
+    ret = venv.run_code(
+        code, input=json.dumps(salt_minion_factory.config.copy()), check=False
+    )
+    # Exitcode 1 - Extension was already installed
+    # Exitcode 2 - Failed to install the extension
+    # Exitcode 3 - Extension was not found within the same python process after being installed
+    assert ret.returncode == 0
+    installed_packages = venv.get_installed_packages()
+    assert salt_extension.name in installed_packages
+
+    loader_functions = json.loads(ret.stdout)
+
+    # A non existing module should not appear in the loader
+    assert "monty.python" not in loader_functions
+
+    # But our extension's modules should appear on the loader
+    assert "foobar.echo1" in loader_functions
+    assert "foobar.echo2" in loader_functions
+
+
+def test_extension_discovery_without_reload_with_importlib_metadata_5_installed(
     venv, salt_extension, salt_minion_factory
 ):
     # Install our extension into the virtualenv


### PR DESCRIPTION
### What does this PR do?

This PR backports https://github.com/saltstack/salt/pull/62854 to our Salt 3005.1 package, in order to fix the issue we already found in our openQA tests for Tumbleweed, caused by `importlib-metadata >= 5.0.0`:

http://bugzilla.opensuse.org/show_bug.cgi?id=1207071

### What issues does this PR fix or reference?
Fixes: 

### Previous Behavior
```
# salt-run state.event pretty=True`
[ERROR   ] 'EntryPoints' object has no attribute 'items'
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/salt/utils/parsers.py", line 214, in parse_args
    mixin_after_parsed_func(self)
  File "/usr/lib/python3.10/site-packages/salt/utils/parsers.py", line 907, in __setup_logging
    salt._logging.setup_logging()
  File "/usr/lib/python3.10/site-packages/salt/_logging/impl.py", line 984, in setup_logging
    setup_extended_logging(opts)
  File "/usr/lib/python3.10/site-packages/salt/_logging/impl.py", line 891, in setup_extended_logging
    providers = salt.loader.log_handlers(opts)
  File "/usr/lib/python3.10/site-packages/salt/loader/__init__.py", line 878, in log_handlers
    _module_dirs(
  File "/usr/lib/python3.10/site-packages/salt/loader/__init__.py", line 166, in _module_dirs
    for entry_point in entrypoints.iter_entry_points("salt.loader"):
  File "/usr/lib/python3.10/site-packages/salt/utils/entrypoints.py", line 29, in _wrapped
    return f(*args, **kwargs)
  File "/usr/lib/python3.10/site-packages/salt/utils/entrypoints.py", line 41, in iter_entry_points
    for entry_point_group, entry_points_list in entry_points.items():
AttributeError: 'EntryPoints' object has no attribute 'items'
Usage: salt-run [options] <function> [arguments]
```

### New Behavior

Salt does not crash and work as expected.

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes
