### PR TITLE
Remove redundant run_func from salt.master.MWorker._handle_aes

### DIFF
--- a/salt/_logging/impl.py
+++ b/salt/_logging/impl.py
@@ -26,6 +26,8 @@ GARBAGE = logging.GARBAGE = 1
 QUIET = logging.QUIET = 1000
 
 import salt.defaults.exitcodes  # isort:skip  pylint: disable=unused-import
+import salt.utils.ctx
+
 from salt._logging.handlers import DeferredStreamHandler  # isort:skip
 from salt._logging.handlers import RotatingFileHandler  # isort:skip
 from salt._logging.handlers import StreamHandler  # isort:skip
@@ -33,7 +35,6 @@ from salt._logging.handlers import SysLogHandler  # isort:skip
 from salt._logging.handlers import WatchedFileHandler  # isort:skip
 from salt._logging.mixins import LoggingMixinMeta  # isort:skip
 from salt.exceptions import LoggingRuntimeError  # isort:skip
-from salt.utils.ctx import RequestContext  # isort:skip
 from salt.utils.immutabletypes import freeze, ImmutableDict  # isort:skip
 from salt.utils.textformat import TextFormat  # isort:skip
 
@@ -242,10 +243,14 @@ class SaltLoggingClass(LOGGING_LOGGER_CLASS, metaclass=LoggingMixinMeta):
         if extra is None:
             extra = {}
 
-        # pylint: disable=no-member
-        current_jid = RequestContext.current.get("data", {}).get("jid", None)
-        log_fmt_jid = RequestContext.current.get("opts", {}).get("log_fmt_jid", None)
-        # pylint: enable=no-member
+        current_jid = (
+            salt.utils.ctx.get_request_context().get("data", {}).get("jid", None)
+        )
+        log_fmt_jid = (
+            salt.utils.ctx.get_request_context()
+            .get("opts", {})
+            .get("log_fmt_jid", None)
+        )
 
         if current_jid is not None:
             extra["jid"] = current_jid

--- a/salt/master.py
+++ b/salt/master.py
@@ -1107,11 +1107,8 @@ class MWorker(salt.utils.process.SignalHandlingProcess):
             start = time.time()
             self.stats[cmd]["runs"] += 1
 
-        def run_func(data):
-            return self.aes_funcs.run_func(data["cmd"], data)
-
         with salt.utils.ctx.request_context({"data": data, "opts": self.opts}):
-            ret = run_func(data)
+            ret = self.aes_funcs.run_func(data["cmd"], data)
 
         if self.opts["master_stats"]:
             self._post_stats(start, cmd)

--- a/salt/master.py
+++ b/salt/master.py
@@ -38,6 +38,7 @@ import salt.state
 import salt.utils.args
 import salt.utils.atomicfile
 import salt.utils.crypt
+import salt.utils.ctx
 import salt.utils.event
 import salt.utils.files
 import salt.utils.gitfs
@@ -58,10 +59,8 @@ import salt.wheel
 from salt.cli.batch_async import BatchAsync, batch_async_required
 from salt.config import DEFAULT_INTERVAL
 from salt.defaults import DEFAULT_TARGET_DELIM
-from salt.ext.tornado.stack_context import StackContext
 from salt.transport import TRANSPORTS
 from salt.utils.channel import iter_transport_opts
