### PR TITLE
Skip package names without colon (bsc#1208691)

### DIFF
--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -2758,6 +2758,8 @@ def _find_ptf_packages(pkgs, root=None):
     for line in output.splitlines():
         if not line.strip():
             continue
+        if ":" not in line:
+            continue
         pkg, provides = line.split(":", 1)
         if "ptf()" in provides:
             ptfs.append(pkg)


### PR DESCRIPTION
### What does this PR do?

Fixes a problem in `_find_ptf_packages()` when passing multiple packages to `zypperpkg.remove` / `zypperpkg.purge`. The problem occurs when a passed package is not installed, in that case the output of the `rpm` subprocess is not parsed correctly.

Backport of https://github.com/saltstack/salt/commit/58feb8c31a63d5070feb919abc56f5fa9463a73a (part of https://github.com/saltstack/salt/pull/63460)

### Previous Behavior
Exception.

### New Behavior
No exception.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
