### PR TITLE
Allow explicit reboot on transactional minions

### DIFF
--- a/salt/modules/transactional_update.py
+++ b/salt/modules/transactional_update.py
@@ -283,6 +283,7 @@ import sys
 import salt.client.ssh.state
 import salt.client.ssh.wrapper.state
 import salt.exceptions
+import salt.executors.transactional_update
 import salt.utils.args
 from salt.modules.state import _check_queue, _prior_running_states, _wait, running
 
@@ -996,14 +997,15 @@ def call(function, *args, **kwargs):
 
 
 def _user_specified_reboot(local, function):
-    if function != "state.highstate" and function != "state.sls":
+    explicit_reboot_cmds = set(["reboot", "system.reboot"])
+    explicit_reboot_modules = ["cmd", "module"]
+
+    if function not in salt.executors.transactional_update.DELEGATION_MAP.keys():
         return False
 
     if not isinstance(local, dict):
         return False
 
-    explicit_reboot_cmds = set(["reboot", "system.reboot"])
-    explicit_reboot_modules = ["cmd", "module"]
     names = set()
     for execution_id, execution_result in local.items():
         if not isinstance(execution_id, str):

--- a/salt/modules/transactional_update.py
+++ b/salt/modules/transactional_update.py
@@ -1003,18 +1003,18 @@ def _user_specified_reboot(local, function):
         return False
 
     explicit_reboot_cmds = set(["reboot", "system.reboot"])
-    explicit_reboot_modules = ["cmd_", "module_"]
+    explicit_reboot_modules = ["cmd", "module"]
     names = set()
-    for full_module_name, module_result in local.items():
-        if not isinstance(full_module_name, str):
+    for execution_id, execution_result in local.items():
+        if not isinstance(execution_id, str):
             continue
 
-        module = full_module_name.split("|")[0]
+        module = execution_id.split("_|-")[0]
         if module not in explicit_reboot_modules:
             continue
 
-        if isinstance(module_result, dict) and "name" in module_result:
-            names.add(module_result["name"])
+        if isinstance(execution_result, dict) and "name" in execution_result:
+            names.add(execution_result["name"])
 
     return bool(explicit_reboot_cmds.intersection(names))
 

--- a/salt/modules/transactional_update.py
+++ b/salt/modules/transactional_update.py
@@ -1003,8 +1003,16 @@ def _user_specified_reboot(local, function):
         return False
 
     explicit_reboot_cmds = set(["reboot", "system.reboot"])
+    explicit_reboot_modules = ["cmd_", "module_"]
     names = set()
-    for _, value in local.items():
+    for key, value in local.items():
+        if not isinstance(key, str):
+            continue
+
+        module = key.split("|")[0]
+        if module not in explicit_reboot_modules:
+            continue
+
         if isinstance(value, dict) and "name" in value:
             names.add(value["name"])
 

--- a/salt/modules/transactional_update.py
+++ b/salt/modules/transactional_update.py
@@ -990,14 +990,16 @@ def call(function, *args, **kwargs):
     finally:
         # Check if reboot is needed
         if (activate_transaction and pending_transaction()) or (
-            not kwargs.get("test", False) and _user_specified_reboot(local)
+            not kwargs.get("test", False) and _user_specified_reboot(local, function)
         ):
             reboot()
 
 
-def _user_specified_reboot(local):
+def _user_specified_reboot(local, function):
+    if function != "state.highstate" and function != "state.sls":
+        return False
+
     if not isinstance(local, dict):
-        # Skip if execution is not state/highstate
         return False
 
     explicit_reboot_cmds = set(["reboot", "system.reboot"])

--- a/salt/modules/transactional_update.py
+++ b/salt/modules/transactional_update.py
@@ -1005,16 +1005,16 @@ def _user_specified_reboot(local, function):
     explicit_reboot_cmds = set(["reboot", "system.reboot"])
     explicit_reboot_modules = ["cmd_", "module_"]
     names = set()
-    for key, value in local.items():
-        if not isinstance(key, str):
+    for full_module_name, module_result in local.items():
+        if not isinstance(full_module_name, str):
             continue
 
-        module = key.split("|")[0]
+        module = full_module_name.split("|")[0]
         if module not in explicit_reboot_modules:
             continue
 
