### PR TITLE
Make sure configured user is properly set by Salt (bsc#1210994)

### DIFF
--- a/pkg/common/salt-master.service
+++ b/pkg/common/salt-master.service
@@ -8,6 +8,7 @@ LimitNOFILE=100000
 Type=notify
 NotifyAccess=all
 ExecStart=/usr/bin/salt-master
+User=salt
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/old/deb/salt-master.service
+++ b/pkg/old/deb/salt-master.service
@@ -7,6 +7,7 @@ LimitNOFILE=16384
 Type=notify
 NotifyAccess=all
 ExecStart=/usr/bin/salt-master
+User=salt
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/old/suse/salt-master.service
+++ b/pkg/old/suse/salt-master.service
@@ -8,6 +8,7 @@ LimitNOFILE=100000
 Type=simple
 ExecStart=/usr/bin/salt-master
 TasksMax=infinity
+User=salt
 
 [Install]
 WantedBy=multi-user.target

--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -7,6 +7,7 @@ import logging
 import os
 import warnings
 
+import salt.defaults.exitcodes
 import salt.utils.kinds as kinds
 from salt.exceptions import SaltClientError, SaltSystemExit, get_error_message
 from salt.utils import migrations
@@ -81,7 +82,7 @@ class DaemonsMixin:  # pylint: disable=no-init
         """
         if not check_user(self.config["user"]):
             self.action_log_info("Cannot switch to configured user for Salt. Exiting")
-            self.shutdown(1)
+            self.shutdown(salt.defaults.exitcodes.EX_NOUSER)
 
     def action_log_info(self, action):
         """

--- a/salt/cli/ssh.py
+++ b/salt/cli/ssh.py
@@ -1,7 +1,9 @@
 import sys
 
 import salt.client.ssh
+import salt.defaults.exitcodes
 import salt.utils.parsers
+from salt.utils.verify import check_user
 
 
 class SaltSSH(salt.utils.parsers.SaltSSHOptionParser):
@@ -14,6 +16,12 @@ class SaltSSH(salt.utils.parsers.SaltSSHOptionParser):
             sys.argv += ["x", "x"]  # Hack: pass a mandatory two options
             # that won't be used anyways with -H or --hosts
         self.parse_args()
+
+        if not check_user(self.config["user"]):
+            self.exit(
+                salt.defaults.exitcodes.EX_NOUSER,
+                "Cannot switch to configured user for Salt. Exiting",
+            )
 
         ssh = salt.client.ssh.SSH(self.config)
         ssh.run()

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -335,8 +335,8 @@ def check_user(user):
 
         # We could just reset the whole environment but let's just override
         # the variables we can get from pwuser
-        if "HOME" in os.environ:
-            os.environ["HOME"] = pwuser.pw_dir
+        # We ensure HOME is always present and set according to pwuser
+        os.environ["HOME"] = pwuser.pw_dir
 
         if "SHELL" in os.environ:
             os.environ["SHELL"] = pwuser.pw_shell

--- a/tests/pytests/integration/cli/test_salt_minion.py
+++ b/tests/pytests/integration/cli/test_salt_minion.py
@@ -41,7 +41,7 @@ def test_exit_status_unknown_user(salt_master, minion_id):
         factory = salt_master.salt_minion_daemon(
             minion_id, overrides={"user": "unknown-user"}
         )
-        factory.start(start_timeout=10, max_start_attempts=1)
+        factory.start(start_timeout=30, max_start_attempts=1)
 
     assert exc.value.process_result.returncode == salt.defaults.exitcodes.EX_NOUSER
     assert "The user is not available." in exc.value.process_result.stderr
@@ -53,7 +53,7 @@ def test_exit_status_unknown_argument(salt_master, minion_id):
     """
     with pytest.raises(FactoryNotStarted) as exc:
         factory = salt_master.salt_minion_daemon(minion_id)
-        factory.start("--unknown-argument", start_timeout=10, max_start_attempts=1)
+        factory.start("--unknown-argument", start_timeout=30, max_start_attempts=1)
 
     assert exc.value.process_result.returncode == salt.defaults.exitcodes.EX_USAGE
     assert "Usage" in exc.value.process_result.stderr


### PR DESCRIPTION
### What does this PR do?

This PR is a continuation of https://github.com/openSUSE/salt/pull/588 in order to incorporate latest fixes at https://github.com/saltstack/salt/pull/64510 to ensure configured Salt user is properly set when instantiating the stack.

Also fixes the user when running "salt-ssh" client.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/21805

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
