### PR TITLE
Revert usage of long running REQ channel (bsc#1213960, bsc#1213630, bsc#1213257)

### DIFF
--- a/doc/topics/development/architecture.rst
+++ b/doc/topics/development/architecture.rst
@@ -220,15 +220,11 @@ the received message.
 4) The new minion thread is created. The _thread_return() function starts up
 and actually calls out to the requested function contained in the job.
 5) The requested function runs and returns a result. [Still in thread.]
-6) The result of the function that's run is published on the minion's local event bus with event
-tag "__master_req_channel_payload" [Still in thread.]
+6) The result of the function that's run is encrypted and returned to the
+master's ReqServer (TCP 4506 on master). [Still in thread.]
 7) Thread exits. Because the main thread was only blocked for the time that it
 took to initialize the worker thread, many other requests could have been
 received and processed during this time.
-8) Minion event handler gets the event with tag "__master_req_channel_payload"
-and sends the payload to master's ReqServer (TCP 4506 on master), via the long-running async request channel
-that was opened when minion first started up.
-
 
 
 A Note on ClearFuncs vs. AESFuncs

--- a/salt/channel/client.py
+++ b/salt/channel/client.py
@@ -98,7 +98,6 @@ class AsyncReqChannel:
         "_crypted_transfer",
         "_uncrypted_transfer",
         "send",
