### PR TITLE
Make logging calls lighter

### DIFF
--- a/salt/_logging/impl.py
+++ b/salt/_logging/impl.py
@@ -426,6 +426,7 @@ def set_logging_options_dict(opts):
     except AttributeError:
         pass
     set_logging_options_dict.__options_dict__ = opts
+    set_lowest_log_level_by_opts(opts)
 
 
 def freeze_logging_options_dict():

--- a/tests/pytests/integration/_logging/test_logging.py
+++ b/tests/pytests/integration/_logging/test_logging.py
@@ -1,0 +1,106 @@
+import logging
+import os
+
+import pytest
+
+import salt._logging.impl as log_impl
+from tests.support.mock import MagicMock, patch
+
+pytestmark = [
+    pytest.mark.skip_on_windows(reason="Temporarily skipped on the newer golden images")
+]
+
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {log_impl: {}}
+
+
+def log_nameToLevel(name):
+    """
+    Return the numeric representation of textual logging level
+    """
+    # log level values
+    CRITICAL = 50
+    FATAL = CRITICAL
+    ERROR = 40
+    WARNING = 30
+    WARN = WARNING
+    INFO = 20
+    DEBUG = 10
+    NOTSET = 0
+
+    _nameToLevel = {
+        "CRITICAL": CRITICAL,
+        "FATAL": FATAL,
+        "ERROR": ERROR,
+        "WARN": WARNING,
+        "WARNING": WARNING,
+        "INFO": INFO,
+        "DEBUG": DEBUG,
+        "NOTSET": NOTSET,
+    }
+    return _nameToLevel.get(name, None)
+
+
+def test_lowest_log_level():
+    ret = log_impl.get_lowest_log_level()
+    assert ret is not None
+
+    log_impl.set_lowest_log_level(log_nameToLevel("DEBUG"))
+    ret = log_impl.get_lowest_log_level()
+    assert ret is log_nameToLevel("DEBUG")
+
+    log_impl.set_lowest_log_level(log_nameToLevel("WARNING"))
+    ret = log_impl.get_lowest_log_level()
+    assert ret is log_nameToLevel("WARNING")
+
+    opts = {"log_level": "ERROR", "log_level_logfile": "INFO"}
+    log_impl.set_lowest_log_level_by_opts(opts)
+    ret = log_impl.get_lowest_log_level()
+    assert ret is log_nameToLevel("INFO")
+
+
+def test_get_logging_level_from_string(caplog):
+    ret = log_impl.get_logging_level_from_string(None)
+    assert ret is log_nameToLevel("WARNING")
+
+    ret = log_impl.get_logging_level_from_string(log_nameToLevel("DEBUG"))
+    assert ret is log_nameToLevel("DEBUG")
+
+    ret = log_impl.get_logging_level_from_string("CRITICAL")
+    assert ret is log_nameToLevel("CRITICAL")
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        msg = "Could not translate the logging level string 'BADLEVEL' into an actual logging level integer. Returning 'logging.ERROR'."
+        ret = log_impl.get_logging_level_from_string("BADLEVEL")
+        assert ret is log_nameToLevel("ERROR")
+        assert msg in caplog.text
+
+
+def test_logfile_handler(caplog):
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        ret = log_impl.is_logfile_handler_configured()
+        assert ret is False
+
+        msg = "log_path setting is set to `None`. Nothing else to do"
+        log_path = None
+        assert log_impl.setup_logfile_handler(log_path) is None
+        assert msg in caplog.text
+
+
+def test_in_mainprocess():
+    ret = log_impl.in_mainprocess()
+    assert ret is True
+
+    curr_pid = os.getpid()
+    with patch(
+        "os.getpid", MagicMock(side_effect=[AttributeError, curr_pid, curr_pid])
+    ):
+        ret = log_impl.in_mainprocess()
+        assert ret is True

--- a/tests/pytests/unit/_logging/handlers/test_deferred_stream_handler.py
+++ b/tests/pytests/unit/_logging/handlers/test_deferred_stream_handler.py
@@ -9,6 +9,7 @@ import pytest
 from pytestshellutils.utils.processes import terminate_process
 
 from salt._logging.handlers import DeferredStreamHandler
+from salt._logging.impl import set_lowest_log_level
 from salt.utils.nb_popen import NonBlockingPopen
 from tests.support.helpers import CaptureOutput, dedent
 from tests.support.runtests import RUNTIME_VARS
@@ -20,7 +21,7 @@ def _sync_with_handlers_proc_target():
 
     with CaptureOutput() as stds:
         handler = DeferredStreamHandler(sys.stderr)
-        handler.setLevel(logging.DEBUG)
+        set_lowest_log_level(logging.DEBUG)
         formatter = logging.Formatter("%(message)s")
         handler.setFormatter(formatter)
         logging.root.addHandler(handler)
@@ -45,7 +46,7 @@ def _deferred_write_on_flush_proc_target():
 
     with CaptureOutput() as stds:
         handler = DeferredStreamHandler(sys.stderr)
-        handler.setLevel(logging.DEBUG)
+        set_lowest_log_level(logging.DEBUG)
         formatter = logging.Formatter("%(message)s")
         handler.setFormatter(formatter)
         logging.root.addHandler(handler)
@@ -126,7 +127,7 @@ def test_deferred_write_on_atexit(tmp_path):
         # Just loop consuming output
         while True:
             if time.time() > max_time:
-                pytest.fail("Script didn't exit after {} second".format(execution_time))
+                pytest.fail(f"Script didn't exit after {execution_time} second")
 
             time.sleep(0.125)
             _out = proc.recv()
@@ -146,7 +147,7 @@ def test_deferred_write_on_atexit(tmp_path):
     finally:
         terminate_process(proc.pid, kill_children=True)
     if b"Foo" not in err:
-        pytest.fail("'Foo' should be in stderr and it's not: {}".format(err))
+        pytest.fail(f"'Foo' should be in stderr and it's not: {err}")
 
 
 @pytest.mark.skip_on_windows(reason="Windows does not support SIGINT")

--- a/tests/pytests/unit/utils/test_vt.py
+++ b/tests/pytests/unit/utils/test_vt.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import signal
 
@@ -43,10 +44,13 @@ def test_log_sanitize(test_cmd, caplog):
         cmd,
         log_stdout=True,
         log_stderr=True,
+        log_stdout_level="debug",
+        log_stderr_level="debug",
         log_sanitize=password,
         stream_stdout=False,
         stream_stderr=False,
     )
-    ret = term.recv()
+    with caplog.at_level(logging.DEBUG):
+        ret = term.recv()
     assert password not in caplog.text
     assert "******" in caplog.text


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/saltstack/salt/pull/66024

For some reason the lowest logging level is not set while setting the logging opts from the config with dict. And on each single call like `log.trace`, `log.debug` etc. a lot of calls performed internally anyway even if the current logging level for logfile and console is not supposed to write messages with such logging level. With this change each single call to write logging message in case if the message shouldn't be show become way more lighter.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/23526

### Previous Behavior
Some delays on intensive output like `salt-run state.event` with huge amount of messages in the event bus due to the checks on calling `log.trace` and some possible delays in other parts. The case with `salt-run state.event` could cause the growth of the amount of messages to be sent to the `subscriber` inside `EventPublisher`.

### New Behavior
Way less chances to cause delays on potential intensive logging.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
