### PR TITLE
Remove unused import causing delays on starting salt-master

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -9,7 +9,6 @@ import logging
 import os
 import re
 
-import salt.auth.ldap
 import salt.cache
 import salt.payload
 import salt.roster


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/saltstack/salt/pull/65982
Removes unused import of `salt.auth.ldap` in `salt.utils.minions` causing delay on starting the `salt-minion` service.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/23526

### Previous Behavior
Some delays on starting `salt-master`.

### New Behavior
`salt-master` is starting bit faster.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
