### PR TITLE
3000: tornado: Fix an open redirect in StaticFileHandler (CVE-2023-28370, bsc#1211741) 

### DIFF
--- a/salt/ext/tornado/web.py
+++ b/salt/ext/tornado/web.py
@@ -2544,6 +2544,15 @@ class StaticFileHandler(RequestHandler):
             # but there is some prefix to the path that was already
             # trimmed by the routing
             if not self.request.path.endswith("/"):
+                if self.request.path.startswith("//"):
+                    # A redirect with two initial slashes is a "protocol-relative" URL.
+                    # This means the next path segment is treated as a hostname instead
+                    # of a part of the path, making this effectively an open redirect.
+                    # Reject paths starting with two slashes to prevent this.
+                    # This is only reachable under certain configurations.
+                    raise HTTPError(
+                        403, "cannot redirect path with two initial slashes"
+                    )
                 self.redirect(self.request.path + "/", permanent=True)
                 return
             absolute_path = os.path.join(absolute_path, self.default_filename)


### PR DESCRIPTION
### What does this PR do?
This PR provides fix for CVE-2023-28370, from https://github.com/tornadoweb/tornado/pull/3266 to our vendored "tornado" codebase inside the Salt 3000 package.

**NOTE: Since we are in the middle of 4.3.6 submission, let's wait until 4.3.6 is released to merge this PR - so it is easier to do a Salt resubmission if needed**

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
