### PR TITLE
Allow kwargs for fileserver roots update (bsc#1218482)

### DIFF
--- a/changelog/65819.fixed.md
+++ b/changelog/65819.fixed.md
@@ -1,1 +1,1 @@
-Allow keyword arguments for the fileserver roots backend update function.
+Prevent exceptions with fileserver.update when called via state

--- a/changelog/65819.fixed.md
+++ b/changelog/65819.fixed.md
@@ -1,0 +1,1 @@
+Allow keyword arguments for the fileserver roots backend update function.

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -138,16 +138,10 @@ def serve_file(load, fnd):
     return ret
 
 
-def update(**kwargs):
+def update():
     """
     When we are asked to update (regular interval) lets reap the cache
     """
-    # __pub_user responsible for the runner can be passed but we don't do anything with it
-    if "__pub_user" in kwargs:
-        del kwargs["__pub_user"]
-    if kwargs:
-        raise ValueError("Unexpected keyword arguments received: %s" % kwargs)
-
     try:
         salt.fileserver.reap_fileserver_cache_dir(
             os.path.join(__opts__["cachedir"], "roots", "hash"), find_file

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -138,10 +138,16 @@ def serve_file(load, fnd):
     return ret
 
 
-def update():
+def update(**kwargs):
     """
     When we are asked to update (regular interval) lets reap the cache
     """
+    # __pub_user responsible for the runner can be passed but we don't do anything with it
+    if "__pub_user" in kwargs:
+        del kwargs["__pub_user"]
+    if kwargs:
+        raise ValueError("Unexpected keyword arguments received: %s" % kwargs)
+
     try:
         salt.fileserver.reap_fileserver_cache_dir(
             os.path.join(__opts__["cachedir"], "roots", "hash"), find_file
@@ -193,9 +199,7 @@ def update():
         os.makedirs(mtime_map_path_dir)
     with salt.utils.files.fopen(mtime_map_path, "wb") as fp_:
         for file_path, mtime in new_mtime_map.items():
-            fp_.write(
-                salt.utils.stringutils.to_bytes("{}:{}\n".format(file_path, mtime))
-            )
+            fp_.write(salt.utils.stringutils.to_bytes(f"{file_path}:{mtime}\n"))
 
     if __opts__.get("fileserver_events", False):
         # if there is a change, fire an event
@@ -326,11 +330,11 @@ def _file_lists(load, form):
             return []
     list_cache = os.path.join(
         list_cachedir,
-        "{}.p".format(salt.utils.files.safe_filename_leaf(actual_saltenv)),
+        f"{salt.utils.files.safe_filename_leaf(actual_saltenv)}.p",
     )
     w_lock = os.path.join(
         list_cachedir,
-        ".{}.w".format(salt.utils.files.safe_filename_leaf(actual_saltenv)),
+        f".{salt.utils.files.safe_filename_leaf(actual_saltenv)}.w",
     )
     cache_match, refresh_cache, save_cache = salt.fileserver.check_file_list_cache(
         __opts__, form, list_cache, w_lock

--- a/salt/runners/fileserver.py
+++ b/salt/runners/fileserver.py
@@ -350,6 +350,12 @@ def update(backend=None, **kwargs):
         salt-run fileserver.update backend=git remotes=myrepo,yourrepo
     """
     fileserver = salt.fileserver.Fileserver(__opts__)
+
+    # Remove possible '__pub_user' in kwargs as it is not expected
+    # on "update" function for the different fileserver backends.
+    if "__pub_user" in kwargs:
+        del kwargs["__pub_user"]
+
     fileserver.update(back=backend, **kwargs)
     return True
 

--- a/tests/pytests/unit/fileserver/test_roots.py
+++ b/tests/pytests/unit/fileserver/test_roots.py
@@ -4,7 +4,6 @@
 
 import copy
 import pathlib
-import re
 import shutil
 import textwrap
 
@@ -278,9 +277,3 @@ def test_update_mtime_map_unicode_error(tmp_path):
         },
         "backend": "roots",
     }
-
-
-def test_update_unexpected_kwargs():
-    with pytest.raises(ValueError) as exc_info:
-        ret = roots.update(foo="bar")
-    assert re.match(r"Unexpected keyword arguments received:", str(exc_info.value))

--- a/tests/pytests/unit/fileserver/test_roots.py
+++ b/tests/pytests/unit/fileserver/test_roots.py
@@ -4,6 +4,7 @@
 
 import copy
 import pathlib
+import re
 import shutil
 import textwrap
 
@@ -236,7 +237,7 @@ def test_update_mtime_map():
     # between Python releases.
     lines_written = sorted(mtime_map_mock.write_calls())
     expected = sorted(
-        salt.utils.stringutils.to_bytes("{key}:{val}\n".format(key=key, val=val))
+        salt.utils.stringutils.to_bytes(f"{key}:{val}\n")
         for key, val in new_mtime_map.items()
     )
     assert lines_written == expected, lines_written
@@ -277,3 +278,9 @@ def test_update_mtime_map_unicode_error(tmp_path):
         },
         "backend": "roots",
     }
+
+
+def test_update_unexpected_kwargs():
+    with pytest.raises(ValueError) as exc_info:
+        ret = roots.update(foo="bar")
+    assert re.match(r"Unexpected keyword arguments received:", str(exc_info.value))


### PR DESCRIPTION
### What does this PR do?

When an orchestration state is applied the user responsible for the runner is passed to the `update` function as the `__pub_user` keyword argument. Therefore, the `update` function must be aware of this or the orchestration state application will fail.

### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/23324
Upstream PR: https://github.com/saltstack/salt/pull/65819

### Previous Behavior
The application of this example orchestration state fails

```
my_orch:
  salt.runner:
    - name: fileserver.update
```
with the following error:
```
 Passed invalid arguments: update() got an unexpected keyword argument '__pub_user'
```
### New Behavior
Now the orchestrating state is applied correctly.

Additionally, it fixes wrong asserts on fileserver.update tests, as it was producing false positives when ret["return"] is a string (i.a. when errors are produced) instead of True value.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
