### PR TITLE
Fix calculation of SLS context vars when trailing dots on targetted sls/state (bsc#1213518)

### DIFF
--- a/changelog/63411.fixed.md
+++ b/changelog/63411.fixed.md
@@ -1,0 +1,1 @@
+Fix calculation of SLS context vars when trailing dots on targetted state

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -113,8 +113,9 @@ def generate_sls_context(tmplpath, sls):
 
     sls_context = {}
 
-    # Normalize SLS as path.
-    slspath = sls.replace(".", "/")
+    # Normalize SLS as path and remove possible trailing slashes
+    # to prevent matching issues and wrong vars calculation
+    slspath = sls.replace(".", "/").rstrip("/")
 
     if tmplpath:
         # Normalize template path

--- a/tests/unit/utils/test_templates.py
+++ b/tests/unit/utils/test_templates.py
@@ -320,6 +320,20 @@ class WrapRenderTestCase(TestCase):
             slspath="foo",
         )
 
+    def test_generate_sls_context__one_level_init_implicit_with_trailing_dot(self):
+        """generate_sls_context - Basic one level with implicit init.sls with trailing dot"""
+        self._test_generated_sls_context(
+            "/tmp/foo/init.sls",
+            "foo.",
+            tplfile="foo/init.sls",
+            tpldir="foo",
+            tpldot="foo",
+            slsdotpath="foo",
+            slscolonpath="foo",
+            sls_path="foo",
+            slspath="foo",
+        )
+
     def test_generate_sls_context__one_level_init_explicit(self):
         """generate_sls_context - Basic one level with explicit init.sls"""
         self._test_generated_sls_context(


### PR DESCRIPTION
### What does this PR do?

This PR backports https://github.com/saltstack/salt/pull/65036 to `openSUSE/release/3006.0` branch.

An elaborated description of the PR can be found in the upstream PR.

### Commits signed with GPG?
Yes
