### PR TITLE
Make "master_tops" compatible with Salt 3000 and older minions (bsc#1212516) (bsc#1212517)

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1213,6 +1213,7 @@ class AESFuncs(TransportMethods):
         "_dir_list",
         "_symlink_list",
         "_file_envs",
+        "_ext_nodes", # To keep compatibility with old Salt minion versions
     )
 
     def __init__(self, opts, context=None):
@@ -1411,6 +1412,9 @@ class AESFuncs(TransportMethods):
         if load is False:
             return {}
         return self.masterapi._master_tops(load, skip_verify=True)
+
+    # Needed so older minions can request master_tops
+    _ext_nodes = _master_tops
 
     def _master_opts(self, load):
         """


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue with older Salt 3000 and earlier minion versions, where they cannot request "master_tops" to our newer Salt 3006.0 master, as it was dropped the compatibily layer for this old versions (former `_ext_nodes` method)

We are basically putting this PR back: https://github.com/saltstack/salt/pull/62923

### Previous Behavior
In the context of Uyuni/SUMA, after upgrading server to Salt 3006.0, the highstate is empty for minions with Salt 3000 or older version, as "master_top" data cannot be fetched by minions.

### New Behavior
After this PR, the old minions can request "master_top" data and therefore "highstate" appears popullated as expected.

### Merge requirements satisfied?
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
