### PR TITLE
Remove usage of "mock" in favor of "unittest.mock"

### DIFF
--- a/requirements/pytest.txt
+++ b/requirements/pytest.txt
@@ -1,4 +1,3 @@
-mock >= 3.0.0
 # PyTest
 pytest >= 7.0.1; python_version <= "3.6"
 pytest >= 7.2.0; python_version > "3.6"

--- a/requirements/static/ci/py3.10/cloud.txt
+++ b/requirements/static/ci/py3.10/cloud.txt
@@ -502,8 +502,6 @@ markupsafe==2.1.2
     #   mako
     #   moto
     #   werkzeug
-mock==4.0.3
-    # via -r requirements/pytest.txt
 more-itertools==8.8.0
     # via
     #   cheroot

--- a/requirements/static/ci/py3.10/darwin.txt
+++ b/requirements/static/ci/py3.10/darwin.txt
@@ -505,8 +505,6 @@ markupsafe==2.1.2
     #   werkzeug
 mercurial==6.0.1
     # via -r requirements/static/ci/darwin.in
-mock==3.0.5
-    # via -r requirements/pytest.txt
 more-itertools==8.2.0
     # via
     #   cheroot
@@ -806,7 +804,6 @@ six==1.16.0
     #   jsonschema
     #   junos-eznc
     #   kubernetes
-    #   mock
     #   msrestazure
     #   ncclient
     #   paramiko

--- a/requirements/static/ci/py3.10/freebsd.txt
+++ b/requirements/static/ci/py3.10/freebsd.txt
@@ -502,8 +502,6 @@ markupsafe==2.1.2
     #   werkzeug
 mercurial==6.0.1
     # via -r requirements/static/ci/freebsd.in
-mock==3.0.5
-    # via -r requirements/pytest.txt
 more-itertools==5.0.0
     # via
     #   cheroot
@@ -805,7 +803,6 @@ six==1.16.0
     #   junos-eznc
     #   kazoo
     #   kubernetes
-    #   mock
     #   more-itertools
     #   msrestazure
     #   ncclient

--- a/requirements/static/ci/py3.10/linux.txt
+++ b/requirements/static/ci/py3.10/linux.txt
@@ -518,8 +518,6 @@ markupsafe==2.1.2
     #   werkzeug
 mercurial==6.0.1
     # via -r requirements/static/ci/linux.in
-mock==3.0.5
-    # via -r requirements/pytest.txt
 more-itertools==5.0.0
     # via
     #   cheroot
@@ -843,7 +841,6 @@ six==1.16.0
     #   junos-eznc
     #   kazoo
     #   kubernetes
-    #   mock
     #   more-itertools
     #   ncclient
     #   paramiko

--- a/requirements/static/ci/py3.10/windows.txt
+++ b/requirements/static/ci/py3.10/windows.txt
@@ -173,8 +173,6 @@ markupsafe==2.1.1
     #   mako
     #   moto
     #   werkzeug
-mock==3.0.5
-    # via -r requirements/pytest.txt
 more-itertools==8.2.0
     # via
     #   cheroot
@@ -361,7 +359,6 @@ six==1.15.0
     #   google-auth
     #   jsonschema
     #   kubernetes
-    #   mock
     #   python-dateutil
     #   pyvmomi
     #   pywinrm

--- a/requirements/static/ci/py3.6/cloud.txt
+++ b/requirements/static/ci/py3.6/cloud.txt
@@ -516,7 +516,6 @@ markupsafe==2.0.1
     #   jinja2
     #   mako
     #   moto
-mock==4.0.3
     # via -r requirements/pytest.txt
 more-itertools==8.8.0
     # via

--- a/requirements/static/ci/py3.6/linux.txt
+++ b/requirements/static/ci/py3.6/linux.txt
@@ -533,8 +533,6 @@ markupsafe==2.0.1
     #   moto
 mercurial==6.0.1
     # via -r requirements/static/ci/linux.in
