### PR TITLE
Make MWorkers reconnecting to EventPublisher if it was killed

### DIFF
--- a/tests/pytests/unit/utils/event/test_event.py
+++ b/tests/pytests/unit/utils/event/test_event.py
@@ -447,3 +447,46 @@ def test_event_fire_ret_load():
         )
         assert mock_log_error.mock_calls[0].args[1] == "minion_id.example.org"
         assert mock_log_error.mock_calls[0].args[2] == "".join(test_traceback)
+
+
+@pytest.mark.slow_test
+def test_event_single_timeout_tries(sock_dir):
+    """Test an event is sent with timout and tries"""
+
+    write_calls_count = 0
+    real_stream_write = None
+
+    @salt.ext.tornado.gen.coroutine
+    def write_mock(pack):
+        nonlocal write_calls_count
+        nonlocal real_stream_write
+        write_calls_count += 1
+        if write_calls_count > 3:
+            yield real_stream_write(pack)
+        else:
+            raise salt.ext.tornado.iostream.StreamClosedError()
+
+    with eventpublisher_process(str(sock_dir)), salt.utils.event.MasterEvent(
+        str(sock_dir), listen=True
+    ) as me:
+        me.fire_event({"data": "foo1"}, "evt1")
+        evt1 = me.get_event(tag="evt1")
+        _assert_got_event(evt1, {"data": "foo1"})
+        real_stream_write = me.pusher.stream.write
+        with patch.object(
+            me.pusher,
+            "connected",
+            side_effect=[True, True, False, False, True, True],
+        ), patch.object(
+            me.pusher,
+            "connect",
+            side_effect=salt.ext.tornado.iostream.StreamClosedError,
+        ), patch.object(
+            me.pusher.stream,
+            "write",
+            write_mock,
+        ):
+            me.fire_event({"data": "bar2"}, "evt2", timeout=5000)
+            evt2 = me.get_event(tag="evt2")
+            _assert_got_event(evt2, {"data": "bar2"})
+            assert write_calls_count == 4


### PR DESCRIPTION
### What does this PR do?

It makes MWorkers to be able to recoonect with `salt.transport.ipc.IPCMessageClient` to the `EventPublisher` after killing it with OOM or any other reason, so it makes `salt-master` to be able to self recover after killing the `EventPublisher`.

Implementation of `timeout` and `tries` is a kind of bonus there, the main fix is in the way of handling `StreamClosedError` exceptions.

#### The reason why there is norelated upstream change:
`salt.transport.ipc` is specified as deprecated for `3009` and in the `master` either `tcp` or `zmq` can be used, but they have different implementation of this part which can be not affected, but it's better to check it deeper on switching the version.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/23526

### Previous Behavior
On killing `EventPublisher` subprocess the `salt-master` is still running but is not able to handle the incoming events the proper way as the stream to the `EventPublisher` in `MWorker` was closed and not restored, so the `salt-master` is running but not functional.

### New Behavior
The `salt-master` is able to self recover on killing `EventPublisher` and continue handling the events.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
