### PR TITLE
fix modules/suse_apache missing apache2ctl

### DIFF
--- a/salt/modules/suse_apache.py
+++ b/salt/modules/suse_apache.py
@@ -19,7 +19,7 @@ def __virtual__():
     """
     Only load the module if apache is installed.
     """
-    if salt.utils.path.which("apache2ctl") and __grains__["os_family"] == "Suse":
+    if salt.utils.path.which("a2enmod") and salt.utils.path.which("a2dismod") and __grains__["os_family"] == "Suse":
         return __virtualname__
     return (False, "apache execution module not loaded: apache not installed.")
 


### PR DESCRIPTION
The suse_apache module is checking if `apache2ctl` is present at the minion. This check fails on current openSUSE Factory because apache2ctl was renamed to apachectl.

`apache2ctl` isn't execute in the suse_apache module at all.

### What does this PR do?

With this patch the suse_apache module checks for the two really used excecutables (`a2enmod`/`a2dismod`)

### What issues does this PR fix or reference?
Fixes: NONE

### Previous Behavior

enabling/disabling modules failed

### Commits signed with GPG?
Yes

