### PR TITLE
Speed up salt.matcher.confirm_top by using __context__

### DIFF
--- a/salt/matchers/confirm_top.py
+++ b/salt/matchers/confirm_top.py
@@ -21,7 +21,11 @@ def confirm_top(match, data, nodegroups=None):
             if "match" in item:
                 matcher = item["match"]
 
-    matchers = salt.loader.matchers(__opts__)
+    if "matchers" in __context__:
+        matchers = __context__["matchers"]
+    else:
+        matchers = salt.loader.matchers(__opts__)
+        __context__["matchers"] = matchers
     funcname = matcher + "_match.match"
     if matcher == "nodegroup":
         return matchers[funcname](match, nodegroups)

--- a/tests/pytests/unit/matchers/test_confirm_top.py
+++ b/tests/pytests/unit/matchers/test_confirm_top.py
@@ -2,6 +2,7 @@ import pytest
 
 import salt.config
 import salt.loader
+from tests.support.mock import patch
 
 
 @pytest.fixture
@@ -12,3 +13,17 @@ def matchers(minion_opts):
 def test_sanity(matchers):
     match = matchers["confirm_top.confirm_top"]
     assert match("*", []) is True
+
+
+@pytest.mark.parametrize("in_context", [False, True])
+def test_matchers_from_context(matchers, in_context):
+    match = matchers["confirm_top.confirm_top"]
+    with patch.dict(
+        matchers.pack["__context__"], {"matchers": matchers} if in_context else {}
+    ), patch("salt.loader.matchers", return_value=matchers) as loader_matchers:
+        assert match("*", []) is True
+        assert id(matchers.pack["__context__"]["matchers"]) == id(matchers)
+        if in_context:
+            loader_matchers.assert_not_called()
+        else:
+            loader_matchers.assert_called_once()


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/saltstack/salt/pull/66494

In case of having complex `top.sls` with a list of different matchers based on grains/pillars etc. it could be possible that salt will reload matchers again and again for all of the possible matches in `top.sls`, this fix is intended to speed up the pillar renderer by reusing he matchers loaded once and stored in the `__context__`.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/23526

### Previous Behavior
If there is a list of different matches in `top.sls` for `pillar` it could take much time to render pillar data on `_pillar` calls from the minions.

### New Behavior
Each next call for rendering the pillar will reuse the matchers from the `__context__` so it will significantly speed up the calls.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
