### PR TITLE
Switch oscap encoding to utf-8

### DIFF
--- a/salt/modules/openscap.py
+++ b/salt/modules/openscap.py
@@ -153,7 +153,7 @@ def xccdf_eval(xccdffile, ovalfiles=None, **kwargs):
         tempdir = tempfile.mkdtemp()
         proc = Popen(cmd_opts, stdout=PIPE, stderr=PIPE, cwd=tempdir)
         (_, error) = proc.communicate()
-        error = error.decode('ascii', errors='ignore')
+        error = error.decode('utf-8', errors='surogateescape')
         success = _OSCAP_EXIT_CODES_MAP.get(proc.returncode, False)
         if proc.returncode < 0:
             error += "\nKilled by signal {}\n".format(proc.returncode)
@@ -204,10 +204,11 @@ def xccdf(params):
         cmd = _XCCDF_MAP[action]["cmd_pattern"].format(args.profile, policy)
         tempdir = tempfile.mkdtemp()
         proc = Popen(shlex.split(cmd), stdout=PIPE, stderr=PIPE, cwd=tempdir)
-        (stdoutdata, error) = proc.communicate()
+        (_, error) = proc.communicate()
+        error = error.decode('utf-8', errors='surogateescape')
         success = _OSCAP_EXIT_CODES_MAP.get(proc.returncode, False)
         if proc.returncode < 0:
-            error += "\nKilled by signal {}\n".format(proc.returncode).encode('ascii')
+            error += "\nKilled by signal {}\n".format(proc.returncode)
         returncode = proc.returncode
         if success:
             __salt__["cp.push_dir"](tempdir)

--- a/tests/unit/modules/test_openscap.py
+++ b/tests/unit/modules/test_openscap.py
@@ -35,7 +35,7 @@ class OpenscapTestCase(TestCase):
             "salt.modules.openscap.Popen",
             MagicMock(
                 return_value=Mock(
-                    **{"returncode": 0, "communicate.return_value": ("", "")}
+                    **{"returncode": 0, "communicate.return_value": (bytes(0), bytes(0))}
                 )
             ),
         ):
@@ -82,7 +82,7 @@ class OpenscapTestCase(TestCase):
             "salt.modules.openscap.Popen",
             MagicMock(
                 return_value=Mock(
-                    **{"returncode": 2, "communicate.return_value": ("", "some error")}
+                    **{"returncode": 2, "communicate.return_value": (bytes(0), bytes("some error", "UTF-8"))}
                 )
             ),
         ):
@@ -137,7 +137,7 @@ class OpenscapTestCase(TestCase):
             "salt.modules.openscap.Popen",
             MagicMock(
                 return_value=Mock(
-                    **{"returncode": 2, "communicate.return_value": ("", "some error")}
+                    **{"returncode": 2, "communicate.return_value": (bytes(0), bytes("some error", "UTF-8"))}
                 )
             ),
         ):
@@ -180,7 +180,7 @@ class OpenscapTestCase(TestCase):
                 return_value=Mock(
                     **{
                         "returncode": 1,
-                        "communicate.return_value": ("", "evaluation error"),
+                        "communicate.return_value": (bytes(0), bytes("evaluation error", "UTF-8")),
                     }
                 )
             ),


### PR DESCRIPTION
### What does this PR do?

In this PR, I am:

- Switching the default oscap encoding to `UTF-8`
- Modifying the `xccdf` method to use the same encoding