### PR TITLE
Repair virt_query outputter

### DIFF
--- a/changelog/65841.fixed.md
+++ b/changelog/65841.fixed.md
@@ -1,1 +1,1 @@
-Restore functionality of virt_query outputter.
+Restore functionality of virt_query outputter and add support for block devices.

--- a/changelog/65841.fixed.md
+++ b/changelog/65841.fixed.md
@@ -1,0 +1,1 @@
+Restore functionality of virt_query outputter.

--- a/salt/output/virt_query.py
+++ b/salt/output/virt_query.py
@@ -32,7 +32,8 @@ def output(data, **kwargs):  # pylint: disable=unused-argument
                 if "disks" in vm_data:
                     for disk, d_data in vm_data["disks"].items():
                         out += "    Disk - {}:\n".format(disk)
-                        out += "      Size: {}\n".format(d_data["disk size"])
+                        if "disk size" in d_data:
+                            out += "      Size: {}\n".format(d_data["disk size"])
                         out += "      File: {}\n".format(d_data["file"])
                         out += "      File Format: {}\n".format(d_data["file format"])
                 if "nics" in vm_data:

--- a/salt/output/virt_query.py
+++ b/salt/output/virt_query.py
@@ -12,35 +12,36 @@ def output(data, **kwargs):  # pylint: disable=unused-argument
     Display output for the salt-run virt.query function
     """
     out = ""
-    for id_ in data["data"]:
-        out += "{}\n".format(id_)
-        for vm_ in data["data"][id_]["vm_info"]:
-            out += "  {}\n".format(vm_)
-            vm_data = data[id_]["vm_info"][vm_]
-            if "cpu" in vm_data:
-                out += "    CPU: {}\n".format(vm_data["cpu"])
-            if "mem" in vm_data:
-                out += "    Memory: {}\n".format(vm_data["mem"])
-            if "state" in vm_data:
-                out += "    State: {}\n".format(vm_data["state"])
-            if "graphics" in vm_data:
-                if vm_data["graphics"].get("type", "") == "vnc":
-                    out += "    Graphics: vnc - {}:{}\n".format(
-                        id_, vm_data["graphics"]["port"]
-                    )
-            if "disks" in vm_data:
-                for disk, d_data in vm_data["disks"].items():
-                    out += "    Disk - {}:\n".format(disk)
-                    out += "      Size: {}\n".format(d_data["disk size"])
-                    out += "      File: {}\n".format(d_data["file"])
-                    out += "      File Format: {}\n".format(d_data["file format"])
-            if "nics" in vm_data:
-                for mac in vm_data["nics"]:
-                    out += "    Nic - {}:\n".format(mac)
-                    out += "      Source: {}\n".format(
-                        vm_data["nics"][mac]["source"][
-                            next(iter(vm_data["nics"][mac]["source"].keys()))
-                        ]
-                    )
-                    out += "      Type: {}\n".format(vm_data["nics"][mac]["type"])
+    if isinstance(data, dict) and "event" in data:
+        for id_ in data["event"]["data"]:
+            out += "{}\n".format(id_)
+            for vm_ in data["event"]["data"][id_]["vm_info"]:
+                out += "  {}\n".format(vm_)
+                vm_data = data["event"]["data"][id_]["vm_info"][vm_]
+                if "cpu" in vm_data:
+                    out += "    CPU: {}\n".format(vm_data["cpu"])
+                if "mem" in vm_data:
+                    out += "    Memory: {}\n".format(vm_data["mem"])
+                if "state" in vm_data:
+                    out += "    State: {}\n".format(vm_data["state"])
+                if "graphics" in vm_data:
+                    if vm_data["graphics"].get("type", "") == "vnc":
+                        out += "    Graphics: vnc - {}:{}\n".format(
+                            id_, vm_data["graphics"]["port"]
+                        )
+                if "disks" in vm_data:
+                    for disk, d_data in vm_data["disks"].items():
+                        out += "    Disk - {}:\n".format(disk)
+                        out += "      Size: {}\n".format(d_data["disk size"])
+                        out += "      File: {}\n".format(d_data["file"])
+                        out += "      File Format: {}\n".format(d_data["file format"])
+                if "nics" in vm_data:
+                    for mac in vm_data["nics"]:
+                        out += "    NIC - {}:\n".format(mac)
+                        out += "      Source: {}\n".format(
+                            vm_data["nics"][mac]["source"][
+                                next(iter(vm_data["nics"][mac]["source"].keys()))
+                            ]
+                        )
+                        out += "      Type: {}\n".format(vm_data["nics"][mac]["type"])
     return out

--- a/tests/pytests/unit/output/test_virt_query.py
+++ b/tests/pytests/unit/output/test_virt_query.py
@@ -1,0 +1,176 @@
+"""
+unittests for virt_query outputter
+"""
+
+import pytest
+
+import salt.output.virt_query as virt_query
+from tests.support.mock import patch
+
+
+@pytest.fixture
+def configure_loader_modules():
+    return {virt_query: {}}
+
+
+@pytest.fixture
+def data():
+    return {
+        "suffix": "progress",
+        "event": {
+            "data": {
+                "mysystem": {
+                    "freecpu": 14,
+                    "freemem": 29566.0,
+                    "node_info": {
+                        "cpucores": 8,
+                        "cpumhz": 1089,
+                        "cpumodel": "x86_64",
+                        "cpus": 16,
+                        "cputhreads": 2,
+                        "numanodes": 1,
+                        "phymemory": 30846,
+                        "sockets": 1,
+                    },
+                    "vm_info": {
+                        "vm1": {
+                            "cpu": 2,
+                            "cputime": 1214270000000,
+                            "disks": {
+                                "vda": {
+                                    "file": "default/vm1-main-disk",
+                                    "type": "disk",
+                                    "file format": "qcow2",
+                                    "virtual size": 214748364800,
+                                    "disk size": 1831731200,
+                                    "backing file": {
+                                        "file": "/var/lib/libvirt/images/sles15sp4o",
+                                        "file format": "qcow2",
+                                    },
+                                },
+                                "hdd": {
+                                    "file": "default/vm1-cloudinit-disk",
+                                    "type": "cdrom",
+                                    "file format": "raw",
+                                    "virtual size": 374784,
+                                    "disk size": 376832,
+                                },
+                            },
+                            "graphics": {
+                                "autoport": "yes",
+                                "keymap": "None",
+                                "listen": "0.0.0.0",
+                                "port": "5900",
+                                "type": "spice",
+                            },
+                            "nics": {
+                                "aa:bb:cc:dd:ee:ff": {
+                                    "type": "network",
+                                    "mac": "aa:bb:cc:dd:ee:ff",
+                                    "source": {"network": "default"},
+                                    "model": "virtio",
+                                    "address": {
+                                        "type": "pci",
+                                        "domain": "0x0000",
+                                        "bus": "0x00",
+                                        "slot": "0x03",
+                                        "function": "0x0",
+                                    },
+                                }
+                            },
+                            "uuid": "yyyyyy",
+                            "loader": {"path": "None"},
+                            "on_crash": "destroy",
+                            "on_reboot": "restart",
+                            "on_poweroff": "destroy",
+                            "maxMem": 1048576,
+                            "mem": 1048576,
+                            "state": "running",
+                        },
+                        "uyuni-proxy": {
+                            "cpu": 2,
+                            "cputime": 0,
+                            "disks": {
+                                "vda": {
+                                    "file": "default/uyuni-proxy-main-disk",
+                                    "type": "disk",
+                                    "file format": "qcow2",
+                                    "virtual size": 214748364800,
+                                    "disk size": 4491255808,
+                                    "backing file": {
+                                        "file": "/var/lib/libvirt/images/leapmicro55o",
+                                        "file format": "qcow2",
+                                    },
+                                }
+                            },
+                            "graphics": {
+                                "autoport": "yes",
+                                "keymap": "None",
+                                "listen": "0.0.0.0",
+                                "port": "None",
+                                "type": "spice",
+                            },
+                            "nics": {
+                                "aa:bb:cc:dd:ee:aa": {
+                                    "type": "network",
+                                    "mac": "aa:bb:cc:dd:ee:aa",
+                                    "source": {"network": "default"},
+                                    "model": "virtio",
+                                    "address": {
+                                        "type": "pci",
+                                        "domain": "0x0000",
+                                        "bus": "0x00",
+                                        "slot": "0x03",
+                                        "function": "0x0",
+                                    },
+                                }
+                            },
+                            "uuid": "xxxxx",
+                            "loader": {"path": "None"},
+                            "on_crash": "destroy",
+                            "on_reboot": "restart",
+                            "on_poweroff": "destroy",
+                            "maxMem": 2097152,
+                            "mem": 2097152,
+                            "state": "shutdown",
+                        },
+                    },
+                }
+            },
+            "outputter": "virt_query",
+            "_stamp": "2025-02-21T11:28:04.406561",
+        },
+    }
+
+
+def test_default_output(data):
+    ret = virt_query.output(data)
+    expected = """mysystem
+  vm1
+    CPU: 2
+    Memory: 1048576
+    State: running
+    Disk - vda:
+      Size: 1831731200
+      File: default/vm1-main-disk
+      File Format: qcow2
+    Disk - hdd:
+      Size: 376832
+      File: default/vm1-cloudinit-disk
+      File Format: raw
+    NIC - aa:bb:cc:dd:ee:ff:
+      Source: default
+      Type: network
+  uyuni-proxy
+    CPU: 2
+    Memory: 2097152
+    State: shutdown
+    Disk - vda:
+      Size: 4491255808
+      File: default/uyuni-proxy-main-disk
+      File Format: qcow2
+    NIC - aa:bb:cc:dd:ee:aa:
+      Source: default
+      Type: network
+"""
+    assert expected == ret


### PR DESCRIPTION
### Upstream PR

https://github.com/saltstack/salt/pull/65843

### What does this PR do?

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/65841

### Previous Behavior

Outputter returns traceback.

### New Behavior

Outputter returns pretty output:

```
# salt-run --out=virt_query virt.query host=squanchy.infra.opensuse.org
squanchy.infra.opensuse.org
  thor1.infra.opensuse.org
    CPU: 1
    Memory: 1000000
    State: running
    Disk - vdb:
      Size: 2541887488
      File: /data0/kvm/disks/thor1.infra.opensuse.org_root.qcow2
      File Format: qcow2
    NIC - fe:cd:47:19:e7:86:
      Source: x-os-thor
      Type: direct
# more VMs ...
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

^ I'm not sure about tests for this, some other outputters have tests in `tests/pytests/unit/output/`, but I'm not sure it's feasible for this one, it would need to hook into the `virt` module tests somehow to generate a VM fixture?

### Commits signed with GPG?
Yes

