### PR TITLE
Check timeout on ssh calls (bsc#1213550)

### DIFF
--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -400,6 +400,7 @@ class Shell:
         ret_stdout = ""
         ret_stderr = ""
         old_stdout = ""
+        t_start = time.time()
 
         try:
             while term.has_unread_data:
@@ -463,6 +464,9 @@ class Shell:
                     term.sendline(mods_raw)
                 if stdout:
                     old_stdout = stdout
+                # self.timeout is used for ConnectTimeout. Allow the same time for command execution.
+                if time.time() - t_start > self.timeout * 2:
+                    return ("", "timeout", 255)
                 time.sleep(0.01)
             if term.exitstatus is None:
                 try:


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1213550

### Previous Behavior
When executing ssh or scp command, the timeout was checked only on connection.
When the command got stuck after connecting, it could run forever.

### New Behavior
Total execution time is limited.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
