### PR TITLE
Fix __salt__ when used via __utils__ (bsc#1220357)

### DIFF
--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -335,6 +335,10 @@ def minion_mods(
         pack_self="__salt__",
     )
 
+    # Allow the usage of salt dunder in utils modules.
+    if utils and isinstance(utils, _LazyLoader):
+        utils.pack["__salt__"] = ret
+
     # Load any provider overrides from the configuration file providers option
     #  Note: Providers can be pkg, service, user or group - not to be confused
     #        with cloud providers.

--- a/salt/loader/context.py
+++ b/salt/loader/context.py
@@ -12,6 +12,8 @@ except ImportError:
     # Py<3.7
     import contextvars
 
+import salt.exceptions
+
 DEFAULT_CTX_VAR = "loader_ctxvar"
 
 loader_ctxvar = contextvars.ContextVar(DEFAULT_CTX_VAR)
@@ -69,7 +71,12 @@ class NamedLoaderContext(collections.abc.MutableMapping):
             return loader.pack[self.name]
         if self.name == loader.pack_self:
             return loader
-        return loader.pack[self.name]
+        try:
+            return loader.pack[self.name]
+        except KeyError:
+            raise salt.exceptions.LoaderError(
+                f"LazyLoader does not have a packed value for: {self.name}"
+            )
 
     def get(self, key, default=None):
         return self.value().get(key, default)

--- a/salt/utils/azurearm.py
+++ b/salt/utils/azurearm.py
@@ -47,8 +47,6 @@ try:
 except ImportError:
     HAS_AZURE = False
 
-__opts__ = salt.config.minion_config("/etc/salt/minion")
-__salt__ = salt.loader.minion_mods(__opts__)
 
 log = logging.getLogger(__name__)
 

--- a/salt/utils/vault.py
+++ b/salt/utils/vault.py
@@ -36,8 +36,9 @@ def __virtual__():
             logging.getLogger("requests").setLevel(logging.WARNING)
             return True
     except Exception as e:  # pylint: disable=broad-except
-        log.error("Could not load __salt__: %s", e)
+        log.error("Could not load __salt__: %s", e, exc_info=True)
         return False
+    return True
 
 
 def _get_token_and_url_from_master():

--- a/tests/pytests/integration/cli/test_matcher.py
+++ b/tests/pytests/integration/cli/test_matcher.py
@@ -506,7 +506,9 @@ def test_salt_documentation(salt_cli, salt_minion):
     """
     Test to see if we're supporting --doc
     """
-    ret = salt_cli.run("-d", "test", minion_tgt=salt_minion.id)
+    # Setting an explicity long timeout otherwise this test may fail when the
+    # system is under load.
+    ret = salt_cli.run("-d", "test", minion_tgt=salt_minion.id, _timeout=90)
     assert ret.returncode == 0
     assert "test.ping" in ret.data
 

--- a/tests/pytests/integration/minion/test_return_retries.py
+++ b/tests/pytests/integration/minion/test_return_retries.py
@@ -28,7 +28,7 @@ def salt_minion_retry(salt_master_factory, salt_minion_id):
 @pytest.mark.slow_test
 def test_publish_retry(salt_master, salt_minion_retry, salt_cli, salt_run_cli):
     # run job that takes some time for warmup
-    rtn = salt_cli.run("test.sleep", "5", "--async", minion_tgt=salt_minion_retry.id)
+    rtn = salt_cli.run("test.sleep", "3.5", "--async", minion_tgt=salt_minion_retry.id)
     # obtain JID
     jid = rtn.stdout.strip().split(" ")[-1]
 

--- a/tests/pytests/scenarios/multimaster/beacons/test_inotify.py
+++ b/tests/pytests/scenarios/multimaster/beacons/test_inotify.py
@@ -46,6 +46,7 @@ def setup_beacons(mm_master_1_salt_cli, salt_mm_minion_1, inotify_test_path):
             "inotify",
             beacon_data=[{"files": {str(inotify_test_path): {"mask": ["create"]}}}],
             minion_tgt=salt_mm_minion_1.id,
+            timeout=60,
         )
         assert ret.returncode == 0
         log.debug("Inotify beacon add returned: %s", ret.data or ret.stdout)

--- a/tests/pytests/unit/loader/test_loader.py
+++ b/tests/pytests/unit/loader/test_loader.py
@@ -13,7 +13,6 @@ import pytest
 import salt.exceptions
 import salt.loader
 import salt.loader.lazy
-import tests.support.helpers
 
 
 @pytest.fixture
@@ -70,19 +69,16 @@ def test_named_loader_context_name_not_packed(tmp_path):
     opts = {
         "optimization_order": [0],
     }
-    (tmp_path / "mymod.py").write_text(
-        tests.support.helpers.dedent(
-            """
+    contents = """
     from salt.loader.dunder import loader_context
     __not_packed__ = loader_context.named_context("__not_packed__")
     def foobar():
         return __not_packed__["not.packed"]()
     """
-        )
-    )
-    loader = salt.loader.LazyLoader([tmp_path], opts)
-    with pytest.raises(
-        salt.exceptions.LoaderError,
-        match="LazyLoader does not have a packed value for: __not_packed__",
-    ):
-        loader["mymod.foobar"]()
+    with pytest.helpers.temp_file("mymod.py", contents, directory=tmp_path):
+        loader = salt.loader.LazyLoader([tmp_path], opts)
+        with pytest.raises(
+            salt.exceptions.LoaderError,
+            match="LazyLoader does not have a packed value for: __not_packed__",
+        ):
+            loader["mymod.foobar"]()

--- a/tests/pytests/unit/loader/test_loader.py
+++ b/tests/pytests/unit/loader/test_loader.py
@@ -70,7 +70,8 @@ def test_named_loader_context_name_not_packed(tmp_path):
         "optimization_order": [0],
     }
     contents = """
-    from salt.loader.dunder import loader_context
+    from salt.loader.context import LoaderContext
+    loader_context = LoaderContext()
     __not_packed__ = loader_context.named_context("__not_packed__")
     def foobar():
         return __not_packed__["not.packed"]()

--- a/tests/pytests/unit/loader/test_loading_modules.py
+++ b/tests/pytests/unit/loader/test_loading_modules.py
@@ -1,0 +1,35 @@
+import pytest
+
+import salt.loader
+import salt.loader.lazy
+
+import salt.modules.boto_vpc
+import salt.modules.virt
+
+
+@pytest.fixture
+def minion_mods(minion_opts):
+    utils = salt.loader.utils(minion_opts)
+    return salt.loader.minion_mods(minion_opts, utils=utils)
+
+
+@pytest.mark.skipIf(not salt.modules.boto_vpc.HAS_BOTO, "boto must be installed.")
+def test_load_boto_vpc(minion_mods):
+    func = None
+    try:
+        func = minion_mods["boto_vpc.check_vpc"]
+    except KeyError:
+        pytest.fail("loader should not raise KeyError")
+    assert func is not None
+    assert isinstance(func, salt.loader.lazy.LoadedFunc)
+
+
+@pytest.mark.skipIf(not salt.modules.virt.HAS_LIBVIRT, "libvirt-python must be installed.")
+def test_load_virt(minion_mods):
+    func = None
+    try:
+        func = minion_mods["virt.ctrl_alt_del"]
+    except KeyError:
+        pytest.fail("loader should not raise KeyError")
+    assert func is not None
+    assert isinstance(func, salt.loader.lazy.LoadedFunc)

--- a/tests/pytests/unit/loader/test_loading_modules.py
+++ b/tests/pytests/unit/loader/test_loading_modules.py
@@ -2,7 +2,6 @@ import pytest
 
 import salt.loader
 import salt.loader.lazy
-
 import salt.modules.boto_vpc
 import salt.modules.virt
 
@@ -13,7 +12,9 @@ def minion_mods(minion_opts):
     return salt.loader.minion_mods(minion_opts, utils=utils)
 
 
-@pytest.mark.skipIf(not salt.modules.boto_vpc.HAS_BOTO, "boto must be installed.")
+@pytest.mark.skipif(
+    not salt.modules.boto_vpc.HAS_BOTO, reason="boto must be installed."
+)
 def test_load_boto_vpc(minion_mods):
     func = None
     try:
@@ -24,7 +25,9 @@ def test_load_boto_vpc(minion_mods):
     assert isinstance(func, salt.loader.lazy.LoadedFunc)
 
 
-@pytest.mark.skipIf(not salt.modules.virt.HAS_LIBVIRT, "libvirt-python must be installed.")
+@pytest.mark.skipif(
+    not salt.modules.virt.HAS_LIBVIRT, reason="libvirt-python must be installed."
+)
 def test_load_virt(minion_mods):
     func = None
     try:


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/saltstack/salt/pull/65696

In some cases `salt-call` on the salt-ssh client side is rereading `/etc/salt/minion` explicitly what doesn't make any sense.
The upstreram PR contains the fix of it in https://github.com/openSUSE/salt/commit/ef140fc308533d9c49179c7981e6e6041efa0491

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/23799

### Previous Behavior
In some cases `salt-call` on the salt-ssh client side is rereading `/etc/salt/minion`.

### New Behavior
Prevent `salt-call` of rereading `/etc/salt/minion` with no reason.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
