### PR TITLE
Add missing contextvars dependency in salt.version

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -717,6 +717,7 @@ def dependency_information(include_salt_cloud=False):
         ("docker-py", "docker", "__version__"),
         ("packaging", "packaging", "__version__"),
         ("looseversion", "looseversion", None),
+        ("contextvars", "contextvars", None),
         ("relenv", "relenv", "__version__"),
     ]
 

--- a/tests/unit/states/test_pip_state.py
+++ b/tests/unit/states/test_pip_state.py
@@ -419,7 +419,7 @@ class PipStateInstallationErrorTest(TestCase):
     def test_importable_installation_error(self):
         extra_requirements = []
         for name, version in salt.version.dependency_information():
-            if name in ["PyYAML", "packaging", "looseversion"]:
+            if name in ["PyYAML", "packaging", "looseversion", "contextvars"]:
                 extra_requirements.append("{}=={}".format(name, version))
         failures = {}
         pip_version_requirements = [


### PR DESCRIPTION
### What does this PR do?

PR: https://github.com/openSUSE/salt/pull/650 is causing test fail due to missing `contextvar` dependency.

This change intended to fix the following error failing the test `tests/unit/states/test_pip_state.py::PipStateInstallationErrorTest::test_importable_installation_error`:
```
E           b'Traceback (most recent call last):\n  File "/__w/salt/salt/salt/utils/ctx.py", line 5, in <module>\n    import _contextvars as contextvars\nModuleNotFoundError: No module named \'_contextvars\'\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File "<string>", line 4, in <module>\n  File "/__w/salt/salt/salt/__init__.py", line 175, in <module>\n    import salt._logging  # isort:skip\n  File "/__w/salt/salt/salt/_logging/__init__.py", line 12, in <module>\n    from salt._logging.impl import (\n  File "/__w/salt/salt/salt/_logging/impl.py", line 29, in <module>\n    import salt.utils.ctx\n  File "/__w/salt/salt/salt/utils/ctx.py", line 8, in <module>\n    import contextvars\nModuleNotFoundError: No module named \'contextvars\'\n'
```


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