-mock==3.0.5
-    # via -r requirements/pytest.txt
 more-itertools==5.0.0
     # via
     #   cheroot
@@ -862,7 +860,6 @@ six==1.16.0
     #   junos-eznc
     #   kazoo
     #   kubernetes
-    #   mock
     #   more-itertools
     #   ncclient
     #   paramiko

--- a/requirements/static/ci/py3.7/cloud.txt
+++ b/requirements/static/ci/py3.7/cloud.txt
@@ -529,7 +529,6 @@ markupsafe==2.1.2
     #   mako
     #   moto
     #   werkzeug
-mock==4.0.3
     # via -r requirements/pytest.txt
 more-itertools==8.8.0
     # via

--- a/requirements/static/ci/py3.7/freebsd.txt
+++ b/requirements/static/ci/py3.7/freebsd.txt
@@ -526,7 +526,6 @@ markupsafe==2.1.2
     #   werkzeug
 mercurial==6.0.1
     # via -r requirements/static/ci/freebsd.in
-mock==3.0.5
     # via -r requirements/pytest.txt
 more-itertools==5.0.0
     # via
@@ -848,7 +847,6 @@ six==1.16.0
     #   junos-eznc
     #   kazoo
     #   kubernetes
-    #   mock
     #   more-itertools
     #   msrestazure
     #   ncclient

--- a/requirements/static/ci/py3.7/linux.txt
+++ b/requirements/static/ci/py3.7/linux.txt
@@ -542,7 +542,6 @@ markupsafe==2.1.2
     #   werkzeug
 mercurial==6.0.1
     # via -r requirements/static/ci/linux.in
-mock==3.0.5
     # via -r requirements/pytest.txt
 more-itertools==5.0.0
     # via
@@ -888,7 +887,6 @@ six==1.16.0
     #   junos-eznc
     #   kazoo
     #   kubernetes
-    #   mock
     #   more-itertools
     #   ncclient
     #   paramiko

--- a/requirements/static/ci/py3.7/windows.txt
+++ b/requirements/static/ci/py3.7/windows.txt
@@ -187,7 +187,6 @@ markupsafe==2.1.2
     #   mako
     #   moto
     #   werkzeug
-mock==3.0.5
     # via -r requirements/pytest.txt
 more-itertools==8.2.0
     # via
@@ -375,7 +374,6 @@ six==1.15.0
     #   google-auth
     #   jsonschema
     #   kubernetes
-    #   mock
     #   python-dateutil
     #   pyvmomi
     #   pywinrm

--- a/requirements/static/ci/py3.8/cloud.txt
+++ b/requirements/static/ci/py3.8/cloud.txt
@@ -518,7 +518,6 @@ markupsafe==2.1.2
     #   mako
     #   moto
     #   werkzeug
-mock==4.0.3
     # via -r requirements/pytest.txt
 more-itertools==8.8.0
     # via

--- a/requirements/static/ci/py3.8/freebsd.txt
+++ b/requirements/static/ci/py3.8/freebsd.txt
@@ -516,8 +516,6 @@ markupsafe==2.1.2
     #   werkzeug
 mercurial==6.0.1
     # via -r requirements/static/ci/freebsd.in
-mock==3.0.5
-    # via -r requirements/pytest.txt
 more-itertools==5.0.0
     # via
     #   cheroot
@@ -838,7 +836,6 @@ six==1.16.0
     #   junos-eznc
     #   kazoo
     #   kubernetes
-    #   mock
     #   more-itertools
     #   msrestazure
     #   ncclient

--- a/requirements/static/ci/py3.8/linux.txt
+++ b/requirements/static/ci/py3.8/linux.txt
@@ -532,8 +532,6 @@ markupsafe==2.1.2
     #   werkzeug
 mercurial==6.0.1
     # via -r requirements/static/ci/linux.in
-mock==3.0.5
-    # via -r requirements/pytest.txt
 more-itertools==5.0.0
     # via
     #   cheroot