-        if isinstance(value, dict) and "name" in value:
-            names.add(value["name"])
+        if isinstance(module_result, dict) and "name" in module_result:
+            names.add(module_result["name"])
 
     return bool(explicit_reboot_cmds.intersection(names))
 

--- a/tests/pytests/unit/modules/test_transactional_update.py
+++ b/tests/pytests/unit/modules/test_transactional_update.py
@@ -630,7 +630,7 @@ def test_call_fail_explicit_reboot_non_cmd():
     with patch.dict(tu.__utils__, utils_mock), patch.dict(
         tu.__salt__, salt_mock
     ), patch("salt.modules.transactional_update.reboot", reboot_mock):
-        tu.call("state.test")
+        tu.call("state.sls")
         assert not reboot_mock.called
 
 

--- a/tests/pytests/unit/modules/test_transactional_update.py
+++ b/tests/pytests/unit/modules/test_transactional_update.py
@@ -528,7 +528,7 @@ def test_call_success_explicit_reboot():
         reboot_mock.assert_called_once()
 
 
-def test_call_success_explicit_reboot_test():
+def test_call_fail_explicit_reboot_test():
     """Test transactional_update.call does NOT execute reboot when user specifies 'reboot' in sls in test mode"""
     return_json = {
         "local": {

--- a/tests/pytests/unit/modules/test_transactional_update.py
+++ b/tests/pytests/unit/modules/test_transactional_update.py
@@ -606,6 +606,34 @@ def test_call_fail_explicit_reboot_non_sls():
         assert not reboot_mock.called
 
 
+def test_call_fail_explicit_reboot_non_cmd():
+    """
+    Test transactional_update.call does NOT execute reboot when the word 'reboot'
+    appears in sls executed with module other than `cmd` or `module.include`
+    """
+    return_json = {
+        "local": {
+            "test_|-reboot_test_|-reboot_|-run": {
+                "name": "reboot",
+                "changes": {},
+                "result": True,
+            }
+        }
+    }
+    utils_mock = {
+        "json.find_json": MagicMock(return_value=return_json),
+    }
+    salt_mock = {
+        "cmd.run_all": MagicMock(return_value={"retcode": 0, "stdout": ""}),
+    }
+    reboot_mock = MagicMock()
+    with patch.dict(tu.__utils__, utils_mock), patch.dict(
+        tu.__salt__, salt_mock
+    ), patch("salt.modules.transactional_update.reboot", reboot_mock):
+        tu.call("state.test")
+        assert not reboot_mock.called
+
+
 def test_sls():
     """Test transactional_update.sls"""
     salt_mock = {

--- a/tests/pytests/unit/modules/test_transactional_update.py
+++ b/tests/pytests/unit/modules/test_transactional_update.py
@@ -524,7 +524,7 @@ def test_call_success_explicit_reboot():
     with patch.dict(tu.__utils__, utils_mock), patch.dict(
         tu.__salt__, salt_mock
     ), patch("salt.modules.transactional_update.reboot", reboot_mock):
-        tu.call("module.function", key="value")
+        tu.call("state.sls", key="value")
         reboot_mock.assert_called_once()
 
 
@@ -549,7 +549,7 @@ def test_call_success_explicit_reboot_test():
     with patch.dict(tu.__utils__, utils_mock), patch.dict(
         tu.__salt__, salt_mock
     ), patch("salt.modules.transactional_update.reboot", reboot_mock):
-        tu.call("module.function", test="True")
+        tu.call("state.sls", test="True")
         assert not reboot_mock.called
 
 
@@ -574,7 +574,7 @@ def test_call_fail_explicit_reboot():
     with patch.dict(tu.__utils__, utils_mock), patch.dict(
         tu.__salt__, salt_mock
     ), patch("salt.modules.transactional_update.reboot", reboot_mock):
-        tu.call("module.function", test="True")
+        tu.call("state.sls", test="True")
         assert not reboot_mock.called
 
 

--- a/tests/pytests/unit/modules/test_transactional_update.py
+++ b/tests/pytests/unit/modules/test_transactional_update.py
@@ -501,6 +501,57 @@ def test_call_success_parameters():
         )
 
 
+def test_call_success_explicit_reboot():
+    """Test transactional_update.call executes reboot when user specifies 'reboot' in sls"""
+    return_json = {'local': { 'cmd_|-reboot_test_|-reboot_|-run': {'name': 'reboot', 'changes': {}, 'result': True}}}
+    utils_mock = {
+        "json.find_json": MagicMock(return_value=return_json),
+    }
+    salt_mock = {
+        "cmd.run_all": MagicMock(return_value={"retcode": 0, "stdout": ""}),
+    }
+    reboot_mock = MagicMock()
+    with patch.dict(tu.__utils__, utils_mock), patch.dict(tu.__salt__, salt_mock), patch(
+        "salt.modules.transactional_update.reboot", reboot_mock
+    ):
+        tu.call("module.function", key="value")
+        reboot_mock.assert_called_once()
+
+
+def test_call_success_explicit_reboot_test():
+    """Test transactional_update.call does NOT execute reboot when user specifies 'reboot' in sls in test mode"""
+    return_json = {'local': { 'cmd_|-reboot_test_|-reboot_|-run': {'name': 'reboot', 'changes': {}, 'result': True}}}
+    utils_mock = {
+        "json.find_json": MagicMock(return_value=return_json),
+    }
+    salt_mock = {
+        "cmd.run_all": MagicMock(return_value={"retcode": 0, "stdout": ""}),
+    }
+    reboot_mock = MagicMock()
+    with patch.dict(tu.__utils__, utils_mock), patch.dict(tu.__salt__, salt_mock), patch(
+        "salt.modules.transactional_update.reboot", reboot_mock
+    ):
+        tu.call("module.function", test="True")
+        assert not reboot_mock.called
+
+
+def test_call_fail_explicit_reboot():
+    """Test transactional_update.call does NOT execute reboot when the word 'reboot' appears in sls"""
+    return_json = {'local': { 'cmd_|-reboot_test_|-reboot_|-run': {'name': 'service reboot', 'changes': {}, 'result': True}}}
+    utils_mock = {
+        "json.find_json": MagicMock(return_value=return_json),
+    }
+    salt_mock = {
+        "cmd.run_all": MagicMock(return_value={"retcode": 0, "stdout": ""}),
+    }
+    reboot_mock = MagicMock()
+    with patch.dict(tu.__utils__, utils_mock), patch.dict(tu.__salt__, salt_mock), patch(
+        "salt.modules.transactional_update.reboot", reboot_mock
+    ):
+        tu.call("module.function", test="True")
+        assert not reboot_mock.called
+
+
 def test_sls():
     """Test transactional_update.sls"""
     salt_mock = {

--- a/tests/pytests/unit/modules/test_transactional_update.py
+++ b/tests/pytests/unit/modules/test_transactional_update.py
@@ -178,9 +178,11 @@ def test_commands_with_global_params():
                     "--non-interactive",
                     "--drop-if-no-change",
                     "--no-selfupdate",
-                    cmd.replace("_", ".")
-                    if cmd.startswith("grub")
-                    else cmd.replace("_", "-"),
+                    (
+                        cmd.replace("_", ".")
+                        if cmd.startswith("grub")
+                        else cmd.replace("_", "-")
+                    ),
                 ]
             )
 
@@ -503,7 +505,15 @@ def test_call_success_parameters():
 
 def test_call_success_explicit_reboot():
     """Test transactional_update.call executes reboot when user specifies 'reboot' in sls"""
-    return_json = {'local': { 'cmd_|-reboot_test_|-reboot_|-run': {'name': 'reboot', 'changes': {}, 'result': True}}}
+    return_json = {
+        "local": {
+            "cmd_|-reboot_test_|-reboot_|-run": {
+                "name": "reboot",
+                "changes": {},
+                "result": True,
+            }
+        }
+    }
     utils_mock = {
         "json.find_json": MagicMock(return_value=return_json),
     }
@@ -511,16 +521,24 @@ def test_call_success_explicit_reboot():
         "cmd.run_all": MagicMock(return_value={"retcode": 0, "stdout": ""}),
     }
     reboot_mock = MagicMock()
