### PR TITLE
Suppress deprecation warning with Python 3.11

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -55,6 +55,13 @@ warnings.filterwarnings(
     # never show up
 )
 
+warnings.filterwarnings(
+    "ignore",
+    r"(Use setlocale\(\)|'(cgi|pipes)' is deprecated)",
+    DeprecationWarning,
+    r"^(salt|salt\.(.*))$",
+)
+
 # Filter the backports package UserWarning about being re-imported
 warnings.filterwarnings(
     "ignore",


### PR DESCRIPTION
### What does this PR do?

This change makes sense in the context of the salt bundle with python 3.11
No need to upstream it.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/23185

### Previous Behavior
Noisy deprecation warnings on running salt related commands with Python 3.11

### New Behavior
No deprecation warnings

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
