### PR TITLE
Use unittest.mock for newer Python versions

### DIFF
--- a/requirements/pytest.txt
+++ b/requirements/pytest.txt
@@ -1,4 +1,4 @@
-mock >= 3.0.0
+mock >= 3.0.0; python_version < '3.8'
 # PyTest
 pytest >= 7.0.1; python_version <= "3.6"
 pytest >= 7.2.0; python_version > "3.6"

--- a/tests/pytests/unit/cloud/clouds/test_dimensiondata.py
+++ b/tests/pytests/unit/cloud/clouds/test_dimensiondata.py
@@ -11,7 +11,6 @@ from salt.cloud.clouds import dimensiondata
 from salt.exceptions import SaltCloudSystemExit
 from salt.utils.versions import Version
 from tests.support.mock import MagicMock
-from tests.support.mock import __version__ as mock_version
 from tests.support.mock import patch
 
 try:
@@ -144,8 +143,7 @@ def test_import():
     with patch("salt.config.check_driver_dependencies", return_value=True) as p:
         get_deps = dimensiondata.get_dependencies()
         assert get_deps is True
-        if Version(mock_version) >= Version("2.0.0"):
-            assert p.call_count >= 1
+        assert p.call_count >= 1
 
 
 def test_provider_matches():

--- a/tests/pytests/unit/cloud/clouds/test_gce.py
+++ b/tests/pytests/unit/cloud/clouds/test_gce.py
@@ -13,7 +13,6 @@ from salt.cloud.clouds import gce
 from salt.exceptions import SaltCloudSystemExit
 from salt.utils.versions import Version
 from tests.support.mock import MagicMock
-from tests.support.mock import __version__ as mock_version
 from tests.support.mock import call, patch
 
 
@@ -281,8 +280,7 @@ def test_import():
     with patch("salt.config.check_driver_dependencies", return_value=True) as p:
         get_deps = gce.get_dependencies()
         assert get_deps is True
-        if Version(mock_version) >= Version("2.0.0"):
-            p.assert_called_once()
+        p.assert_called_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/support/mock.py
+++ b/tests/support/mock.py
@@ -18,36 +18,32 @@ import copy
 import errno
 import fnmatch
 import sys
+import importlib
 
-# By these days, we should blowup if mock is not available
-import mock  # pylint: disable=blacklisted-external-import
+current_version = (sys.version_info.major, sys.version_info.minor)
 
-# pylint: disable=no-name-in-module,no-member
-from mock import (
-    ANY,
-    DEFAULT,
-    FILTER_DIR,
-    MagicMock,
-    Mock,
-    NonCallableMagicMock,
-    NonCallableMock,
-    PropertyMock,
-    __version__,
-    call,
-    create_autospec,
-    patch,
-    sentinel,
-)
+# Prefer unittest.mock for Python versions that are sufficient
+if current_version >= (3,8):
+    mock = importlib.import_module('unittest.mock')
+else:
+    mock = importlib.import_module('mock')
+
+ANY = mock.ANY
+DEFAULT = mock.DEFAULT
+FILTER_DIR = mock.FILTER_DIR
+MagicMock = mock.MagicMock
+Mock = mock.Mock
+NonCallableMagicMock = mock.NonCallableMagicMock
+NonCallableMock = mock.NonCallableMock
+PropertyMock = mock.PropertyMock
+call = mock.call
+create_autospec = mock.create_autospec
+patch = mock.patch
+sentinel = mock.sentinel
 
 import salt.utils.stringutils
 
 # pylint: disable=no-name-in-module,no-member
-
-
-__mock_version = tuple(
-    int(part) for part in mock.__version__.split(".") if part.isdigit()
-)  # pylint: disable=no-member
-
 
 class MockFH:
     def __init__(self, filename, read_data, *args, **kwargs):


### PR DESCRIPTION
### What does this PR do?

This PR causes the test suite to use unittest.mock instead of mock for supported Python versions, so the usage of standard library components is favoured.

To achieve this, the __version__ variable is removed as it was dropped from Python 3.9 and it's almost not used.

The results of the test suite do not change.

Upstream PR:
https://github.com/saltstack/salt/pull/65644

### What issues does this PR fix or reference?
Related: https://github.com/SUSE/spacewalk/issues/22793

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
