### PR TITLE
Fixed KeyError in logs when running a state that fails

### DIFF
--- a/changelog/64231.fixed.md
+++ b/changelog/64231.fixed.md
@@ -1,0 +1,1 @@
+Fixed KeyError in logs when running a state that fails.

--- a/salt/master.py
+++ b/salt/master.py
@@ -1790,7 +1790,7 @@ class AESFuncs(TransportMethods):
     def pub_ret(self, load):
         """
         Request the return data from a specific jid, only allowed
-        if the requesting minion also initialted the execution.
+        if the requesting minion also initiated the execution.
 
         :param dict load: The minion payload
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2022,6 +2022,8 @@ class Minion(MinionBase):
         ret["jid"] = data["jid"]
         ret["fun"] = data["fun"]
         ret["fun_args"] = data["arg"]
+        if "user" in data:
+            ret["user"] = data["user"]
         if "master_id" in data:
             ret["master_id"] = data["master_id"]
         if "metadata" in data:
@@ -2141,6 +2143,8 @@ class Minion(MinionBase):
             ret["jid"] = data["jid"]
             ret["fun"] = data["fun"]
             ret["fun_args"] = data["arg"]
+            if "user" in data:
+                ret["user"] = data["user"]
         if "metadata" in data:
             ret["metadata"] = data["metadata"]
         if minion_instance.connected:

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -902,7 +902,8 @@ class SaltEvent:
                     data["success"] = False
                     data["return"] = "Error: {}.{}".format(tags[0], tags[-1])
                     data["fun"] = fun
-                    data["user"] = load["user"]
+                    if "user" in load:
+                        data["user"] = load["user"]
                     self.fire_event(
                         data,
                         tagify([load["jid"], "sub", load["id"], "error", fun], "job"),

--- a/tests/pytests/integration/states/test_state_test.py
+++ b/tests/pytests/integration/states/test_state_test.py
@@ -1,0 +1,38 @@
+def test_failing_sls(salt_master, salt_minion, salt_cli, caplog):
+    """
+    Test when running state.sls and the state fails.
+    When the master stores the job and attempts to send
+    an event a KeyError was previously being logged.
+    This test ensures we do not log an error when
+    attempting to send an event about a failing state.
+    """
+    statesls = """
+    test_state:
+      test.fail_without_changes:
+        - name: "bla"
+    """
+    with salt_master.state_tree.base.temp_file("test_failure.sls", statesls):
+        ret = salt_cli.run("state.sls", "test_failure", minion_tgt=salt_minion.id)
+        for message in caplog.messages:
+            assert "Event iteration failed with" not in message
+
+
+def test_failing_sls_compound(salt_master, salt_minion, salt_cli, caplog):
+    """
+    Test when running state.sls in a compound command and the state fails.
+    When the master stores the job and attempts to send
+    an event a KeyError was previously being logged.
+    This test ensures we do not log an error when
+    attempting to send an event about a failing state.
+    """
+    statesls = """
+    test_state:
+      test.fail_without_changes:
+        - name: "bla"
+    """
+    with salt_master.state_tree.base.temp_file("test_failure.sls", statesls):
+        ret = salt_cli.run(
+            "state.sls,cmd.run", "test_failure,ls", minion_tgt=salt_minion.id
+        )
+        for message in caplog.messages:
+            assert "Event iteration failed with" not in message


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/saltstack/salt/pull/65009

What does this PR do?
When running state.sls against a state that fails would result in a KeyError in the logs:

```
[ERROR   ] Event iteration failed with exception: 'user'
Traceback (most recent call last):
  File "/opt/saltstack/salt/lib/python3.10/site-packages/salt/utils/event.py", line 905, in _fire_ret_load_specific_fun
    data["user"] = load["user"]
KeyError: 'user'
```
This is because `user` was never in the returned payload back to the master. This PR adds the user who originally submitted the job to the minion to be added to the return payload.

More details in the original description of upstream PR: https://github.com/saltstack/salt/pull/65009

What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/64231

### What issues does this PR fix or reference?

### Previous Behavior
KeyError in logs and failing state event would not properly fire off

### New Behavior
No KeyError in log and the event properly fires off.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
