### PR TITLE
Make tests compatible with venv bundle

### DIFF
--- a/tests/pytests/functional/modules/test_sdb.py
+++ b/tests/pytests/functional/modules/test_sdb.py
@@ -16,6 +16,7 @@ def minion_config_overrides():
         }
 
 
+@pytest.mark.skip("Great module migration")
 @pytest.mark.parametrize(
     "expected_value",
     (

--- a/tests/pytests/functional/modules/test_yaml.py
+++ b/tests/pytests/functional/modules/test_yaml.py
@@ -13,7 +13,7 @@ try:
     import salt.modules.yaml
     import salt.utils.yamllint
 
-    YAMLLINT_AVAILABLE = True
+    YAMLLINT_AVAILABLE = salt.utils.yamllint.has_yamllint()
 except ImportError:
     YAMLLINT_AVAILABLE = False
 

--- a/tests/pytests/functional/utils/pyinstaller/rthooks/test_salt_utils_vt_terminal.py
+++ b/tests/pytests/functional/utils/pyinstaller/rthooks/test_salt_utils_vt_terminal.py
@@ -8,6 +8,9 @@ import salt.utils.pyinstaller.rthooks._overrides as overrides
 from tests.support import mock
 from tests.support.helpers import PatchedEnviron
 
+LD_LIBRARY_PATH = ""
+if os.environ.get('VIRTUAL_ENV'):
+    LD_LIBRARY_PATH = f"{os.environ.get('VIRTUAL_ENV')}/lib"
 
 @pytest.fixture(params=("LD_LIBRARY_PATH", "LIBPATH"))
 def envvar(request):
@@ -17,9 +20,14 @@ def envvar(request):
 @pytest.fixture
 def meipass(envvar):
     with mock.patch("salt.utils.pyinstaller.rthooks._overrides.sys") as patched_sys:
-        patched_sys._MEIPASS = "{}_VALUE".format(envvar)
-        assert overrides.sys._MEIPASS == "{}_VALUE".format(envvar)
-        yield "{}_VALUE".format(envvar)
+        ld_path_mock_val = f"{envvar}_VALUE"
+        if envvar == "LD_LIBRARY_PATH" and LD_LIBRARY_PATH:
+            # venv-minion python wrapper hardcodes LD_LIB_PATH that
+            # we cannot overwrite from the testsuite
+            ld_path_mock_val = LD_LIBRARY_PATH
+        patched_sys._MEIPASS = ld_path_mock_val
+        assert overrides.sys._MEIPASS == ld_path_mock_val
+        yield ld_path_mock_val
     assert not hasattr(sys, "_MEIPASS")
     assert not hasattr(overrides.sys, "_MEIPASS")
 
@@ -111,7 +119,8 @@ def test_vt_terminal_environ_cleanup(envvar, meipass):
         returned_env = json.loads(buffer_o)
         assert returned_env != original_env
         assert envvar in returned_env
-        assert returned_env[envvar] == ""
+        envvar_value = LD_LIBRARY_PATH if envvar == "LD_LIBRARY_PATH" else ""
+        assert returned_env[envvar] == envvar_value
 
 
 def test_vt_terminal_environ_cleanup_passed_directly_not_removed(envvar, meipass):
@@ -139,4 +148,7 @@ def test_vt_terminal_environ_cleanup_passed_directly_not_removed(envvar, meipass
     returned_env = json.loads(buffer_o)
     assert returned_env != original_env
     assert envvar in returned_env
-    assert returned_env[envvar] == envvar
+    envvar_val = envvar
+    if LD_LIBRARY_PATH and envvar == "LD_LIBRARY_PATH":
+        envvar_val = LD_LIBRARY_PATH
+    assert returned_env[envvar] == envvar_val

--- a/tests/pytests/functional/utils/pyinstaller/rthooks/test_subprocess.py
+++ b/tests/pytests/functional/utils/pyinstaller/rthooks/test_subprocess.py
@@ -9,6 +9,9 @@ import salt.utils.pyinstaller.rthooks._overrides as overrides
 from tests.support import mock
 from tests.support.helpers import PatchedEnviron
 
+LD_LIBRARY_PATH = ""
+if os.environ.get('VIRTUAL_ENV'):
+    LD_LIBRARY_PATH = f"{os.environ.get('VIRTUAL_ENV')}/lib"
 
 @pytest.fixture(params=("LD_LIBRARY_PATH", "LIBPATH"))
 def envvar(request):
@@ -18,9 +21,14 @@ def envvar(request):
 @pytest.fixture
 def meipass(envvar):
     with mock.patch("salt.utils.pyinstaller.rthooks._overrides.sys") as patched_sys:
-        patched_sys._MEIPASS = "{}_VALUE".format(envvar)
-        assert overrides.sys._MEIPASS == "{}_VALUE".format(envvar)
-        yield "{}_VALUE".format(envvar)
+        ld_path_mock_val = f"{envvar}_VALUE"
+        if envvar == "LD_LIBRARY_PATH" and LD_LIBRARY_PATH:
+            # venv-minion python wrapper hardcodes LD_LIB_PATH that
+            # we cannot overwrite from the testsuite
+            ld_path_mock_val = LD_LIBRARY_PATH
+        patched_sys._MEIPASS = ld_path_mock_val
+        assert overrides.sys._MEIPASS == ld_path_mock_val
+        yield ld_path_mock_val
     assert not hasattr(sys, "_MEIPASS")
     assert not hasattr(overrides.sys, "_MEIPASS")
 
@@ -88,7 +96,8 @@ def test_subprocess_popen_environ_cleanup(envvar, meipass):
         returned_env = json.loads(stdout)
         assert returned_env != original_env
         assert envvar in returned_env
-        assert returned_env[envvar] == ""
+        envvar_value = LD_LIBRARY_PATH if envvar == "LD_LIBRARY_PATH" else ""
+        assert returned_env[envvar] == envvar_value
 
 
 def test_subprocess_popen_environ_cleanup_passed_directly_not_removed(envvar, meipass):
@@ -108,4 +117,7 @@ def test_subprocess_popen_environ_cleanup_passed_directly_not_removed(envvar, me
     returned_env = json.loads(stdout)
     assert returned_env != original_env
     assert envvar in returned_env
-    assert returned_env[envvar] == envvar
+    envvar_val = envvar
+    if LD_LIBRARY_PATH and envvar == "LD_LIBRARY_PATH":
+        envvar_val = LD_LIBRARY_PATH
+    assert returned_env[envvar] == envvar_val

--- a/tests/pytests/functional/utils/yamllint/test_yamllint.py
+++ b/tests/pytests/functional/utils/yamllint/test_yamllint.py
@@ -7,7 +7,7 @@ import salt.utils.versions as versions
 try:
     import salt.utils.yamllint as yamllint
 
-    YAMLLINT_AVAILABLE = True
+    YAMLLINT_AVAILABLE = yamllint.has_yamllint()
 except ImportError:
     YAMLLINT_AVAILABLE = False
 

--- a/tests/pytests/unit/modules/test_pip.py
+++ b/tests/pytests/unit/modules/test_pip.py
@@ -15,6 +15,10 @@ MISSING_SETUP_PY_FILE = not os.path.exists(
     os.path.join(RUNTIME_VARS.CODE_DIR, "setup.py")
 )
 
+TARGET = []
+if os.environ.get('VENV_PIP_TARGET'):
+    TARGET = ["--target", os.environ.get('VENV_PIP_TARGET')]
+
 
 class FakeFopen:
     def __init__(self, filename):
@@ -102,6 +106,7 @@ def test_install_frozen_app(python_binary):
                 expected = [
                     *python_binary,
                     "install",
+                    *TARGET,
                     pkg,
                 ]
                 mock.assert_called_with(
@@ -123,6 +128,7 @@ def test_install_source_app(python_binary):
                 expected = [
                     *python_binary,
                     "install",
+                    *TARGET,
                     pkg,
                 ]
                 mock.assert_called_with(
@@ -143,6 +149,7 @@ def test_fix4361(python_binary):
             "install",
             "--requirement",
             "requirements.txt",
+            *TARGET,
         ]
         mock.assert_called_with(
             expected_cmd,
@@ -169,7 +176,7 @@ def test_install_multiple_editable(python_binary):
         "git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting",
     ]
 
-    expected = [*python_binary, "install"]
+    expected = [*python_binary, "install", *TARGET]
     for item in editables:
         expected.extend(["--editable", item])
 
@@ -205,7 +212,7 @@ def test_install_multiple_pkgs_and_editables(python_binary):
         "git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting",
     ]
 
-    expected = [*python_binary, "install"]
+    expected = [*python_binary, "install", *TARGET]
     expected.extend(pkgs)
     for item in editables:
         expected.extend(["--editable", item])
@@ -241,6 +248,7 @@ def test_install_multiple_pkgs_and_editables(python_binary):
         expected = [
             *python_binary,
             "install",
+            *TARGET,
             pkgs[0],
             "--editable",
             editables[0],
@@ -268,7 +276,7 @@ def test_issue5940_install_multiple_pip_mirrors(python_binary):
         expected = [*python_binary, "install", "--use-mirrors"]
         for item in mirrors:
             expected.extend(["--mirrors", item])
-        expected.append("pep8")
+        expected = [*expected, *TARGET, "pep8"]
 
         # Passing mirrors as a list
         mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
@@ -300,6 +308,7 @@ def test_issue5940_install_multiple_pip_mirrors(python_binary):
             "--use-mirrors",
             "--mirrors",
             mirrors[0],
+            *TARGET,
             "pep8",
         ]
 
@@ -327,7 +336,7 @@ def test_install_with_multiple_find_links(python_binary):
     expected = [*python_binary, "install"]
     for item in find_links:
         expected.extend(["--find-links", item])
-    expected.append(pkg)
+    expected = [*expected, *TARGET, pkg]
 
     # Passing mirrors as a list
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
@@ -370,6 +379,7 @@ def test_install_with_multiple_find_links(python_binary):
         "install",
         "--find-links",
         find_links[0],
+        *TARGET,
         pkg,
     ]
 
@@ -435,6 +445,7 @@ def test_install_cached_requirements_used(python_binary):
                 "install",
                 "--requirement",
                 "my_cached_reqs",
+                *TARGET,
             ]
             mock.assert_called_with(
                 expected,
@@ -491,6 +502,7 @@ def test_install_log_argument_in_resulting_command(python_binary):
                 "install",
                 "--log",
                 log_path,
+                *TARGET,
                 pkg,
             ]
             mock.assert_called_with(
@@ -521,7 +533,7 @@ def test_install_timeout_argument_in_resulting_command(python_binary):
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, timeout=10)
         mock.assert_called_with(
-            expected + [10, pkg],
+            expected + [10, *TARGET, pkg],
             saltenv="base",
             runas=None,
             use_vt=False,
@@ -533,7 +545,7 @@ def test_install_timeout_argument_in_resulting_command(python_binary):
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, timeout="10")
         mock.assert_called_with(
-            expected + ["10", pkg],
+            expected + ["10", *TARGET, pkg],
             saltenv="base",
             runas=None,
             use_vt=False,
@@ -557,6 +569,7 @@ def test_install_index_url_argument_in_resulting_command(python_binary):
             "install",
             "--index-url",
             index_url,
+            *TARGET,
             pkg,
         ]
         mock.assert_called_with(
@@ -579,6 +592,7 @@ def test_install_extra_index_url_argument_in_resulting_command(python_binary):
             "install",
             "--extra-index-url",
             extra_index_url,
+            *TARGET,
             pkg,
         ]
         mock.assert_called_with(
@@ -595,7 +609,7 @@ def test_install_no_index_argument_in_resulting_command(python_binary):
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, no_index=True)
-        expected = [*python_binary, "install", "--no-index", pkg]
+        expected = [*python_binary, "install", "--no-index", *TARGET, pkg]
         mock.assert_called_with(
             expected,
             saltenv="base",
@@ -611,7 +625,7 @@ def test_install_build_argument_in_resulting_command(python_binary):
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, build=build)
-        expected = [*python_binary, "install", "--build", build, pkg]
+        expected = [*python_binary, "install", "--build", build, *TARGET, pkg]
         mock.assert_called_with(
             expected,
             saltenv="base",
@@ -646,6 +660,7 @@ def test_install_download_argument_in_resulting_command(python_binary):
         expected = [
             *python_binary,
             "install",
+            *TARGET,
             "--download",
             download,
             pkg,
@@ -664,7 +679,7 @@ def test_install_no_download_argument_in_resulting_command(python_binary):
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, no_download=True)
-        expected = [*python_binary, "install", "--no-download", pkg]
+        expected = [*python_binary, "install", *TARGET, "--no-download", pkg]
         mock.assert_called_with(
             expected,
             saltenv="base",
@@ -691,6 +706,7 @@ def test_install_download_cache_dir_arguments_in_resulting_command(python_binary
                 expected = [
                     *python_binary,
                     "install",
+                    *TARGET,
                     cmd_arg,
                     download_cache,
                     pkg,
@@ -720,7 +736,7 @@ def test_install_source_argument_in_resulting_command(python_binary):
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, source=source)
-        expected = [*python_binary, "install", "--source", source, pkg]
+        expected = [*python_binary, "install", *TARGET, "--source", source, pkg]
         mock.assert_called_with(
             expected,
             saltenv="base",
@@ -739,6 +755,7 @@ def test_install_exists_action_argument_in_resulting_command(python_binary):
             expected = [
                 *python_binary,
                 "install",
+                *TARGET,
                 "--exists-action",
                 action,
                 pkg,
@@ -761,7 +778,7 @@ def test_install_install_options_argument_in_resulting_command(python_binary):
     install_options = ["--exec-prefix=/foo/bar", "--install-scripts=/foo/bar/bin"]
     pkg = "pep8"
 
-    expected = [*python_binary, "install"]
+    expected = [*python_binary, "install", *TARGET]
     for item in install_options:
         expected.extend(["--install-option", item])
     expected.append(pkg)
@@ -797,6 +814,7 @@ def test_install_install_options_argument_in_resulting_command(python_binary):
         expected = [
             *python_binary,
             "install",
+            *TARGET,
             "--install-option",
             install_options[0],
             pkg,
@@ -814,7 +832,7 @@ def test_install_global_options_argument_in_resulting_command(python_binary):
     global_options = ["--quiet", "--no-user-cfg"]
     pkg = "pep8"
 
-    expected = [*python_binary, "install"]
+    expected = [*python_binary, "install", *TARGET]
     for item in global_options:
         expected.extend(["--global-option", item])
     expected.append(pkg)
@@ -850,6 +868,7 @@ def test_install_global_options_argument_in_resulting_command(python_binary):
         expected = [
             *python_binary,
             "install",
+            *TARGET,
             "--global-option",
             global_options[0],
             pkg,
@@ -868,7 +887,7 @@ def test_install_upgrade_argument_in_resulting_command(python_binary):
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, upgrade=True)
-        expected = [*python_binary, "install", "--upgrade", pkg]
+        expected = [*python_binary, "install", *TARGET, "--upgrade", pkg]
         mock.assert_called_with(
             expected,
             saltenv="base",
@@ -886,6 +905,7 @@ def test_install_force_reinstall_argument_in_resulting_command(python_binary):
         expected = [
             *python_binary,
             "install",
+            *TARGET,
             "--force-reinstall",
             pkg,
         ]
@@ -906,6 +926,7 @@ def test_install_ignore_installed_argument_in_resulting_command(python_binary):
         expected = [
             *python_binary,
             "install",
+            *TARGET,
             "--ignore-installed",
             pkg,
         ]
@@ -923,7 +944,7 @@ def test_install_no_deps_argument_in_resulting_command(python_binary):
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, no_deps=True)
-        expected = [*python_binary, "install", "--no-deps", pkg]
+        expected = [*python_binary, "install", *TARGET, "--no-deps", pkg]
         mock.assert_called_with(
             expected,
             saltenv="base",
@@ -938,7 +959,7 @@ def test_install_no_install_argument_in_resulting_command(python_binary):
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, no_install=True)
-        expected = [*python_binary, "install", "--no-install", pkg]
+        expected = [*python_binary, "install", *TARGET, "--no-install", pkg]
         mock.assert_called_with(
             expected,
             saltenv="base",
@@ -954,7 +975,7 @@ def test_install_proxy_argument_in_resulting_command(python_binary):
     mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         pip.install(pkg, proxy=proxy)
-        expected = [*python_binary, "install", "--proxy", proxy, pkg]
+        expected = [*python_binary, "install", "--proxy", proxy, *TARGET, pkg]
         mock.assert_called_with(
             expected,
             saltenv="base",
@@ -981,7 +1002,7 @@ def test_install_proxy_false_argument_in_resulting_command(python_binary):
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         with patch.dict(pip.__opts__, config_mock):
             pip.install(pkg, proxy=proxy)
-            expected = [*python_binary, "install", pkg]
+            expected = [*python_binary, "install", *TARGET, pkg]
             mock.assert_called_with(
                 expected,
                 saltenv="base",
@@ -1012,6 +1033,7 @@ def test_install_global_proxy_in_resulting_command(python_binary):
                 "install",
                 "--proxy",
                 proxy,
+                *TARGET,
                 pkg,
             ]
             mock.assert_called_with(
@@ -1032,6 +1054,7 @@ def test_install_multiple_requirements_arguments_in_resulting_command(python_bin
         expected = [*python_binary, "install"]
         for item in cached_reqs:
             expected.extend(["--requirement", item])
+        expected.extend(TARGET)
 
         # Passing option as a list
         mock = MagicMock(return_value={"retcode": 0, "stdout": ""})
@@ -1068,6 +1091,7 @@ def test_install_multiple_requirements_arguments_in_resulting_command(python_bin
                 "install",
                 "--requirement",
                 cached_reqs[0],
+                *TARGET,
             ]
             mock.assert_called_with(
                 expected,
@@ -1088,6 +1112,7 @@ def test_install_extra_args_arguments_in_resulting_command(python_binary):
         expected = [
             *python_binary,
             "install",
+            *TARGET,
             pkg,
             "--latest-pip-kwarg",
             "param",
@@ -1604,7 +1629,7 @@ def test_install_pre_argument_in_resulting_command(python_binary):
     with patch.dict(pip.__salt__, {"cmd.run_all": mock}):
         with patch("salt.modules.pip.version", MagicMock(return_value="1.3")):
             pip.install(pkg, pre_releases=True)
-            expected = [*python_binary, "install", pkg]
+            expected = [*python_binary, "install", *TARGET, pkg]
             mock.assert_called_with(
                 expected,
                 saltenv="base",
@@ -1620,7 +1645,7 @@ def test_install_pre_argument_in_resulting_command(python_binary):
     ):
         with patch("salt.modules.pip._get_pip_bin", MagicMock(return_value=["pip"])):
             pip.install(pkg, pre_releases=True)
-            expected = ["pip", "install", "--pre", pkg]
+            expected = ["pip", "install", *TARGET, "--pre", pkg]
             mock_run_all.assert_called_with(
                 expected,
                 saltenv="base",

--- a/tests/pytests/unit/modules/test_transactional_update.py
+++ b/tests/pytests/unit/modules/test_transactional_update.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 import salt.loader.context
@@ -9,6 +10,10 @@ from tests.support.mock import MagicMock, patch
 pytestmark = [
     pytest.mark.skip_on_windows(reason="Not supported on Windows"),
 ]
+
+SALT_CALL_BINARY = "salt-call"
+if os.environ.get('VIRTUAL_ENV'):
+    SALT_CALL_BINARY = f"{os.environ.get('VIRTUAL_ENV')}/bin/salt-call"
 
 
 @pytest.fixture
@@ -379,7 +384,7 @@ def test_call_fails_function():
                 "--continue",
                 "--quiet",
                 "run",
-                "salt-call",
+                SALT_CALL_BINARY,
                 "--out",
                 "json",
                 "-l",
@@ -411,7 +416,7 @@ def test_call_success_no_reboot():
                 "--continue",
                 "--quiet",
                 "run",
-                "salt-call",
+                SALT_CALL_BINARY,
                 "--out",
                 "json",
                 "-l",
@@ -454,7 +459,7 @@ def test_call_success_reboot():
                 "--continue",
                 "--quiet",
                 "run",
-                "salt-call",
+                SALT_CALL_BINARY,
                 "--out",
                 "json",
                 "-l",
@@ -488,7 +493,7 @@ def test_call_success_parameters():
                 "--continue",
                 "--quiet",
                 "run",
-                "salt-call",
+                SALT_CALL_BINARY,
                 "--out",
                 "json",
                 "-l",

--- a/tests/pytests/unit/states/test_pkgrepo.py
+++ b/tests/pytests/unit/states/test_pkgrepo.py
@@ -1,7 +1,6 @@
 """
     :codeauthor: Tyler Johnson <tjohnson@saltstack.com>
 """
-
 import pytest
 
 import salt.states.pkgrepo as pkgrepo
@@ -390,7 +389,7 @@ def test_migrated_wrong_method():
     with patch.dict(pkgrepo.__grains__, grains), patch.dict(
         pkgrepo.__salt__, salt_mock
     ):
-        assert pkgrepo.migrated("/mnt", method_="magic") == {
+        assert pkgrepo.migrated("/mnt", method="magic") == {
             "name": "/mnt",
             "result": False,
             "changes": {},

--- a/tests/pytests/unit/test_fileserver.py
+++ b/tests/pytests/unit/test_fileserver.py
@@ -75,9 +75,7 @@ def test_file_server_url_escape(tmp_path):
     opts = {
         "fileserver_backend": ["roots"],
         "extension_modules": "",
-        "optimization_order": [
-            0,
-        ],
+        "optimization_order": [0, 1],
         "file_roots": {
             "base": [fileroot],
         },
@@ -102,9 +100,7 @@ def test_file_server_serve_url_escape(tmp_path):
     opts = {
         "fileserver_backend": ["roots"],
         "extension_modules": "",
-        "optimization_order": [
-            0,
-        ],
+        "optimization_order": [0, 1],
         "file_roots": {
             "base": [fileroot],
         },

--- a/tests/pytests/unit/utils/test_gitfs.py
+++ b/tests/pytests/unit/utils/test_gitfs.py
@@ -3,6 +3,7 @@ import time
 
 import pytest
 
+import salt.config
 import salt.fileserver.gitfs
 import salt.utils.gitfs
 from salt.exceptions import FileserverConfigError
@@ -22,6 +23,23 @@ except AttributeError:
 
 if HAS_PYGIT2:
     import pygit2
+
+
+@pytest.fixture
+def minion_opts(tmp_path):
+    """
+    Default minion configuration with relative temporary paths to not require root permissions.
+    """
+    root_dir = tmp_path / "minion"
+    opts = salt.config.DEFAULT_MINION_OPTS.copy()
+    opts["__role"] = "minion"
+    opts["root_dir"] = str(root_dir)
+    for name in ("cachedir", "pki_dir", "sock_dir", "conf_dir"):
+        dirpath = root_dir / name
+        dirpath.mkdir(parents=True)
+        opts[name] = str(dirpath)
+    opts["log_file"] = "logs/minion.log"
+    return opts
 
 
 @pytest.mark.parametrize(

--- a/tests/pytests/unit/utils/test_msgpack.py
+++ b/tests/pytests/unit/utils/test_msgpack.py
@@ -3,7 +3,7 @@ import pytest
 import salt.utils.msgpack
 from tests.support.mock import MagicMock, patch
 
-
+@pytest.mark.skipif(salt.utils.msgpack.version < (1, 0, 0), reason="Test requires msgpack version >= 1.0.0")
 def test_load_encoding(tmp_path):
     """
     test when using msgpack version >= 1.0.0 we

--- a/tests/pytests/unit/utils/test_pycrypto.py
+++ b/tests/pytests/unit/utils/test_pycrypto.py
@@ -57,21 +57,20 @@ def test_gen_hash_crypt(algorithm, expected):
     """
     Test gen_hash with crypt library
     """
-    with patch("salt.utils.pycrypto.methods", {}):
-        ret = salt.utils.pycrypto.gen_hash(
-            crypt_salt=expected["salt"], password=passwd, algorithm=algorithm
-        )
-        assert ret == expected["hashed"]
+    ret = salt.utils.pycrypto.gen_hash(
+        crypt_salt=expected["salt"], password=passwd, algorithm=algorithm
+    )
+    assert ret == expected["hashed"]
 
-        ret = salt.utils.pycrypto.gen_hash(
-            crypt_salt=expected["badsalt"], password=passwd, algorithm=algorithm
-        )
-        assert ret != expected["hashed"]
+    ret = salt.utils.pycrypto.gen_hash(
+        crypt_salt=expected["badsalt"], password=passwd, algorithm=algorithm
+    )
+    assert ret != expected["hashed"]
 
-        ret = salt.utils.pycrypto.gen_hash(
-            crypt_salt=None, password=passwd, algorithm=algorithm
-        )
-        assert ret != expected["hashed"]
+    ret = salt.utils.pycrypto.gen_hash(
+        crypt_salt=None, password=passwd, algorithm=algorithm
+    )
+    assert ret != expected["hashed"]
 
 
 @pytest.mark.skipif(not salt.utils.pycrypto.HAS_CRYPT, reason="crypt not available")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -83,9 +83,12 @@ class SampleConfTest(DefaultConfigsBase, TestCase):
         """
         master_config = SAMPLE_CONF_DIR + "master"
         ret = salt.config._read_conf_file(master_config)
+        # openSUSE modified the default config in
+        # https://github.com/opensuse/salt/commit/6ffbf7fcc178f32c670b177b25ed64658c59f1bf
+        expected_config = {"user": "salt", "syndic_user": "salt"}
         self.assertEqual(
             ret,
-            {},
+            expected_config,
             "Sample config file '{}' must be commented out.".format(master_config),
         )
 
@@ -347,7 +350,10 @@ class ConfigTestCase(TestCase, AdaptedConfigurationTestCaseMixin):
 
         with patched_environ(SALT_MINION_CONFIG=env_fpath):
             # Should load from env variable, not the default configuration file
-            config = salt.config.minion_config("{}/minion".format(CONFIG_DIR))
+            # Override defaults from venv-minion conf
+            defaults = salt.config.DEFAULT_MINION_OPTS.copy()
+            defaults["default_include"] = ""
+            config = salt.config.minion_config("{}/minion".format(CONFIG_DIR), defaults=defaults)
             self.assertEqual(config["log_file"], env_fpath)
 
         root_dir = os.path.join(tempdir, "foo", "bar")
@@ -1946,6 +1952,11 @@ class APIConfigTestCase(DefaultConfigsBase, TestCase):
             if salt.utils.platform.is_windows():
                 expected = "{}\\var\\log\\salt\\api".format(RUNTIME_VARS.TMP_ROOT_DIR)
 
+            if os.environ.get("VIRTUAL_ENV"):
+                # venv bundle configures --salt-logs-dir=%{_localstatedir}/log
+                # in the RPM spec file
+                expected = expected.replace("/salt/api", "/api")
+
             ret = salt.config.api_config("/some/fake/path")
             self.assertEqual(ret["log_file"], expected)
 
@@ -2016,6 +2027,11 @@ class APIConfigTestCase(DefaultConfigsBase, TestCase):
             mock_log = "c:\\mock\\root\\var\\log\\salt\\api"
             mock_pid = "c:\\mock\\root\\var\\run\\salt-api.pid"
             mock_master_config["root_dir"] = "c:\\mock\\root"
+
+        if os.environ.get("VIRTUAL_ENV"):
+            # venv bundle configures --salt-logs-dir=%{_localstatedir}/log
+            # in the RPM spec file
+            mock_log = mock_log.replace("/salt", "")
 
         with patch(
             "salt.config.client_config", MagicMock(return_value=mock_master_config)

--- a/tests/unit/utils/test_sdb.py
+++ b/tests/unit/utils/test_sdb.py
@@ -49,7 +49,7 @@ class SdbTestCase(TestCase, LoaderModuleMockMixin):
     # test with SQLite database write and read
 
     def test_sqlite_get_found(self):
-        expected = {b"name": b"testone", b"number": 46}
+        expected = {"name": "testone", "number": 46}
         sdb.sdb_set("sdb://test_sdb_data/test1", expected, self.sdb_opts)
         resp = sdb.sdb_get("sdb://test_sdb_data/test1", self.sdb_opts)
         self.assertEqual(resp, expected)

--- a/tests/unit/utils/test_templates.py
+++ b/tests/unit/utils/test_templates.py
@@ -1,6 +1,7 @@
 """
 Unit tests for salt.utils.templates.py
 """
+
 import logging
 import os
 import sys
@@ -21,6 +22,20 @@ try:
     HAS_CHEETAH = True
 except ImportError:
     HAS_CHEETAH = False
+
+try:
+    import genshi as _
+
+    HAS_GENSHI = True
+except ImportError:
+    HAS_GENSHI = False
+
+try:
+    import mako as _
+
+    HAS_MAKO = True
+except ImportError:
+    HAS_MAKO = False
 
 log = logging.getLogger(__name__)
 
@@ -83,16 +98,19 @@ class RenderTestCase(TestCase):
         assert res == expected
 
     ### Tests for mako template
+    @pytest.mark.skipif(not HAS_MAKO, reason="Mako module not available for testing")
     def test_render_mako_sanity(self):
         tmpl = """OK"""
         res = salt.utils.templates.render_mako_tmpl(tmpl, dict(self.context))
         self.assertEqual(res, "OK")
 
+    @pytest.mark.skipif(not HAS_MAKO, reason="Mako module not available for testing")
     def test_render_mako_evaluate(self):
         tmpl = """${ "OK" }"""
         res = salt.utils.templates.render_mako_tmpl(tmpl, dict(self.context))
         self.assertEqual(res, "OK")
 
+    @pytest.mark.skipif(not HAS_MAKO, reason="Mako module not available for testing")
     def test_render_mako_evaluate_multi(self):
         tmpl = """
         % if 1:
@@ -103,6 +121,7 @@ class RenderTestCase(TestCase):
         stripped = res.strip()
         self.assertEqual(stripped, "OK")
 
+    @pytest.mark.skipif(not HAS_MAKO, reason="Mako module not available for testing")
     def test_render_mako_variable(self):
         tmpl = """${ var }"""
 
@@ -152,21 +171,33 @@ class RenderTestCase(TestCase):
         self.assertEqual(res, "OK")
 
     ### Tests for genshi template (xml-based)
+    @pytest.mark.skipif(
+        not HAS_GENSHI, reason="Genshi module not available for testing"
+    )
     def test_render_genshi_sanity(self):
         tmpl = """<RU>OK</RU>"""
         res = salt.utils.templates.render_genshi_tmpl(tmpl, dict(self.context))
         self.assertEqual(res, "<RU>OK</RU>")
 
+    @pytest.mark.skipif(
+        not HAS_GENSHI, reason="Genshi module not available for testing"
+    )
     def test_render_genshi_evaluate(self):
         tmpl = """<RU>${ "OK" }</RU>"""
         res = salt.utils.templates.render_genshi_tmpl(tmpl, dict(self.context))
         self.assertEqual(res, "<RU>OK</RU>")
 
+    @pytest.mark.skipif(
+        not HAS_GENSHI, reason="Genshi module not available for testing"
+    )
     def test_render_genshi_evaluate_condition(self):
         tmpl = """<RU xmlns:py="http://genshi.edgewall.org/" py:if="1">OK</RU>"""
         res = salt.utils.templates.render_genshi_tmpl(tmpl, dict(self.context))
         self.assertEqual(res, "<RU>OK</RU>")
 
+    @pytest.mark.skipif(
+        not HAS_GENSHI, reason="Genshi module not available for testing"
+    )
     def test_render_genshi_variable(self):
         tmpl = """<RU>$var</RU>"""
 
@@ -175,6 +206,9 @@ class RenderTestCase(TestCase):
         res = salt.utils.templates.render_genshi_tmpl(tmpl, ctx)
         self.assertEqual(res, "<RU>OK</RU>")
 
+    @pytest.mark.skipif(
+        not HAS_GENSHI, reason="Genshi module not available for testing"
+    )
     def test_render_genshi_variable_replace(self):
         tmpl = """<RU xmlns:py="http://genshi.edgewall.org/" py:content="var">not ok</RU>"""
 


### PR DESCRIPTION
### What does this PR do?

In this PR, we fix the `test_pip` and `test_fileserver` tests to be compatible with venv minion bundle.

This PR is a part of https://github.com/SUSE/spacewalk/issues/23536.

NOTE: This change includes the following commit: https://github.com/openSUSE/salt/pull/662/commits/96391b8784f24fe79b576dfd94fd994502583e04

This commit will be reverted before merging. The commit modifies the skip list temporarily to actually test the modified tests.

In https://raw.githubusercontent.com/openSUSE/salt-test-skiplist/testing-failing-tests/skipped_tests.toml, I have commented out tests that are fixed by this PR for better readability. 

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
