### PR TITLE
Make compound_match thread safe (bsc#1211649)

### DIFF
--- a/salt/roster/range.py
+++ b/salt/roster/range.py
@@ -15,16 +15,21 @@ import copy
 import fnmatch
 import logging
 
+import salt.loader
+
 log = logging.getLogger(__name__)
 
 # Try to import range from https://github.com/ytoolshed/range
 HAS_RANGE = False
 try:
+    salt.loader.LOAD_LOCK.acquire()
     import seco.range
 
     HAS_RANGE = True
 except ImportError:
     log.error("Unable to load range library")
+finally:
+    salt.loader.LOAD_LOCK.release()
 # pylint: enable=import-error
 
 

--- a/salt/utils/roster_matcher.py
+++ b/salt/utils/roster_matcher.py
@@ -8,14 +8,19 @@ import functools
 import logging
 import re
 
+import salt.loader
+
 # Try to import range from https://github.com/ytoolshed/range
 HAS_RANGE = False
 try:
+    salt.loader.LOAD_LOCK.acquire()
     import seco.range
 
     HAS_RANGE = True
 except ImportError:
     pass
+finally:
+    salt.loader.LOAD_LOCK.release()
 # pylint: enable=import-error
 
 


### PR DESCRIPTION
### What does this PR do?

It seems like this is a bug in CPython (https://github.com/python/cpython/issues/83065) where import statement stopped being thread safe after Python 3.2, and this has not been yet fixed (the reproducer still works on Python 3.11).

When Salt loads the `range.py` and `roster_matcher.py` files from the context of salt.loader, those files try to import the `seco.range` module. In the context of salt-ssh calls, there's a third file, `salt/matchers/compound_match.py`, which attempts to import the same module.

While the `compound_match.py` file already contains a higher-level lock from the salt.loader context, the `range.py` and `roster_matcher.py` files seem not to, which can cause (under the condition of a lot of ssh-based minions) a thread lock similar to this:

```
Thread 0x7F1373400700 (active): "CP Server Thread-57"
    acquire (<frozen importlib._bootstrap>:98)
    __enter__ (<frozen importlib._bootstrap>:149)
    _find_and_load (<frozen importlib._bootstrap>:968)
    <module> (salt/matchers/compound_match.py:12)
    _call_with_frames_removed (<frozen importlib._bootstrap>:219)
    exec_module (<frozen importlib._bootstrap_external>:678)
    _load_unlocked (<frozen importlib._bootstrap>:665)
    _load (<frozen importlib._bootstrap>:684)
    _load_module_shim (<frozen importlib._bootstrap>:265)
    load_module (<frozen importlib._bootstrap_external>:682)
    load_module (<frozen importlib._bootstrap_external>:823)
    _check_name_wrapper (<frozen importlib._bootstrap_external>:399)
    _run_as (salt/loader/lazy.py:1249)
    run (contextvars/__init__.py:38)
    run (salt/loader/lazy.py:1234)
    _load_module (salt/loader/lazy.py:772)
    _inner_load (salt/loader/lazy.py:1055)
    _load (salt/loader/lazy.py:1066)
    __getitem__ (salt/utils/lazy.py:98)
    __getitem__ (salt/loader/lazy.py:336)
    confirm_top (salt/matchers/confirm_top.py:29)
    _run_as (salt/loader/lazy.py:1249)
    run (contextvars/__init__.py:38)
    run (salt/loader/lazy.py:1234)
    __call__ (salt/loader/lazy.py:149)
    top_matches (salt/pillar/__init__.py:869)
    compile_pillar (salt/pillar/__init__.py:1243)
    run_wfunc (salt/client/ssh/__init__.py:1355)
    run (salt/client/ssh/__init__.py:1260)
    handle_routine (salt/client/ssh/__init__.py:607)
    run (multiprocessing/process.py:93)
    wrapped_run_func (salt/utils/process.py:993)
    _bootstrap (multiprocessing/process.py:258)
    _launch (multiprocessing/popen_fork.py:73)
    __init__ (multiprocessing/popen_fork.py:19)
    _Popen (multiprocessing/context.py:277)
    _Popen (multiprocessing/context.py:223)
    start (multiprocessing/process.py:105)
    handle_ssh (salt/client/ssh/__init__.py:730)
    run_iter (salt/client/ssh/__init__.py:847)
    cmd (salt/client/ssh/client.py:159)
    cmd_sync (salt/client/ssh/client.py:197)
    ssh (salt/netapi/__init__.py:249)
    run (salt/netapi/__init__.py:183)
    exec_lowstate (salt/netapi/rest_cherrypy/app.py:1225)
    POST (salt/netapi/rest_cherrypy/app.py:2162)
    __call__ (cherrypy/_cpdispatch.py:54)
    hypermedia_handler (salt/netapi/rest_cherrypy/app.py:860)
    __call__ (cherrypy/lib/encoding.py:219)
    _do_respond (cherrypy/_cprequest.py:697)
    respond (cherrypy/_cprequest.py:638)
    run (cherrypy/_cprequest.py:604)
    run (cherrypy/_cpwsgi.py:335)
    __init__ (cherrypy/_cpwsgi.py:236)
    tail (cherrypy/_cpwsgi.py:423)
    __call__ (cherrypy/_cpwsgi.py:104)
    trap (cherrypy/_cpwsgi.py:184)
    __init__ (cherrypy/_cpwsgi.py:167)
    __call__ (cherrypy/_cpwsgi.py:152)
    __call__ (cherrypy/_cpwsgi.py:435)
    __call__ (cherrypy/_cptree.py:168)
    __call__ (cherrypy/_cptree.py:302)
    respond (cheroot/wsgi.py:143)
    respond (cheroot/server.py:1078)
    communicate (cheroot/server.py:1279)
    run (cheroot/workers/threadpool.py:114)
    _bootstrap_inner (threading.py:916)
    _bootstrap (threading.py:884)
```

In this approach, we explicitly add a lock to the `range.py` and `roster_matcher.py` files, which works around the fact that `import` is thread unstafe in CPython.

This is an alternative approach to https://github.com/openSUSE/salt/pull/626
### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/21578

BZ: https://bugzilla.suse.com/show_bug.cgi?id=1211649


### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