-    with patch.dict(tu.__utils__, utils_mock), patch.dict(tu.__salt__, salt_mock), patch(
-        "salt.modules.transactional_update.reboot", reboot_mock
-    ):
+    with patch.dict(tu.__utils__, utils_mock), patch.dict(
+        tu.__salt__, salt_mock
+    ), patch("salt.modules.transactional_update.reboot", reboot_mock):
         tu.call("module.function", key="value")
         reboot_mock.assert_called_once()
 
 
 def test_call_success_explicit_reboot_test():
     """Test transactional_update.call does NOT execute reboot when user specifies 'reboot' in sls in test mode"""
-    return_json = {'local': { 'cmd_|-reboot_test_|-reboot_|-run': {'name': 'reboot', 'changes': {}, 'result': True}}}
+    return_json = {
+        "local": {
+            "cmd_|-reboot_test_|-reboot_|-run": {
+                "name": "reboot",
+                "changes": {},
+                "result": True,
+            }
+        }
+    }
     utils_mock = {
         "json.find_json": MagicMock(return_value=return_json),
     }
@@ -528,16 +546,24 @@ def test_call_success_explicit_reboot_test():
         "cmd.run_all": MagicMock(return_value={"retcode": 0, "stdout": ""}),
     }
     reboot_mock = MagicMock()
