### PR TITLE
Only call native_str on curl_debug message in tornado when needed

### DIFF
--- a/salt/ext/tornado/curl_httpclient.py
+++ b/salt/ext/tornado/curl_httpclient.py
@@ -494,10 +494,11 @@ class CurlAsyncHTTPClient(AsyncHTTPClient):
 
     def _curl_debug(self, debug_type, debug_msg):
         debug_types = ('I', '<', '>', '<', '>')
-        debug_msg = native_str(debug_msg)
         if debug_type == 0:
+            debug_msg = native_str(debug_msg)
             curl_log.debug('%s', debug_msg.strip())
         elif debug_type in (1, 2):
+            debug_msg = native_str(debug_msg)
             for line in debug_msg.splitlines():
                 curl_log.debug('%s %s', debug_types[debug_type], line)
         elif debug_type == 4:


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/tornadoweb/tornado/pull/2277 to `salt.ext.tornado`.

### What issues does this PR fix or reference?
Track: https://github.com/SUSE/spacewalk/issues/22297 (this change is not fixing this issue, but required as become visible on adding proper `pycurl` library to the bundle)

### Previous Behavior
In case if we add proper `pycurl` to the bundle and not include this fix it could cause a lot of error messages in the logs of the minion:
```
2023-08-22 18:52:54,871 [salt._logging.impl:1082][ERROR   ][23271] An un-handled exception was caught by Salt's global exception handler:
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x99 in position 0: invalid start byte
Traceback (most recent call last):
  File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/ext/tornado/curl_httpclient.py", line 497, in _curl_debug
    debug_msg = native_str(debug_msg)
  File "/usr/lib/venv-salt-minion/lib64/python3.10/site-packages/salt/ext/tornado/escape.py", line 219, in to_unicode
    return value.decode("utf-8")
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x99 in position 0: invalid start byte
```

### New Behavior
Normal behavior

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
