### PR TITLE
Revert "Make sure configured user is properly set by Salt" (bsc#1216284)

### DIFF
--- a/pkg/common/salt-master.service
+++ b/pkg/common/salt-master.service
@@ -8,7 +8,6 @@ LimitNOFILE=100000
 Type=notify
 NotifyAccess=all
 ExecStart=/usr/bin/salt-master
-User=salt
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/old/deb/salt-master.service
+++ b/pkg/old/deb/salt-master.service
@@ -7,7 +7,6 @@ LimitNOFILE=16384
 Type=notify
 NotifyAccess=all
 ExecStart=/usr/bin/salt-master
-User=salt
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/old/suse/salt-master.service
+++ b/pkg/old/suse/salt-master.service
@@ -8,7 +8,6 @@ LimitNOFILE=100000
 Type=simple
 ExecStart=/usr/bin/salt-master
 TasksMax=infinity
-User=salt
 
 [Install]
 WantedBy=multi-user.target

--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -7,7 +7,6 @@ import logging
 import os
 import warnings
 
-import salt.defaults.exitcodes
 import salt.utils.kinds as kinds
 from salt.exceptions import SaltClientError, SaltSystemExit, get_error_message
 from salt.utils import migrations
@@ -73,16 +72,6 @@ class DaemonsMixin:  # pylint: disable=no-init
                 self.config["hash_type"],
                 self.__class__.__name__,
             )
-
-    def verify_user(self):
-        """
-        Verify Salt configured user for Salt and shutdown daemon if not valid.
-
-        :return:
-        """
-        if not check_user(self.config["user"]):
-            self.action_log_info("Cannot switch to configured user for Salt. Exiting")
-            self.shutdown(salt.defaults.exitcodes.EX_NOUSER)
 
     def action_log_info(self, action):
         """
@@ -188,10 +177,6 @@ class Master(
             self.shutdown(4, "The ports are not available to bind")
         self.config["interface"] = ip_bracket(self.config["interface"])
         migrations.migrate_paths(self.config)
-
-        # Ensure configured user is valid and environment is properly set
-        # before initializating rest of the stack.
-        self.verify_user()
 
         # Late import so logging works correctly
         import salt.master
@@ -304,10 +289,6 @@ class Minion(
             self.shutdown(1)
 
         transport = self.config.get("transport").lower()
-
-        # Ensure configured user is valid and environment is properly set
-        # before initializating rest of the stack.
-        self.verify_user()
 
         try:
             # Late import so logging works correctly
@@ -497,10 +478,6 @@ class ProxyMinion(
             self.action_log_info("An instance is already running. Exiting")
             self.shutdown(1)
 
-        # Ensure configured user is valid and environment is properly set
-        # before initializating rest of the stack.
-        self.verify_user()
-
         # TODO: AIO core is separate from transport
         # Late import so logging works correctly
         import salt.minion
@@ -598,10 +575,6 @@ class Syndic(
             self.environment_failure(error)
 
         self.action_log_info('Setting up "{}"'.format(self.config["id"]))
-
-        # Ensure configured user is valid and environment is properly set
-        # before initializating rest of the stack.
-        self.verify_user()
 
         # Late import so logging works correctly
         import salt.minion

--- a/salt/cli/ssh.py
+++ b/salt/cli/ssh.py
@@ -1,9 +1,7 @@
 import sys
 
 import salt.client.ssh
-import salt.defaults.exitcodes
 import salt.utils.parsers
-from salt.utils.verify import check_user
 
 
 class SaltSSH(salt.utils.parsers.SaltSSHOptionParser):
@@ -16,12 +14,6 @@ class SaltSSH(salt.utils.parsers.SaltSSHOptionParser):
             sys.argv += ["x", "x"]  # Hack: pass a mandatory two options
             # that won't be used anyways with -H or --hosts
         self.parse_args()
-
-        if not check_user(self.config["user"]):
-            self.exit(
-                salt.defaults.exitcodes.EX_NOUSER,
-                "Cannot switch to configured user for Salt. Exiting",
-            )
 
         ssh = salt.client.ssh.SSH(self.config)
         ssh.run()

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -335,8 +335,8 @@ def check_user(user):
 
         # We could just reset the whole environment but let's just override
         # the variables we can get from pwuser
-        # We ensure HOME is always present and set according to pwuser
-        os.environ["HOME"] = pwuser.pw_dir
+        if "HOME" in os.environ:
+            os.environ["HOME"] = pwuser.pw_dir
 
         if "SHELL" in os.environ:
             os.environ["SHELL"] = pwuser.pw_shell

--- a/tests/pytests/integration/cli/test_salt_minion.py
+++ b/tests/pytests/integration/cli/test_salt_minion.py
@@ -41,7 +41,7 @@ def test_exit_status_unknown_user(salt_master, minion_id):
         factory = salt_master.salt_minion_daemon(
             minion_id, overrides={"user": "unknown-user"}
         )
-        factory.start(start_timeout=30, max_start_attempts=1)
+        factory.start(start_timeout=10, max_start_attempts=1)
 
     assert exc.value.process_result.returncode == salt.defaults.exitcodes.EX_NOUSER
     assert "The user is not available." in exc.value.process_result.stderr
@@ -53,7 +53,7 @@ def test_exit_status_unknown_argument(salt_master, minion_id):
     """
     with pytest.raises(FactoryNotStarted) as exc:
         factory = salt_master.salt_minion_daemon(minion_id)
-        factory.start("--unknown-argument", start_timeout=30, max_start_attempts=1)
+        factory.start("--unknown-argument", start_timeout=10, max_start_attempts=1)
 
     assert exc.value.process_result.returncode == salt.defaults.exitcodes.EX_USAGE
     assert "Usage" in exc.value.process_result.stderr


### PR DESCRIPTION
This reverts commit 5ea4add5c8e2bed50b9825edfff7565e5f6124f3 which turned out to be problematic, as it caused some regressions (bsc#1216284), while not being really needed to fix the initial issue that motivated that patch (bsc#1210994).

The patch this PR is reverting is not really needed to fix (bsc#1210994), as that bug was actually fixed by https://github.com/openSUSE/salt/commit/40a57afc65e71835127a437248ed655404cff0e8. 

Introducing the conflictive patch was just to align with upstream PR https://github.com/saltstack/salt/pull/64510, after it was reviewed (which contains the initial working fix + extra changes after the review)

The reason to revert this patch instead of fixing upstream PR is that, it seems we cannot really change the "user" that earlier in the stack as proposed in upstream PR, because this causes problems for "salt-master", while creating user keys (as "chmod" cannot be executed properly if not running as root). So the extra changes done in the upstream PR don't really make sense.

In a nutshell, "salt-master" needs to run as "root" during startup, and then it will switch to the configured user at some point during the startup. We cannot set "salt-master" systemd unit with `User=salt` and neither switching to the configured user  at the begining of the initialization stack, as this is too early and will cause problems.

I will adapt upstream PR to refllect this findings.

Tracks: https://github.com/SUSE/spacewalk/issues/22827