-    with patch.dict(tu.__utils__, utils_mock), patch.dict(tu.__salt__, salt_mock), patch(
-        "salt.modules.transactional_update.reboot", reboot_mock
-    ):
+    with patch.dict(tu.__utils__, utils_mock), patch.dict(
+        tu.__salt__, salt_mock
+    ), patch("salt.modules.transactional_update.reboot", reboot_mock):
         tu.call("module.function", test="True")
         assert not reboot_mock.called
 
 
 def test_call_fail_explicit_reboot():
     """Test transactional_update.call does NOT execute reboot when the word 'reboot' appears in sls"""
-    return_json = {'local': { 'cmd_|-reboot_test_|-reboot_|-run': {'name': 'service reboot', 'changes': {}, 'result': True}}}
+    return_json = {
+        "local": {
+            "cmd_|-reboot_test_|-reboot_|-run": {
+                "name": "service reboot",
+                "changes": {},
+                "result": True,
+            }
+        }
+    }
     utils_mock = {
         "json.find_json": MagicMock(return_value=return_json),
     }
@@ -545,9 +571,9 @@ def test_call_fail_explicit_reboot():
         "cmd.run_all": MagicMock(return_value={"retcode": 0, "stdout": ""}),
     }
     reboot_mock = MagicMock()
-    with patch.dict(tu.__utils__, utils_mock), patch.dict(tu.__salt__, salt_mock), patch(
-        "salt.modules.transactional_update.reboot", reboot_mock
-    ):
+    with patch.dict(tu.__utils__, utils_mock), patch.dict(
+        tu.__salt__, salt_mock
+    ), patch("salt.modules.transactional_update.reboot", reboot_mock):
         tu.call("module.function", test="True")
         assert not reboot_mock.called
 

--- a/tests/pytests/unit/modules/test_transactional_update.py
+++ b/tests/pytests/unit/modules/test_transactional_update.py
@@ -578,6 +578,34 @@ def test_call_fail_explicit_reboot():
         assert not reboot_mock.called
 
 
+def test_call_fail_explicit_reboot_non_sls():
+    """
+    Test transactional_update.call does NOT execute reboot when the word 'reboot'
+    appears in sls executed with function other than state.sls
+    """
+    return_json = {
+        "local": {
+            "cmd_|-reboot_test_|-reboot_|-run": {
+                "name": "reboot",
+                "changes": {},
+                "result": True,
+            }
+        }
+    }
+    utils_mock = {
+        "json.find_json": MagicMock(return_value=return_json),
+    }
+    salt_mock = {
+        "cmd.run_all": MagicMock(return_value={"retcode": 0, "stdout": ""}),
+    }
+    reboot_mock = MagicMock()
+    with patch.dict(tu.__utils__, utils_mock), patch.dict(
+        tu.__salt__, salt_mock
+    ), patch("salt.modules.transactional_update.reboot", reboot_mock):
+        tu.call("state.test")
+        assert not reboot_mock.called
+
+
 def test_sls():
     """Test transactional_update.sls"""
     salt_mock = {


### PR DESCRIPTION
### What does this PR do?

In this PR, we parse the execution result on a transactional system. If user specified any of the provided `explicit_reboot_cmds` commands in a state file, we issue a reboot even when `activate_transaction` was not explicitly passed to the module.

Note that user still gets the result of `running in chroot, ignoring` (but the system actually reboots).

### What issues does this PR fix or reference?
Part of https://github.com/SUSE/spacewalk/issues/23874

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No