@@ -876,7 +874,6 @@ six==1.16.0
     #   junos-eznc
     #   kazoo
     #   kubernetes
-    #   mock
     #   more-itertools
     #   ncclient
     #   paramiko

--- a/requirements/static/ci/py3.8/windows.txt
+++ b/requirements/static/ci/py3.8/windows.txt
@@ -175,8 +175,6 @@ markupsafe==2.1.2
     #   mako
     #   moto
     #   werkzeug
-mock==3.0.5
-    # via -r requirements/pytest.txt
 more-itertools==8.2.0
     # via
     #   cheroot
@@ -363,7 +361,6 @@ six==1.15.0
     #   google-auth
     #   jsonschema
     #   kubernetes
-    #   mock
     #   python-dateutil
     #   pyvmomi
     #   pywinrm

--- a/requirements/static/ci/py3.9/cloud.txt
+++ b/requirements/static/ci/py3.9/cloud.txt
@@ -518,7 +518,6 @@ markupsafe==2.1.2
     #   mako
     #   moto
     #   werkzeug
-mock==4.0.3
     # via -r requirements/pytest.txt
 more-itertools==8.8.0
     # via

--- a/requirements/static/ci/py3.9/darwin.txt
+++ b/requirements/static/ci/py3.9/darwin.txt
@@ -519,8 +519,6 @@ markupsafe==2.1.2
     #   werkzeug
 mercurial==6.0.1
     # via -r requirements/static/ci/darwin.in
-mock==3.0.5
-    # via -r requirements/pytest.txt
 more-itertools==8.2.0
     # via
     #   cheroot
@@ -842,7 +840,6 @@ six==1.16.0
     #   jsonschema
     #   junos-eznc
     #   kubernetes
-    #   mock
     #   msrestazure
     #   ncclient
     #   paramiko

--- a/requirements/static/ci/py3.9/freebsd.txt
+++ b/requirements/static/ci/py3.9/freebsd.txt
@@ -516,8 +516,6 @@ markupsafe==2.1.2
     #   werkzeug
 mercurial==6.0.1
     # via -r requirements/static/ci/freebsd.in
-mock==3.0.5
-    # via -r requirements/pytest.txt
 more-itertools==5.0.0
     # via
     #   cheroot
@@ -841,7 +839,6 @@ six==1.16.0
     #   junos-eznc
     #   kazoo
     #   kubernetes
-    #   mock
     #   more-itertools
     #   msrestazure
     #   ncclient

--- a/requirements/static/ci/py3.9/linux.txt
+++ b/requirements/static/ci/py3.9/linux.txt
@@ -534,8 +534,6 @@ markupsafe==2.1.2
     #   werkzeug
 mercurial==6.0.1
     # via -r requirements/static/ci/linux.in
-mock==3.0.5
-    # via -r requirements/pytest.txt
 more-itertools==5.0.0
     # via
     #   cheroot
@@ -881,7 +879,6 @@ six==1.16.0
     #   junos-eznc
     #   kazoo
     #   kubernetes
-    #   mock
     #   more-itertools
     #   ncclient
     #   paramiko

--- a/requirements/static/ci/py3.9/windows.txt
+++ b/requirements/static/ci/py3.9/windows.txt
@@ -175,8 +175,6 @@ markupsafe==2.1.2
     #   mako
     #   moto
     #   werkzeug
-mock==3.0.5
-    # via -r requirements/pytest.txt
 more-itertools==8.2.0
     # via
     #   cheroot
@@ -364,7 +362,6 @@ six==1.15.0
     #   google-auth
     #   jsonschema
     #   kubernetes
-    #   mock
     #   python-dateutil
     #   pyvmomi
     #   pywinrm

--- a/tests/pytests/unit/cloud/clouds/test_dimensiondata.py
+++ b/tests/pytests/unit/cloud/clouds/test_dimensiondata.py
@@ -10,9 +10,7 @@ import pytest
 from salt.cloud.clouds import dimensiondata
 from salt.exceptions import SaltCloudSystemExit
 from salt.utils.versions import Version
