### PR TITLE
Open suse/backport/3005.1 fix issue 540

### DIFF
--- a/changelog/540.fixed
+++ b/changelog/540.fixed
@@ -1,0 +1,1 @@
+Fix pkg.version_cmp on openEuler and a few other os flavors.

--- a/salt/modules/rpm_lowpkg.py
+++ b/salt/modules/rpm_lowpkg.py
@@ -77,7 +77,7 @@ def __virtual__():
     return (
         False,
         "The rpm execution module failed to load: only available on redhat/suse type"
-        " systems or amazon, xcp or xenserver.",
+        " systems or amazon, xcp, xenserver, virtuozzolinux, virtuozzo, issabel pbx or openeuler.",
     )
 
 

--- a/salt/modules/rpm_lowpkg.py
+++ b/salt/modules/rpm_lowpkg.py
@@ -62,7 +62,15 @@ def __virtual__():
             " grains.",
         )
 
-    enabled = ("amazon", "xcp", "xenserver", "virtuozzolinux")
+    enabled = (
+        "amazon",
+        "xcp",
+        "xenserver",
+        "virtuozzolinux",
+        "virtuozzo",
+        "issabel pbx",
+        "openeuler",
+    )
 
     if os_family in ["redhat", "suse"] or os_grain in enabled:
         return __virtualname__

--- a/tests/pytests/unit/modules/test_rpm_lowpkg.py
+++ b/tests/pytests/unit/modules/test_rpm_lowpkg.py
@@ -35,6 +35,26 @@ def _called_with_root(mock):
 def configure_loader_modules():
     return {rpm: {"rpm": MagicMock(return_value=MagicMock)}}
 
+def test___virtual___openeuler():
+    patch_which = patch("salt.utils.path.which", return_value=True)
+    with patch.dict(rpm.__grains__, {"os": "openEuler", "os_family": "openEuler"}), patch_which:
+        assert rpm.__virtual__() == "lowpkg"
+
+def test___virtual___issabel_pbx():
+    patch_which = patch("salt.utils.path.which", return_value=True)
+    with patch.dict(rpm.__grains__, {"os": "Issabel Pbx", "os_family": "IssabeL PBX"}), patch_which:
+        assert rpm.__virtual__() == "lowpkg"
+
+def test___virtual___virtuozzo():
+    patch_which = patch("salt.utils.path.which", return_value=True)
+    with patch.dict(rpm.__grains__, {"os": "virtuozzo", "os_family": "VirtuoZZO"}), patch_which:
+        assert rpm.__virtual__() == "lowpkg"
+
+def test___virtual___with_no_rpm():
+    patch_which = patch("salt.utils.path.which", return_value=False)
+    ret = rpm.__virtual__()
+    assert isinstance(ret, tuple)
+    assert ret[0] == False
 
 # 'list_pkgs' function tests: 2
 

--- a/tests/pytests/unit/modules/test_rpm_lowpkg.py
+++ b/tests/pytests/unit/modules/test_rpm_lowpkg.py
@@ -37,24 +37,35 @@ def configure_loader_modules():
 
 def test___virtual___openeuler():
     patch_which = patch("salt.utils.path.which", return_value=True)
-    with patch.dict(rpm.__grains__, {"os": "openEuler", "os_family": "openEuler"}), patch_which:
+    with patch.dict(
+        rpm.__grains__, {"os": "openEuler", "os_family": "openEuler"}
+    ), patch_which:
         assert rpm.__virtual__() == "lowpkg"
+
 
 def test___virtual___issabel_pbx():
     patch_which = patch("salt.utils.path.which", return_value=True)
-    with patch.dict(rpm.__grains__, {"os": "Issabel Pbx", "os_family": "IssabeL PBX"}), patch_which:
+    with patch.dict(
+        rpm.__grains__, {"os": "Issabel Pbx", "os_family": "IssabeL PBX"}
+    ), patch_which:
         assert rpm.__virtual__() == "lowpkg"
+
 
 def test___virtual___virtuozzo():
     patch_which = patch("salt.utils.path.which", return_value=True)
-    with patch.dict(rpm.__grains__, {"os": "virtuozzo", "os_family": "VirtuoZZO"}), patch_which:
+    with patch.dict(
+        rpm.__grains__, {"os": "virtuozzo", "os_family": "VirtuoZZO"}
+    ), patch_which:
         assert rpm.__virtual__() == "lowpkg"
+
 
 def test___virtual___with_no_rpm():
     patch_which = patch("salt.utils.path.which", return_value=False)
     ret = rpm.__virtual__()
     assert isinstance(ret, tuple)
-    assert ret[0] == False
+    assert ret[0] is False
+
+
 
 # 'list_pkgs' function tests: 2
 


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes: #540 (backport of #541 )

### Previous Behavior
```
uyuni:~ # salt '192*' pkg.version_cmp 4.10.0-3.oe2203 4
192.168.122.173:
    The minion function caused an exception: Traceback (most recent call last):
      File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/minion.py", line 1916, in _thread_return
        return_data = minion_instance._execute_job_function(
      File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/minion.py", line 1873, in _execute_job_function
        return_data = self.executors[fname](opts, data, func, args, kwargs)
      File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/loader/lazy.py", line 149, in __call__
        return self.loader.run(run_func, *args, **kwargs)
      File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/loader/lazy.py", line 1203, in run
        return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
      File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/loader/lazy.py", line 1218, in _run_as
        return _func_or_method(*args, **kwargs)
      File "/usr/lib/venv-salt-minion/lib/python3.10/site-packages/salt/executors/venv.py", line 24, in execute
        return __executors__["direct_call.execute"](opts, data, func, args, kwargs)
      File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/loader/lazy.py", line 149, in __call__
        return self.loader.run(run_func, *args, **kwargs)
      File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/loader/lazy.py", line 1203, in run
        return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
      File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/loader/lazy.py", line 1218, in _run_as
        return _func_or_method(*args, **kwargs)
      File "/usr/lib/venv-salt-minion/lib/python3.10/site-packages/salt/executors/direct_call.py", line 10, in execute
        return func(*args, **kwargs)
      File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/loader/lazy.py", line 149, in __call__
        return self.loader.run(run_func, *args, **kwargs)
      File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/loader/lazy.py", line 1203, in run
        return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
      File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/loader/lazy.py", line 1218, in _run_as
        return _func_or_method(*args, **kwargs)
      File "/usr/lib/venv-salt-minion/lib/python3.10/site-packages/salt/modules/yumpkg.py", line 685, in version_cmp
        return __salt__["lowpkg.version_cmp"](pkg1, pkg2, ignore_epoch=ignore_epoch)
      File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/loader/context.py", line 78, in __getitem__
        return self.value()[item]
      File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/loader/lazy.py", line 334, in __getitem__
        super().__getitem__(item)  # try to get the item from the dictionary
      File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/utils/lazy.py", line 105, in __getitem__
        raise KeyError(key)
    KeyError: 'lowpkg.version_cmp'
ERROR: Minions returned with non-zero exit code

uyuni:~ # salt '192*' grains.get os_family
192.168.122.173:
    openEuler
```

### New Behavior

```
uyuni:~ # salt '192*' pkg.version_cmp 4.10.0-3.oe2203 4
192.168.122.173:
    1
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes