### PR TITLE
Pass metadata, module_executors and executor_opts to ssh

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1084,6 +1084,7 @@ class Single:
             self.argv = argv
 
         self.fun, self.args, self.kwargs = self.__arg_comps()
+        self.call_args = self.__get_call_args()
         self.id = id_
         self.set_path = kwargs.get("set_path", "")
 
@@ -1147,6 +1148,21 @@ class Single:
         args = parsed[0]
         kws = parsed[1]
         return fun, args, kws
+
+    def __get_call_args(self):
+        """
+        Put extra arguments to the salt-call for the remote client.
+        """
+        call_args = []
+        args_list = (
+            ("module_executors", "--module-executors"),
+            ("executor_opts", "--executor-opts"),
+            ("metadata", "--set-metadata"),
+        )
+        for src, dst in args_list:
+            if src in self.opts:
+                call_args.append(f"{dst}={self.opts[src]}")
+        return call_args if call_args else None
 
     def _escape_arg(self, arg):
         """
@@ -1509,6 +1525,7 @@ OPTIONS.wipe = {wipe}
 OPTIONS.tty = {tty}
 OPTIONS.cmd_umask = {cmd_umask}
 OPTIONS.code_checksum = {code_checksum}
+CALL_ARGS = {call_args}
 ARGS = {arguments}\n'''.format(
             config=self.minion_config,
             delimeter=RSTR,
@@ -1521,6 +1538,7 @@ ARGS = {arguments}\n'''.format(
             tty=self.tty,
             cmd_umask=self.cmd_umask,
             code_checksum=thin_code_digest,
+            call_args=self.call_args,
             arguments=self.argv,
         )
         py_code = SSH_PY_SHIM.replace("#%%OPTS", arg_str)

--- a/salt/client/ssh/client.py
+++ b/salt/client/ssh/client.py
@@ -82,6 +82,9 @@ class SSHClient:
             ("ssh_run_pre_flight", bool),
             ("no_host_keys", bool),
             ("saltfile", str),
+            ("module_executors", list),
+            ("executor_opts", dict),
+            ("metadata", dict),
         ]
         sane_kwargs = {}
         for name, kind in roster_vals:
@@ -92,7 +95,7 @@ class SSHClient:
             except ValueError:
                 log.warning("Unable to cast kwarg %s", name)
                 continue
-            if kind is bool or kind is int:
+            if kind in (bool, int, dict):
                 sane_kwargs[name] = val
             elif kind is str:
                 if val.find("ProxyCommand") != -1:

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -3201,6 +3201,7 @@ class SaltRunOptionParser(
 class SaltSSHOptionParser(
     OptionParser,
     ConfigDirMixIn,
+    ExecutorsMixIn,
     MergeConfigMixIn,
     LogLevelMixIn,
     TargetOptionsMixIn,
@@ -3368,6 +3369,12 @@ class SaltSSHOptionParser(
             action="store_true",
             dest="ssh_run_pre_flight",
             help="Run the defined ssh_pre_flight script in the roster",
+        )
+        self.add_option(
+            "--metadata",
+            default="",
+            metavar="METADATA",
+            help="Pass metadata into Salt, used to search jobs.",
         )
 
         ssh_group = optparse.OptionGroup(


### PR DESCRIPTION
### What does this PR do?

Pass `metadata`, `module_executors` and `executor_opts` to `salt-ssh` clients calls.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/23799

### Previous Behavior
Salt SSH clients are ignoring `metadata`, `module_executors` and `executor_opts`.

### New Behavior
Respect `metadata`, `module_executors` and `executor_opts` passed to Salt SSH clients.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
