### PR TITLE
Use salt-call from salt bundle with transactional_update

### DIFF
--- a/salt/modules/transactional_update.py
+++ b/salt/modules/transactional_update.py
@@ -276,6 +276,9 @@ transaction.
 """
 
 import logging
+import os.path
+import pathlib
+import sys
 
 import salt.client.ssh.state
 import salt.client.ssh.wrapper.state
@@ -941,10 +944,18 @@ def call(function, *args, **kwargs):
     activate_transaction = kwargs.pop("activate_transaction", False)
 
     try:
+        # Set default salt-call command
+        salt_call_cmd = "salt-call"
+        python_exec_dir = os.path.dirname(sys.executable)
+        if "venv-salt-minion" in pathlib.Path(python_exec_dir).parts:
+            # If the module is executed with the Salt Bundle,
+            # use salt-call from the Salt Bundle
+            salt_call_cmd = os.path.join(python_exec_dir, "salt-call")
+
         safe_kwargs = salt.utils.args.clean_kwargs(**kwargs)
         salt_argv = (
             [
-                "salt-call",
+                salt_call_cmd,
                 "--out",
                 "json",
                 "-l",


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/saltstack/salt/pull/65204

### What issues does this PR fix or reference?
In some cases if both salt bundle and classic salt package installed on the same system, transactional_update module can wrongly execute `salt-call` of classic salt packge instead of salt bundle which was used to process the event.

### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/19875

### Previous Behavior
Wrong `salt-call` executed inside the transaction while using `transactional_update`.

### New Behavior
In case if the event processed with salt from the bundle `transactional_update` will call `salt-call` from the bundle explicitly.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
