### PR TITLE
Prevent possible exception in tornado.concurrent.Future._set_done

### DIFF
--- a/salt/ext/tornado/concurrent.py
+++ b/salt/ext/tornado/concurrent.py
@@ -330,12 +330,13 @@ class Future(object):
 
     def _set_done(self):
         self._done = True
-        for cb in self._callbacks:
-            try:
-                cb(self)
-            except Exception:
-                app_log.exception("Exception in callback %r for %r", cb, self)
-        self._callbacks = None
+        if self._callbacks:
+            for cb in self._callbacks:
+                try:
+                    cb(self)
+                except Exception:
+                    app_log.exception("Exception in callback %r for %r", cb, self)
+            self._callbacks = None
 
     # On Python 3.3 or older, objects with a destructor part of a reference
     # cycle are never destroyed. It's no longer the case on Python 3.4 thanks to


### PR DESCRIPTION
### What does this PR do?

In some cases the exception is possible if `tornado.concurrent.Future._set_done` called not just once.

This PR is a partial backport of https://github.com/tornadoweb/tornado/pull/2253
Only one of the commits from the PR above: https://github.com/tornadoweb/tornado/commit/6e8a137e6824716531d749bce8a18a1f229ed873

No need to push it to the upstream as it get rid of `salt.ext.tornado`.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/23526

### Previous Behavior
Possible tracebacks like the following in very specific cases:
```
Future <salt.ext.tornado.concurrent.Future object at 0x7f9136b21278> exception was never retrieved: Traceback
  File "/usr/lib/python3.6/site-packages/salt/transport/ipc.py", line 342, in _connect
    self._connecting_future.set_result(True)
  File "/usr/lib/python3.6/site-packages/salt/ext/tornado/concurrent.py", line 290, in set_result
    self._set_done()
  File "/usr/lib/python3.6/site-packages/salt/ext/tornado/concurrent.py", line 333, in _set_done
    for cb in self._callbacks:
TypeError: 'NoneType' object is not iterable
```

### New Behavior
No such exception.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
