### PR TITLE
Fix the aptpkg.py unit test failure

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -3128,7 +3128,7 @@ def expand_repo_def(**kwargs):
         NOT USABLE IN THE CLI
     """
     warn_until_date(
-        "20240101",
+        "20250101",
         "The pkg.expand_repo_def function is deprecated and set for removal "
         "after {date}. This is only unsed internally by the apt pkg state "
         "module. If that's not the case, please file an new issue requesting "


### PR DESCRIPTION
### What does this PR do?

This PR fixes a test that started failing on new year. In 2025, we should rebase our Salt version, which should provide a proper fix to the test. Hence, prolonging the date seems like an acceptable fix for our downstream. 