-        "connect",
     ]
     close_methods = [
         "close",
@@ -128,7 +127,7 @@ class AsyncReqChannel:
         else:
             auth = None
 
-        transport = salt.transport.request_client(opts, io_loop=io_loop)
+        transport = salt.transport.request_client(opts, io_loop)
         return cls(opts, transport, auth)
 
     def __init__(self, opts, transport, auth, **kwargs):
@@ -272,10 +271,6 @@ class AsyncReqChannel:
         raise salt.ext.tornado.gen.Return(ret)
 
     @salt.ext.tornado.gen.coroutine
-    def connect(self):
-        yield self.transport.connect()
-
-    @salt.ext.tornado.gen.coroutine
     def send(self, load, tries=3, timeout=60, raw=False):
         """
         Send a request, return a future which will complete when we send the message
@@ -295,7 +290,7 @@ class AsyncReqChannel:
                     ret = yield self._crypted_transfer(load, timeout=timeout, raw=raw)
                 break
             except Exception as exc:  # pylint: disable=broad-except
-                log.trace("Failed to send msg %r", exc)
+                log.error("Failed to send msg %r", exc)
                 if _try >= tries:
                     raise
                 else:

--- a/salt/transport/ipc.py
+++ b/salt/transport/ipc.py
@@ -208,10 +208,7 @@ class IPCServer:
                 log.error("Exception occurred while handling stream: %s", exc)
 
     def handle_connection(self, connection, address):
-        log.trace(
-            "IPCServer: Handling connection to address: %s",
-            address if address else connection,
-        )
+        log.trace("IPCServer: Handling connection to address: %s", address)
         try:
             with salt.utils.asynchronous.current_ioloop(self.io_loop):
                 stream = IOStream(

--- a/salt/utils/asynchronous.py
+++ b/salt/utils/asynchronous.py
@@ -34,7 +34,7 @@ class SyncWrapper:
     This is uses as a simple wrapper, for example:
 
     asynchronous = AsyncClass()
-    # this method would regularly return a future
+    # this method would reguarly return a future
     future = asynchronous.async_method()
 
     sync = SyncWrapper(async_factory_method, (arg1, arg2), {'kwarg1': 'val'})

--- a/tests/pytests/functional/transport/server/test_req_channel.py
+++ b/tests/pytests/functional/transport/server/test_req_channel.py
@@ -145,7 +145,7 @@ def test_basic(req_channel):
         {"baz": "qux", "list": [1, 2, 3]},
     ]
     for msg in msgs:
-        ret = req_channel.send(msg, timeout=5, tries=1)
+        ret = req_channel.send(dict(msg), timeout=5, tries=1)
         assert ret["load"] == msg
 
 

--- a/tests/pytests/functional/transport/server/test_req_channel.py
+++ b/tests/pytests/functional/transport/server/test_req_channel.py
@@ -124,7 +124,7 @@ def req_channel_crypt(request):
 
 
 @pytest.fixture
-def push_channel(req_server_channel, salt_minion, req_channel_crypt):
+def req_channel(req_server_channel, salt_minion, req_channel_crypt):
     with salt.channel.client.ReqChannel.factory(
         salt_minion.config, crypt=req_channel_crypt
     ) as _req_channel:
@@ -135,7 +135,7 @@ def push_channel(req_server_channel, salt_minion, req_channel_crypt):
             _req_channel.obj._refcount = 0
 
 
-def test_basic(push_channel):
+def test_basic(req_channel):
     """
     Test a variety of messages, make sure we get the expected responses
     """
@@ -145,11 +145,11 @@ def test_basic(push_channel):
         {"baz": "qux", "list": [1, 2, 3]},
     ]
     for msg in msgs:
-        ret = push_channel.send(dict(msg), timeout=5, tries=1)
+        ret = req_channel.send(msg, timeout=5, tries=1)
         assert ret["load"] == msg
 
 
-def test_normalization(push_channel):
+def test_normalization(req_channel):
     """
     Since we use msgpack, we need to test that list types are converted to lists
     """
@@ -160,21 +160,21 @@ def test_normalization(push_channel):
         {"list": tuple([1, 2, 3])},
     ]
     for msg in msgs:
-        ret = push_channel.send(msg, timeout=5, tries=1)
+        ret = req_channel.send(msg, timeout=5, tries=1)
         for key, value in ret["load"].items():
             assert types[key] == type(value)
 
 
-def test_badload(push_channel, req_channel_crypt):
+def test_badload(req_channel, req_channel_crypt):
     """
     Test a variety of bad requests, make sure that we get some sort of error
     """
     msgs = ["", [], tuple()]
     if req_channel_crypt == "clear":
         for msg in msgs:
-            ret = push_channel.send(msg, timeout=5, tries=1)
+            ret = req_channel.send(msg, timeout=5, tries=1)
             assert ret == "payload and load must be a dict"
     else:
         for msg in msgs:
             with pytest.raises(salt.exceptions.AuthenticationError):
-                push_channel.send(msg, timeout=5, tries=1)
+                req_channel.send(msg, timeout=5, tries=1)

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -67,17 +67,17 @@ def test_minion_load_grains_default():
         ),
     ],
 )
-def test_send_req_tries(req_channel):
+def test_send_req_tries(req_channel, minion_opts):
     channel_enter = MagicMock()
     channel_enter.send.side_effect = req_channel[1]
     channel = MagicMock()
     channel.__enter__.return_value = channel_enter
 
     with patch(req_channel[0], return_value=channel):
-        opts = salt.config.DEFAULT_MINION_OPTS.copy()
-        opts["random_startup_delay"] = 0
-        opts["return_retry_tries"] = 30
-        opts["grains"] = {}
+        minion_opts = salt.config.DEFAULT_MINION_OPTS.copy()
+        minion_opts["random_startup_delay"] = 0
+        minion_opts["return_retry_tries"] = 30
+        minion_opts["grains"] = {}
         with patch("salt.loader.grains"):
             minion = salt.minion.Minion(minion_opts)
 

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -111,7 +111,7 @@ async def test_send_req_async_regression_62453(minion_opts):
 
         # We are just validating no exception is raised
         rtn = await minion._send_req_async(load, timeout)
-        assert rtn is False
+        assert rtn == False
 
 
 def test_mine_send_tries():

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -92,29 +92,8 @@ def test_send_req_tries(req_channel):
             assert rtn == 30
 
 
-async def test_send_req_async_regression_62453(minion_opts):
-    event_enter = MagicMock()
-    event_enter.send.side_effect = (
-        lambda data, tag, cb=None, timeout=60: salt.ext.tornado.gen.maybe_future(True)
-    )
-    event = MagicMock()
-    event.__enter__.return_value = event_enter
-
-    minion_opts["random_startup_delay"] = 0
-    minion_opts["return_retry_tries"] = 30
-    minion_opts["grains"] = {}
-    with patch("salt.loader.grains"):
-        minion = salt.minion.Minion(minion_opts)
-
-        load = {"load": "value"}
-        timeout = 60
-
-        # We are just validating no exception is raised
-        rtn = await minion._send_req_async(load, timeout)
-        assert rtn == False
-
-
-def test_mine_send_tries():
+@patch("salt.channel.client.ReqChannel.factory")
+def test_mine_send_tries(req_channel_factory):
     channel_enter = MagicMock()
     channel_enter.send.side_effect = lambda load, timeout, tries: tries
     channel = MagicMock()


### PR DESCRIPTION
### What does this PR do?

This PR reverts the following commits:
  https://github.com/saltstack/salt/commit/a99ffb557b8a1142225d4925aba4a5e493923d2f
  https://github.com/saltstack/salt/commit/80ae5188807550e7592fa12d8661ee83c4313ec8
  https://github.com/saltstack/salt/commit/3c7e1ec1f08abd7cd1ba78ad7880acb6ba6fdce7
  https://github.com/saltstack/salt/commit/171926cc57618b51bf3fdc042b62212e681180fc

From this conflictive upstream PR: https://github.com/saltstack/salt/pull/61468

See: https://github.com/saltstack/salt/issues/62959#issuecomment-1658335432

**UPDATE:** After reverting this commits, some tests started failing. I had to also revert another PR where implemented tests didn't make sense after the intiial revert: https://github.com/saltstack/salt/pull/62476 + do some minor adjustments so tests are back to green.

### What issues does this PR fix or reference?
Tracks:
- https://github.com/SUSE/spacewalk/issues/22268
- https://github.com/SUSE/spacewalk/issues/21988
- https://github.com/SUSE/spacewalk/issues/22093

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
