### PR TITLE
Make compound_match thread safe (bsc#1211649)

### DIFF
--- a/salt/matchers/compound_match.py
+++ b/salt/matchers/compound_match.py
@@ -3,17 +3,14 @@ This is the default compound matcher function.
 """
 
 import logging
+import importlib.util
 
 import salt.loader
 import salt.utils.minions
 
 HAS_RANGE = False
-try:
-    import seco.range  # pylint: disable=unused-import
-
+if importlib.util.find_spec("seco"):
     HAS_RANGE = True
-except ImportError:
-    pass
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
### What does this PR do?

Instead of trying to import the `seco.range` module, this change checks if the `seco` package is importable without importing it. This helps to make the file thread safe, where multiple threads can try to execute this file at the same time, which can cause deadlock in a thread.

### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/21578

BZ: https://bugzilla.suse.com/show_bug.cgi?id=1211649


### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
