### PR TITLE
Prevent using SyncWrapper with no reason

### DIFF
--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -86,7 +86,7 @@ class ReqServerChannel:
         # other things needed for _auth
         # Create the event manager
         self.event = salt.utils.event.get_master_event(
-            self.opts, self.opts["sock_dir"], listen=False
+            self.opts, self.opts["sock_dir"], listen=False, io_loop=io_loop
         )
         self.auto_key = salt.daemons.masterapi.AutoKey(self.opts)
         # only create a con_cache-client if the con_cache is active


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/saltstack/salt/pull/66510

It's not really clear if it was mate intentionally or just the parameter is missing by accident here.

Due to missing `io_loop` paramerer it's causing setting `_run_io_loop_sync` to `True` in `SaltEvent` object with:
https://github.com/openSUSE/salt/blob/4ec5c8bdb8aecac6752c639f494b86c7f8f57ba2/salt/utils/event.py#L235-L240

And that's why is using `salt.utils.asynchronous.SyncWrapper` here:
https://github.com/openSUSE/salt/blob/4ec5c8bdb8aecac6752c639f494b86c7f8f57ba2/salt/utils/event.py#L362-L370

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/23526

### Previous Behavior
SaltEvent is using `salt.utils.asynchronous.SyncWrapper` with the code which is intended to be used in `async` way.

### New Behavior
`salt.utils.asynchronous.SyncWrapper` is not used, but direct `async` calls are used instead.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
