### PR TITLE
Prevent possible exceptions on salt.utils.user.get_group_dict (bsc#1212794)

### DIFF
--- a/salt/utils/user.py
+++ b/salt/utils/user.py
@@ -352,7 +352,11 @@ def get_group_dict(user=None, include_default=True):
     group_dict = {}
     group_names = get_group_list(user, include_default=include_default)
     for group in group_names:
-        group_dict.update({group: grp.getgrnam(group).gr_gid})
+        try:
+            group_dict.update({group: grp.getgrnam(group).gr_gid})
+        except KeyError:
+            # In case if imporer duplicate group was returned by get_group_list
+            pass
     return group_dict
 
 

--- a/tests/pytests/functional/utils/user/test_get_group_dict.py
+++ b/tests/pytests/functional/utils/user/test_get_group_dict.py
@@ -9,15 +9,8 @@ from tests.support.mock import patch
 log = logging.getLogger(__name__)
 
 pytestmark = [
-    pytest.mark.skip_on_windows,
+    pytest.mark.skip_unless_on_linux(reason="Should only run in platforms which have duplicate GID support"),
 ]
-
-
-@pytest.mark.skip_on_platforms(
-    darwin=True,
-    freebsd=True,
-    reason="This test should not run on FreeBSD and Mac due to lack of duplicate GID support",
-)
 def test_get_group_dict_with_improper_duplicate_root_group():
     with patch("salt.utils.user.get_group_list", return_value=["+", "root"]):
         group_list = salt.utils.user.get_group_dict("root")

--- a/tests/pytests/functional/utils/user/test_get_group_dict.py
+++ b/tests/pytests/functional/utils/user/test_get_group_dict.py
@@ -1,0 +1,24 @@
+import logging
+
+import pytest
+
+import salt.utils.platform
+import salt.utils.user
+from tests.support.mock import patch
+
+log = logging.getLogger(__name__)
+
+pytestmark = [
+    pytest.mark.skip_on_windows,
+]
+
+
+@pytest.mark.skip_on_platforms(
+    darwin=True,
+    freebsd=True,
+    reason="This test should not run on FreeBSD and Mac due to lack of duplicate GID support",
+)
+def test_get_group_dict_with_improper_duplicate_root_group():
+    with patch("salt.utils.user.get_group_list", return_value=["+", "root"]):
+        group_list = salt.utils.user.get_group_dict("root")
+        assert group_list == {"root": 0}


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/saltstack/salt/pull/64599

In case if the client system has NIS enabled it could cause KeyError exception on starting the salt-minion service due to the duplicated record in the `groups`: `+:::`, which is actually the duplicate of `root` group as missing gid is treated as `0`.

### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/21917

### Previous Behavior
Tracebacks on salt-minion start and no service running

### New Behavior
Normal behavior

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
