### PR TITLE
Change zfs module test dependency from man to more

### DIFF
--- a/tests/pytests/unit/modules/test_zfs.py
+++ b/tests/pytests/unit/modules/test_zfs.py
@@ -816,7 +816,7 @@ def test_bookmark_success(utils_patch):
     """
     Tests zfs bookmark success
     """
-    with patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/man")):
+    with patch("salt.utils.path.which", MagicMock(return_value="/usr/bin/more")):
         res = OrderedDict([("bookmarked", True)])
         ret = {"pid": 20990, "retcode": 0, "stderr": "", "stdout": ""}
         mock_cmd = MagicMock(return_value=ret)


### PR DESCRIPTION
### What does this PR do?
The test requires a file that the test can open and read. The problem with temp files is that the files pytest keeps the files open during the test (because the file gets deleted when closed). Consequently, the test previously used the `/usr/bin/man` file.

With our support of SL Micro, `man` is not available, so I changed `man` to `more`.  