-from salt.utils.ctx import RequestContext
 from salt.utils.debug import (
     enable_sigusr1_handler,
     enable_sigusr2_handler,
@@ -1111,9 +1110,7 @@ class MWorker(salt.utils.process.SignalHandlingProcess):
         def run_func(data):
             return self.aes_funcs.run_func(data["cmd"], data)
 
-        with StackContext(
-            functools.partial(RequestContext, {"data": data, "opts": self.opts})
-        ):
+        with salt.utils.ctx.request_context({"data": data, "opts": self.opts}):
             ret = run_func(data)
 
         if self.opts["master_stats"]:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1805,14 +1805,11 @@ class Minion(MinionBase):
                 uid = salt.utils.user.get_uid(user=opts.get("user", None))
                 minion_instance.proc_dir = get_proc_dir(opts["cachedir"], uid=uid)
 
-        def run_func(minion_instance, opts, data):
+        with salt.utils.ctx.request_context({"data": data, "opts": opts}):
             if isinstance(data["fun"], tuple) or isinstance(data["fun"], list):
                 return Minion._thread_multi_return(minion_instance, opts, data)
             else:
                 return Minion._thread_return(minion_instance, opts, data)
-
-        with salt.utils.ctx.request_context({"data": data, "opts": opts}):
-            run_func(minion_instance, opts, data)
 
     def _execute_job_function(
         self, function_name, function_args, executors, opts, data

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -39,6 +39,7 @@ import salt.transport
 import salt.utils.args
 import salt.utils.context
 import salt.utils.crypt
+import salt.utils.ctx
 import salt.utils.data
 import salt.utils.dictdiffer
 import salt.utils.dictupdate
@@ -70,7 +71,6 @@ from salt.exceptions import (
     SaltSystemExit,
 )
 from salt.template import SLS_ENCODING
-from salt.utils.ctx import RequestContext
 from salt.utils.debug import enable_sigusr1_handler
 from salt.utils.event import tagify
 from salt.utils.network import parse_host_port
@@ -1811,11 +1811,8 @@ class Minion(MinionBase):
             else:
                 return Minion._thread_return(minion_instance, opts, data)
 
-        with salt.ext.tornado.stack_context.StackContext(
-            functools.partial(RequestContext, {"data": data, "opts": opts})
-        ):
-            with salt.ext.tornado.stack_context.StackContext(minion_instance.ctx):
-                run_func(minion_instance, opts, data)
+        with salt.utils.ctx.request_context({"data": data, "opts": opts}):
+            run_func(minion_instance, opts, data)
 
     def _execute_job_function(
         self, function_name, function_args, executors, opts, data

--- a/salt/utils/ctx.py
+++ b/salt/utils/ctx.py
@@ -16,12 +16,12 @@ def request_context(data):
     """
     A context manager that sets and un-sets the loader context
     """
-    tok = loader_ctxvar.set(data)
+    tok = request_ctxvar.set(data)
     try:
         yield
     finally:
-        loader_ctxvar.reset(tok)
+        request_ctxvar.reset(tok)
 
 
 def get_request_context():
-    return loader_ctxvar.get({})
+    return request_ctxvar.get({})

--- a/salt/utils/ctx.py
+++ b/salt/utils/ctx.py
@@ -1,49 +1,27 @@
-import threading
+import contextlib
+
+try:
+    # Try the stdlib C extension first
+    import _contextvars as contextvars
+except ImportError:
+    # Py<3.7
+    import contextvars
+
+DEFAULT_CTX_VAR = "request_ctxvar"
+request_ctxvar = contextvars.ContextVar(DEFAULT_CTX_VAR)
 
 
-class ClassProperty(property):
+@contextlib.contextmanager
+def request_context(data):
     """
-    Use a classmethod as a property
-    http://stackoverflow.com/a/1383402/1258307
+    A context manager that sets and un-sets the loader context
     """
+    tok = loader_ctxvar.set(data)
+    try:
+        yield
+    finally:
+        loader_ctxvar.reset(tok)
 
-    def __get__(self, cls, owner):
-        return self.fget.__get__(None, owner)()  # pylint: disable=no-member
 
-
-class RequestContext:
-    """
-    A context manager that saves some per-thread state globally.
-    Intended for use with Tornado's StackContext.
-    https://gist.github.com/simon-weber/7755289
-    Simply import this class into any module and access the current request handler by this
-    class's class method property 'current'. If it returns None, there's no active request.
-    .. code:: python
-        from raas.utils.ctx import RequestContext
-        current_request_handler = RequestContext.current
-    """
-
-    _state = threading.local()
-    _state.current_request = {}
-
-    def __init__(self, current_request):
-        self._current_request = current_request
-
-    @ClassProperty
-    @classmethod
-    def current(cls):
-        if not hasattr(cls._state, "current_request"):
-            return {}
-        return cls._state.current_request
-
-    def __enter__(self):
-        self._prev_request = self.__class__.current
-        self.__class__._state.current_request = self._current_request
-
-    def __exit__(self, *exc):
-        self.__class__._state.current_request = self._prev_request
-        del self._prev_request
-        return False
-
-    def __call__(self):
-        return self
+def get_request_context():
+    return loader_ctxvar.get({})


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/saltstack/salt/pull/66509 and https://github.com/saltstack/salt/commit/0c3ebc0795f9c2adec90118281343cae3070e0f6

Removes redundant useless call for `run_func` which seems introduced with https://github.com/saltstack/salt/pull/48660
It's not really clear if it could give any benefit here to have `run_func` used. Looks like it just adds extra stack entry on the call with no any benefit.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/23526

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