-from tests.support.mock import MagicMock
-from tests.support.mock import __version__ as mock_version
-from tests.support.mock import patch
+from tests.support.mock import MagicMock, patch
 
 try:
     import libcloud.security
@@ -144,8 +142,7 @@ def test_import():
     with patch("salt.config.check_driver_dependencies", return_value=True) as p:
         get_deps = dimensiondata.get_dependencies()
         assert get_deps is True
-        if Version(mock_version) >= Version("2.0.0"):
-            assert p.call_count >= 1
+        assert p.call_count >= 1
 
 
 def test_provider_matches():

--- a/tests/pytests/unit/cloud/clouds/test_gce.py
+++ b/tests/pytests/unit/cloud/clouds/test_gce.py
@@ -11,10 +11,7 @@ import pytest
 
 from salt.cloud.clouds import gce
 from salt.exceptions import SaltCloudSystemExit
-from salt.utils.versions import Version
-from tests.support.mock import MagicMock
-from tests.support.mock import __version__ as mock_version
-from tests.support.mock import call, patch
+from tests.support.mock import MagicMock, call, patch
 
 
 @pytest.fixture
@@ -281,8 +278,7 @@ def test_import():
     with patch("salt.config.check_driver_dependencies", return_value=True) as p:
         get_deps = gce.get_dependencies()
         assert get_deps is True
-        if Version(mock_version) >= Version("2.0.0"):
-            p.assert_called_once()
+        p.assert_called_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/support/mock.py
+++ b/tests/support/mock.py
@@ -15,7 +15,7 @@ import copy
 import errno
 import fnmatch
 import sys
-import unittest.mock as mock
+import unittest.mock as mock  # pylint: disable=blacklisted-import
 
 # pylint: disable=no-name-in-module,no-member
 from unittest.mock import (

--- a/tests/support/mock.py
+++ b/tests/support/mock.py
@@ -7,9 +7,6 @@
     Helper module that wraps `mock` and provides some fake objects in order to
     properly set the function/class decorators and yet skip the test case's
     execution.
-
-    Note: mock >= 2.0.0 required since unittest.mock does not have
-    MagicMock.assert_called in Python < 3.6.
 """
 # pylint: disable=unused-import,function-redefined,blacklisted-module,blacklisted-external-module
 
@@ -18,12 +15,10 @@ import copy
 import errno
 import fnmatch
 import sys
-
-# By these days, we should blowup if mock is not available
-import mock  # pylint: disable=blacklisted-external-import
+import unittest.mock as mock
 
 # pylint: disable=no-name-in-module,no-member
-from mock import (
+from unittest.mock import (
     ANY,
     DEFAULT,
     FILTER_DIR,
@@ -32,7 +27,6 @@ from mock import (
     NonCallableMagicMock,
     NonCallableMock,
     PropertyMock,
-    __version__,
     call,
     create_autospec,
     patch,
@@ -40,13 +34,6 @@ from mock import (
 )
 
 import salt.utils.stringutils
-
-# pylint: disable=no-name-in-module,no-member
-
-
-__mock_version = tuple(
-    int(part) for part in mock.__version__.split(".") if part.isdigit()
-)  # pylint: disable=no-member
 
 
 class MockFH:


### PR DESCRIPTION
### What does this PR do?

This PR simply removes the usage of `mock` in favor of `unittest.mock` (standard library), as after Salt dropping support for Python 3.6, there is no need to keep using `mock` library at the time of testing.

Additionally, it removes the import of  `__version__`  (an unused `__mock_version`), as this attribute was dropped and not available in Python 3.9+ (https://github.com/python/cpython/pull/17977)

---

This PR backports https://github.com/saltstack/salt/pull/65364 to `openSUSE/release/3006.0` branch.

### Commits signed with GPG?
Yes
