### PR TITLE
Provide systemd timer unit

### DIFF
--- a/pkg/common/venv-salt-minion-postinstall.service
+++ b/pkg/common/venv-salt-minion-postinstall.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Clean old environment for venv-salt-minion
+
+[Service]
+ExecStart=/bin/sh -c '/usr/lib/venv-salt-minion/bin/post_start_cleanup.sh || :'
+Type=oneshot
+

--- a/pkg/common/venv-salt-minion-postinstall.timer
+++ b/pkg/common/venv-salt-minion-postinstall.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Clean old venv-salt-minion environment in 60 seconds
+
+[Timer]
+OnActiveSec=60
+
+[Install]
+WantedBy=timers.target
+


### PR DESCRIPTION
### What does this PR do?

Provide systemd timer unit that activates the cleanup script once, 60s after the venv-salt-minion package is installed. Spec changes will come in OBS, where we maintain the venv-salt-minion spec file.
