### PR TITLE
Discover playbooks as either *.yml or *.yaml files (bsc#1211888)

### DIFF
--- a/changelog/66048.changed.md
+++ b/changelog/66048.changed.md
@@ -1,0 +1,1 @@
+Ansiblegate discover_playbooks was changed to find playbooks as either *.yml or *.yaml files

--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -502,7 +502,7 @@ def discover_playbooks(
         List of paths to discover playbooks from.
 
     :param playbook_extension:
-        File extension of playbooks file to search for. Default: "yml"
+        File extension(s) of playbook files to search for, can be a string or tuple of strings. Default: (".yml", ".yaml")
 
     :param hosts_filename:
         Filename of custom playbook inventory to search for. Default: "hosts"
@@ -533,7 +533,7 @@ def discover_playbooks(
         )
 
     if not playbook_extension:
-        playbook_extension = "yml"
+        playbook_extension = (".yml", ".yaml")
     if not hosts_filename:
         hosts_filename = "hosts"
 
@@ -573,7 +573,7 @@ def _explore_path(path, playbook_extension, hosts_filename, syntax_check):
         # Check files in the given path
         for _f in os.listdir(path):
             _path = os.path.join(path, _f)
-            if os.path.isfile(_path) and _path.endswith("." + playbook_extension):
+            if os.path.isfile(_path) and _path.endswith(playbook_extension):
                 ret[_f] = {"fullpath": _path}
                 # Check for custom inventory file
                 if os.path.isfile(os.path.join(path, hosts_filename)):
@@ -584,9 +584,7 @@ def _explore_path(path, playbook_extension, hosts_filename, syntax_check):
                 # Check files in the 1st level of subdirectories
                 for _f2 in os.listdir(_path):
                     _path2 = os.path.join(_path, _f2)
-                    if os.path.isfile(_path2) and _path2.endswith(
-                        "." + playbook_extension
-                    ):
+                    if os.path.isfile(_path2) and _path2.endswith(playbook_extension):
                         ret[os.path.join(_f, _f2)] = {"fullpath": _path2}
                         # Check for custom inventory file
                         if os.path.isfile(os.path.join(_path, hosts_filename)):

--- a/tests/pytests/unit/modules/test_ansiblegate.py
+++ b/tests/pytests/unit/modules/test_ansiblegate.py
@@ -119,10 +119,9 @@ def test_ansible_module_call():
             env=ANY,
             check=True,
             shell=False,
-            stderr=-1,
-            stdout=-1,
+            capture_output=True,
             timeout=1200,
-            universal_newlines=True,
+            text=True,
         )
         assert ret == {"completed": True}
 

--- a/tests/pytests/unit/modules/test_ansiblegate.py
+++ b/tests/pytests/unit/modules/test_ansiblegate.py
@@ -198,6 +198,9 @@ def test_ansible_discover_playbooks_single_path():
     assert ret[playbooks_dir]["playbook1.yml"] == {
         "fullpath": os.path.join(playbooks_dir, "playbook1.yml")
     }
+    assert ret[playbooks_dir]["playbook1.yaml"] == {
+        "fullpath": os.path.join(playbooks_dir, "playbook1.yaml")
+    }
     assert ret[playbooks_dir]["example-playbook2/site.yml"] == {
         "fullpath": os.path.join(playbooks_dir, "example-playbook2/site.yml"),
         "custom_inventory": os.path.join(playbooks_dir, "example-playbook2/hosts"),

--- a/tests/unit/files/playbooks/example_playbooks/playbook1.yaml
+++ b/tests/unit/files/playbooks/example_playbooks/playbook1.yaml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  gather_facts: false
+  tasks:
+    - ping:


### PR DESCRIPTION
### What does this PR do?

This patch is modifying the ansiblegate module to detect playbooks by default as either *.yml or *.yaml files. The playbook_extension parameter is changed to receive either a string or a tuple of strings in case you wanted to discover files with different extensions (endswith() can work with both). Even though *.yml seems to be the more popular extension for Yaml files, both extensions seem to be officially valid. Even the [official Ansible documentation](https://docs.ansible.com/ansible/latest/getting_started/get_started_playbook.html#creating-a-playbook) recommends creating a playbook as *.yaml and without this patch it would not be supported out of the box using the ansiblegate module.

### What issues does this PR fix or reference?

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1211888

### Previous Behavior

Per default discover_playbooks would detect playbooks only with the *.yml extension. The playbook_extension parameter can receive a different extension as a string, so if you wanted to discover *.yml and *.yaml files you would need to call discover_playbooks twice.

### New Behavior

You can pass a tuple of strings to the playbook_extension parameter, the default value is (".yml", ".yaml").

### Merge requirements satisfied?

- [X] Docs
- [X] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [X] Tests written/updated

### Commits signed with GPG?
Yes