### PR TITLE
Make minion reconnecting on changing master IP (bsc#1228182)

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -271,9 +271,8 @@
 #ping_interval: 0
 
 # To auto recover minions if master changes IP address (DDNS)
-#    auth_tries: 10
-#    auth_safemode: True
-#    ping_interval: 2
+#    master_alive_interval: 10
+#    master_tries: -1
 #
 # Minions won't know master is missing until a ping fails. After the ping fail,
 # the minion will attempt authentication and likely fails out and cause a restart.

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -291,7 +291,9 @@ Default: ``0``
 
 Configures how often, in seconds, the minion will verify that the current
 master is alive and responding.  The minion will try to establish a connection
-to the next master in the list if it finds the existing one is dead.
+to the next master in the list if it finds the existing one is dead. This
+setting can also be used to detect master DNS record changes when a minion has
+been disconnected.
 
 .. code-block:: yaml
 

--- a/salt/channel/client.py
+++ b/salt/channel/client.py
@@ -385,8 +385,6 @@ class AsyncPubChannel:
             # else take the relayed publish_port master reports
             else:
                 publish_port = self.auth.creds["publish_port"]
-            # TODO: The zeromq transport does not use connect_callback and
-            # disconnect_callback.
             yield self.transport.connect(
                 publish_port, self.connect_callback, self.disconnect_callback
             )

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -1271,7 +1271,7 @@ DEFAULT_MINION_OPTS = immutabletypes.freeze(
         "username": None,
         "password": None,
         "zmq_filtering": False,
-        "zmq_monitor": False,
+        "zmq_monitor": True,
         "cache_sreqs": True,
         "cmd_safe": True,
         "sudo_user": "",

--- a/salt/config/__init__.py
+++ b/salt/config/__init__.py
@@ -74,7 +74,7 @@ elif salt.utils.platform.is_darwin():
 else:
     _DFLT_IPC_MODE = "ipc"
     _DFLT_FQDNS_GRAINS = False
-    _MASTER_TRIES = 1
+    _MASTER_TRIES = -1
     _MASTER_USER = salt.utils.user.get_user()
 
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2743,9 +2743,60 @@ class Minion(MinionBase):
                 # we are not connected anymore
                 self.connected = False
                 log.info("Connection to master %s lost", self.opts["master"])
+                if self.opts["transport"] != "tcp":
+                    self.schedule.delete_job(name=master_event(type="alive"))
 
-                if self.opts["master_type"] != "failover":
-                    # modify the scheduled job to fire on reconnect
+                log.info("Trying to tune in to next master from master-list")
+
+                if hasattr(self, "pub_channel"):
+                    self.pub_channel.on_recv(None)
+                    if hasattr(self.pub_channel, "auth"):
+                        self.pub_channel.auth.invalidate()
+                    if hasattr(self.pub_channel, "close"):
+                        self.pub_channel.close()
+                if hasattr(self, "req_channel") and self.req_channel:
+                    self.req_channel.close()
+                    self.req_channel = None
+
+                # if eval_master finds a new master for us, self.connected
+                # will be True again on successful master authentication
+                try:
+                    master, self.pub_channel = yield self.eval_master(
+                        opts=self.opts,
+                        failed=True,
+                        failback=tag.startswith(master_event(type="failback")),
+                    )
+                except SaltClientError:
+                    pass
+
+                if self.connected:
+                    self.opts["master"] = master
+
+                    # re-init the subsystems to work with the new master
+                    log.info(
+                        "Re-initialising subsystems for new master %s",
+                        self.opts["master"],
+                    )
+
+                    self.req_channel = salt.channel.client.AsyncReqChannel.factory(
+                        self.opts, io_loop=self.io_loop
+                    )
+
+                    # put the current schedule into the new loaders
+                    self.opts["schedule"] = self.schedule.option("schedule")
+                    (
+                        self.functions,
+                        self.returners,
+                        self.function_errors,
+                        self.executors,
+                    ) = self._load_modules()
+                    # make the schedule to use the new 'functions' loader
+                    self.schedule.functions = self.functions
+                    self.pub_channel.on_recv(self._handle_payload)
+                    self._fire_master_minion_start()
+                    log.info("Minion is ready to receive requests!")
+
+                    # update scheduled job to run with the new master addr
                     if self.opts["transport"] != "tcp":
                         schedule = {
                             "function": "status.master",
@@ -2755,116 +2806,35 @@ class Minion(MinionBase):
                             "return_job": False,
                             "kwargs": {
                                 "master": self.opts["master"],
-                                "connected": False,
+                                "connected": True,
                             },
                         }
                         self.schedule.modify_job(
                             name=master_event(type="alive", master=self.opts["master"]),
                             schedule=schedule,
                         )
+
+                        if self.opts["master_failback"] and "master_list" in self.opts:
+                            if self.opts["master"] != self.opts["master_list"][0]:
+                                schedule = {
+                                    "function": "status.ping_master",
+                                    "seconds": self.opts["master_failback_interval"],
+                                    "jid_include": True,
+                                    "maxrunning": 1,
+                                    "return_job": False,
+                                    "kwargs": {"master": self.opts["master_list"][0]},
+                                }
+                                self.schedule.modify_job(
+                                    name=master_event(type="failback"),
+                                    schedule=schedule,
+                                )
+                            else:
+                                self.schedule.delete_job(
+                                    name=master_event(type="failback"), persist=True
+                                )
                 else:
-                    # delete the scheduled job to don't interfere with the failover process
-                    if self.opts["transport"] != "tcp":
-                        self.schedule.delete_job(name=master_event(type="alive"))
-
-                    log.info("Trying to tune in to next master from master-list")
-
-                    if hasattr(self, "pub_channel"):
-                        self.pub_channel.on_recv(None)
-                        if hasattr(self.pub_channel, "auth"):
-                            self.pub_channel.auth.invalidate()
-                        if hasattr(self.pub_channel, "close"):
-                            self.pub_channel.close()
-                        del self.pub_channel
-
-                    # if eval_master finds a new master for us, self.connected
-                    # will be True again on successful master authentication
-                    try:
-                        master, self.pub_channel = yield self.eval_master(
-                            opts=self.opts,
-                            failed=True,
-                            failback=tag.startswith(master_event(type="failback")),
-                        )
-                    except SaltClientError:
-                        pass
-
-                    if self.connected:
-                        self.opts["master"] = master
-
-                        # re-init the subsystems to work with the new master
-                        log.info(
-                            "Re-initialising subsystems for new master %s",
-                            self.opts["master"],
-                        )
-
-                        self.req_channel = (
-                            salt.transport.client.AsyncReqChannel.factory(
-                                self.opts, io_loop=self.io_loop
-                            )
-                        )
-
-                        # put the current schedule into the new loaders
-                        self.opts["schedule"] = self.schedule.option("schedule")
-                        (
-                            self.functions,
-                            self.returners,
-                            self.function_errors,
-                            self.executors,
-                        ) = self._load_modules()
-                        # make the schedule to use the new 'functions' loader
-                        self.schedule.functions = self.functions
-                        self.pub_channel.on_recv(self._handle_payload)
-                        self._fire_master_minion_start()
-                        log.info("Minion is ready to receive requests!")
-
-                        # update scheduled job to run with the new master addr
-                        if self.opts["transport"] != "tcp":
-                            schedule = {
-                                "function": "status.master",
-                                "seconds": self.opts["master_alive_interval"],
-                                "jid_include": True,
-                                "maxrunning": 1,
-                                "return_job": False,
-                                "kwargs": {
-                                    "master": self.opts["master"],
-                                    "connected": True,
-                                },
-                            }
-                            self.schedule.modify_job(
-                                name=master_event(
-                                    type="alive", master=self.opts["master"]
-                                ),
-                                schedule=schedule,
-                            )
-
-                            if (
-                                self.opts["master_failback"]
-                                and "master_list" in self.opts
-                            ):
-                                if self.opts["master"] != self.opts["master_list"][0]:
-                                    schedule = {
-                                        "function": "status.ping_master",
-                                        "seconds": self.opts[
-                                            "master_failback_interval"
-                                        ],
-                                        "jid_include": True,
-                                        "maxrunning": 1,
-                                        "return_job": False,
-                                        "kwargs": {
-                                            "master": self.opts["master_list"][0]
-                                        },
-                                    }
-                                    self.schedule.modify_job(
-                                        name=master_event(type="failback"),
-                                        schedule=schedule,
-                                    )
-                                else:
-                                    self.schedule.delete_job(
-                                        name=master_event(type="failback"), persist=True
-                                    )
-                    else:
-                        self.restart = True
-                        self.io_loop.stop()
+                    self.restart = True
+                    self.io_loop.stop()
 
         elif tag.startswith(master_event(type="connected")):
             # handle this event only once. otherwise it will pollute the log

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2797,7 +2797,10 @@ class Minion(MinionBase):
                     log.info("Minion is ready to receive requests!")
 
                     # update scheduled job to run with the new master addr
-                    if self.opts["transport"] != "tcp":
+                    if (
+                        self.opts["transport"] != "tcp"
+                        and self.opts["master_alive_interval"] > 0
+                    ):
                         schedule = {
                             "function": "status.master",
                             "seconds": self.opts["master_alive_interval"],
@@ -2846,7 +2849,10 @@ class Minion(MinionBase):
                 self.connected = True
                 # modify the __master_alive job to only fire,
                 # if the connection is lost again
-                if self.opts["transport"] != "tcp":
+                if (
+                    self.opts["transport"] != "tcp"
+                    and self.opts["master_alive_interval"] > 0
+                ):
                     schedule = {
                         "function": "status.master",
                         "seconds": self.opts["master_alive_interval"],

--- a/tests/pytests/scenarios/dns/conftest.py
+++ b/tests/pytests/scenarios/dns/conftest.py
@@ -7,6 +7,11 @@ import pytest
 log = logging.getLogger(__name__)
 
 
+@pytest.fixture(scope="package")
+def master_alive_interval():
+    return 5
+
+
 class HostsFile:
     """
     Simple helper class for tests that need to modify /etc/hosts.
@@ -70,7 +75,7 @@ def salt_cli(master):
 
 
 @pytest.fixture(scope="package")
-def minion(master):
+def minion(master, master_alive_interval):
     config_defaults = {
         "transport": master.config["transport"],
     }
@@ -78,9 +83,7 @@ def minion(master):
     config_overrides = {
         "master": f"master.local:{port}",
         "publish_port": master.config["publish_port"],
-        "master_alive_interval": 5,
-        "master_tries": -1,
-        "auth_safemode": False,
+        "master_alive_interval": master_alive_interval,
     }
     factory = master.salt_minion_daemon(
         "minion",

--- a/tests/pytests/scenarios/dns/conftest.py
+++ b/tests/pytests/scenarios/dns/conftest.py
@@ -45,7 +45,11 @@ def etc_hosts():
 @pytest.fixture(scope="package")
 def master(request, salt_factories):
 
-    subprocess.check_output(["ip", "addr", "add", "172.16.0.1/32", "dev", "lo"])
+    try:
+        subprocess.check_output(["ip", "addr", "add", "172.16.0.1/32", "dev", "lo"])
+        ip_addr_set = True
+    except subprocess.CalledProcessError:
+        ip_addr_set = False
 
     config_defaults = {
         "open_mode": True,
@@ -60,6 +64,7 @@ def master(request, salt_factories):
         overrides=config_overrides,
         extra_cli_arguments_after_first_start_failure=["--log-level=info"],
     )
+    factory.ip_addr_set = ip_addr_set
     with factory.started(start_timeout=180):
         yield factory
 

--- a/tests/pytests/scenarios/dns/conftest.py
+++ b/tests/pytests/scenarios/dns/conftest.py
@@ -1,0 +1,91 @@
+import logging
+import pathlib
+import subprocess
+
+import pytest
+
+log = logging.getLogger(__name__)
+
+
+class HostsFile:
+    """
+    Simple helper class for tests that need to modify /etc/hosts.
+    """
+
+    def __init__(self, path, orig_text):
+        self._path = path
+        self._orig_text = orig_text
+
+    @property
+    def orig_text(self):
+        return self._orig_text
+
+    def __getattr__(self, key):
+        if key in ["_path", "_orig_text", "orig_text"]:
+            return self.__getattribute__(key)
+        return getattr(self._path, key)
+
+
+@pytest.fixture
+def etc_hosts():
+    hosts = pathlib.Path("/etc/hosts")
+    orig_text = hosts.read_text(encoding="utf-8")
+    hosts = HostsFile(hosts, orig_text)
+    try:
+        yield hosts
+    finally:
+        hosts.write_text(orig_text)
+
+
+@pytest.fixture(scope="package")
+def master(request, salt_factories):
+
+    subprocess.check_output(["ip", "addr", "add", "172.16.0.1/32", "dev", "lo"])
+
+    config_defaults = {
+        "open_mode": True,
+        "transport": request.config.getoption("--transport"),
+    }
+    config_overrides = {
+        "interface": "0.0.0.0",
+    }
+    factory = salt_factories.salt_master_daemon(
+        "master",
+        defaults=config_defaults,
+        overrides=config_overrides,
+        extra_cli_arguments_after_first_start_failure=["--log-level=info"],
+    )
+    with factory.started(start_timeout=180):
+        yield factory
+
+    try:
+        subprocess.check_output(["ip", "addr", "del", "172.16.0.1/32", "dev", "lo"])
+    except subprocess.CalledProcessError:
+        pass
+
+
+@pytest.fixture(scope="package")
+def salt_cli(master):
+    return master.salt_cli(timeout=180)
+
+
+@pytest.fixture(scope="package")
+def minion(master):
+    config_defaults = {
+        "transport": master.config["transport"],
+    }
+    port = master.config["ret_port"]
+    config_overrides = {
+        "master": f"master.local:{port}",
+        "publish_port": master.config["publish_port"],
+        "master_alive_interval": 5,
+        "master_tries": -1,
+        "auth_safemode": False,
+    }
+    factory = master.salt_minion_daemon(
+        "minion",
+        defaults=config_defaults,
+        overrides=config_overrides,
+        extra_cli_arguments_after_first_start_failure=["--log-level=info"],
+    )
+    return factory

--- a/tests/pytests/scenarios/dns/multimaster/conftest.py
+++ b/tests/pytests/scenarios/dns/multimaster/conftest.py
@@ -86,67 +86,26 @@ def mm_master_2_salt_cli(salt_mm_master_2):
 
 
 @pytest.fixture(scope="package")
-def salt_mm_minion_1(salt_mm_master_1, salt_mm_master_2):
+def salt_mm_minion_1(salt_mm_master_1, salt_mm_master_2, master_alive_interval):
     config_defaults = {
         "transport": salt_mm_master_1.config["transport"],
     }
 
     mm_master_1_port = salt_mm_master_1.config["ret_port"]
-    # mm_master_1_addr = salt_mm_master_1.config["interface"]
     mm_master_2_port = salt_mm_master_2.config["ret_port"]
-    # mm_master_2_addr = salt_mm_master_2.config["interface"]
     config_overrides = {
         "master": [
             f"master1.local:{mm_master_1_port}",
             f"master2.local:{mm_master_2_port}",
         ],
         "publish_port": salt_mm_master_1.config["publish_port"],
-        # "master_type": "failover",
-        "master_alive_interval": 5,
+        "master_alive_interval": master_alive_interval,
         "master_tries": -1,
         "verify_master_pubkey_sign": True,
-        "retry_dns": 1,
+        "retry_dns": True,
     }
     factory = salt_mm_master_1.salt_minion_daemon(
         "mm-minion-1",
-        defaults=config_defaults,
-        overrides=config_overrides,
-        extra_cli_arguments_after_first_start_failure=["--log-level=info"],
-    )
-    # Need to grab the public signing key from the master, either will do
-    shutil.copyfile(
-        os.path.join(salt_mm_master_1.config["pki_dir"], "master_sign.pub"),
-        os.path.join(factory.config["pki_dir"], "master_sign.pub"),
-    )
-    # with factory.started(start_timeout=180):
-    yield factory
-
-
-@pytest.fixture(scope="package")
-def salt_mm_minion_2(salt_mm_master_1, salt_mm_master_2):
-    config_defaults = {
-        "transport": salt_mm_master_1.config["transport"],
-    }
-
-    mm_master_1_port = salt_mm_master_1.config["ret_port"]
-    mm_master_1_addr = salt_mm_master_1.config["interface"]
-    mm_master_2_port = salt_mm_master_2.config["ret_port"]
-    mm_master_2_addr = salt_mm_master_2.config["interface"]
-    # We put the second master first in the list so it has the right startup checks every time.
-    config_overrides = {
-        "master": [
-            f"{mm_master_2_addr}:{mm_master_2_port}",
-            f"{mm_master_1_addr}:{mm_master_1_port}",
-        ],
-        "publish_port": salt_mm_master_1.config["publish_port"],
-        "master_type": "failover",
-        "master_alive_interval": 5,
-        "master_tries": -1,
-        "verify_master_pubkey_sign": True,
-        "retry_dns": 1,
-    }
-    factory = salt_mm_master_2.salt_minion_daemon(
-        "mm-failover-minion-2",
         defaults=config_defaults,
         overrides=config_overrides,
         extra_cli_arguments_after_first_start_failure=["--log-level=info"],

--- a/tests/pytests/scenarios/dns/multimaster/conftest.py
+++ b/tests/pytests/scenarios/dns/multimaster/conftest.py
@@ -1,0 +1,160 @@
+import logging
+import os
+import shutil
+import subprocess
+
+import pytest
+
+log = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="package")
+def salt_mm_master_1(request, salt_factories):
+
+    subprocess.check_output(["ip", "addr", "add", "172.16.0.1/32", "dev", "lo"])
+
+    config_defaults = {
+        "open_mode": True,
+        "transport": request.config.getoption("--transport"),
+    }
+    config_overrides = {
+        "interface": "0.0.0.0",
+        "master_sign_pubkey": True,
+    }
+    factory = salt_factories.salt_master_daemon(
+        "mm-master-1",
+        defaults=config_defaults,
+        overrides=config_overrides,
+        extra_cli_arguments_after_first_start_failure=["--log-level=info"],
+    )
+    try:
+        with factory.started(start_timeout=180):
+            yield factory
+    finally:
+
+        try:
+            subprocess.check_output(["ip", "addr", "del", "172.16.0.1/32", "dev", "lo"])
+        except subprocess.CalledProcessError:
+            pass
+
+
+@pytest.fixture(scope="package")
+def mm_master_1_salt_cli(salt_mm_master_1):
+    return salt_mm_master_1.salt_cli(timeout=180)
+
+
+@pytest.fixture(scope="package")
+def salt_mm_master_2(salt_factories, salt_mm_master_1):
+    # if salt.utils.platform.is_darwin() or salt.utils.platform.is_freebsd():
+    #    subprocess.check_output(["ifconfig", "lo0", "alias", "127.0.0.2", "up"])
+
+    config_defaults = {
+        "open_mode": True,
+        "transport": salt_mm_master_1.config["transport"],
+    }
+    config_overrides = {
+        "interface": "0.0.0.0",
+        "master_sign_pubkey": True,
+    }
+
+    # Use the same ports for both masters, they are binding to different interfaces
+    for key in (
+        "ret_port",
+        "publish_port",
+    ):
+        config_overrides[key] = salt_mm_master_1.config[key] + 1
+    factory = salt_factories.salt_master_daemon(
+        "mm-master-2",
+        defaults=config_defaults,
+        overrides=config_overrides,
+        extra_cli_arguments_after_first_start_failure=["--log-level=info"],
+    )
+
+    # Both masters will share the same signing key pair
+    for keyfile in ("master_sign.pem", "master_sign.pub"):
+        shutil.copyfile(
+            os.path.join(salt_mm_master_1.config["pki_dir"], keyfile),
+            os.path.join(factory.config["pki_dir"], keyfile),
+        )
+    with factory.started(start_timeout=180):
+        yield factory
+
+
+@pytest.fixture(scope="package")
+def mm_master_2_salt_cli(salt_mm_master_2):
+    return salt_mm_master_2.salt_cli(timeout=180)
+
+
+@pytest.fixture(scope="package")
+def salt_mm_minion_1(salt_mm_master_1, salt_mm_master_2):
+    config_defaults = {
+        "transport": salt_mm_master_1.config["transport"],
+    }
+
+    mm_master_1_port = salt_mm_master_1.config["ret_port"]
+    # mm_master_1_addr = salt_mm_master_1.config["interface"]
+    mm_master_2_port = salt_mm_master_2.config["ret_port"]
+    # mm_master_2_addr = salt_mm_master_2.config["interface"]
+    config_overrides = {
+        "master": [
+            f"master1.local:{mm_master_1_port}",
+            f"master2.local:{mm_master_2_port}",
+        ],
+        "publish_port": salt_mm_master_1.config["publish_port"],
+        # "master_type": "failover",
+        "master_alive_interval": 5,
+        "master_tries": -1,
+        "verify_master_pubkey_sign": True,
+        "retry_dns": 1,
+    }
+    factory = salt_mm_master_1.salt_minion_daemon(
+        "mm-minion-1",
+        defaults=config_defaults,
+        overrides=config_overrides,
+        extra_cli_arguments_after_first_start_failure=["--log-level=info"],
+    )
+    # Need to grab the public signing key from the master, either will do
+    shutil.copyfile(
+        os.path.join(salt_mm_master_1.config["pki_dir"], "master_sign.pub"),
+        os.path.join(factory.config["pki_dir"], "master_sign.pub"),
+    )
+    # with factory.started(start_timeout=180):
+    yield factory
+
+
+@pytest.fixture(scope="package")
+def salt_mm_minion_2(salt_mm_master_1, salt_mm_master_2):
+    config_defaults = {
+        "transport": salt_mm_master_1.config["transport"],
+    }
+
+    mm_master_1_port = salt_mm_master_1.config["ret_port"]
+    mm_master_1_addr = salt_mm_master_1.config["interface"]
+    mm_master_2_port = salt_mm_master_2.config["ret_port"]
+    mm_master_2_addr = salt_mm_master_2.config["interface"]
+    # We put the second master first in the list so it has the right startup checks every time.
+    config_overrides = {
+        "master": [
+            f"{mm_master_2_addr}:{mm_master_2_port}",
+            f"{mm_master_1_addr}:{mm_master_1_port}",
+        ],
+        "publish_port": salt_mm_master_1.config["publish_port"],
+        "master_type": "failover",
+        "master_alive_interval": 5,
+        "master_tries": -1,
+        "verify_master_pubkey_sign": True,
+        "retry_dns": 1,
+    }
+    factory = salt_mm_master_2.salt_minion_daemon(
+        "mm-failover-minion-2",
+        defaults=config_defaults,
+        overrides=config_overrides,
+        extra_cli_arguments_after_first_start_failure=["--log-level=info"],
+    )
+    # Need to grab the public signing key from the master, either will do
+    shutil.copyfile(
+        os.path.join(salt_mm_master_1.config["pki_dir"], "master_sign.pub"),
+        os.path.join(factory.config["pki_dir"], "master_sign.pub"),
+    )
+    # with factory.started(start_timeout=180):
+    yield factory

--- a/tests/pytests/scenarios/dns/multimaster/conftest.py
+++ b/tests/pytests/scenarios/dns/multimaster/conftest.py
@@ -11,7 +11,11 @@ log = logging.getLogger(__name__)
 @pytest.fixture(scope="package")
 def salt_mm_master_1(request, salt_factories):
 
-    subprocess.check_output(["ip", "addr", "add", "172.16.0.1/32", "dev", "lo"])
+    try:
+        subprocess.check_output(["ip", "addr", "add", "172.16.0.1/32", "dev", "lo"])
+        ip_addr_set = True
+    except subprocess.CalledProcessError:
+        ip_addr_set = False
 
     config_defaults = {
         "open_mode": True,
@@ -27,6 +31,7 @@ def salt_mm_master_1(request, salt_factories):
         overrides=config_overrides,
         extra_cli_arguments_after_first_start_failure=["--log-level=info"],
     )
+    factory.ip_addr_set = ip_addr_set
     try:
         with factory.started(start_timeout=180):
             yield factory

--- a/tests/pytests/scenarios/dns/multimaster/test_dns.py
+++ b/tests/pytests/scenarios/dns/multimaster/test_dns.py
@@ -22,6 +22,9 @@ def test_multimaster_dns(
     dns change if it's been disconnected.
     """
 
+    if not salt_mm_master_1.ip_addr_set:
+        pytest.skip("Unable to set additional IP address for master1")
+
     etc_hosts.write_text(
         f"{etc_hosts.orig_text}\n172.16.0.1    master1.local master2.local"
     )

--- a/tests/pytests/scenarios/dns/multimaster/test_dns.py
+++ b/tests/pytests/scenarios/dns/multimaster/test_dns.py
@@ -1,0 +1,43 @@
+import logging
+import subprocess
+import time
+
+import pytest
+
+log = logging.getLogger(__name__)
+
+
+@pytest.mark.skip_unless_on_linux
+def test_multimaster_dns(
+    salt_mm_master_1, salt_mm_minion_1, mm_master_1_salt_cli, etc_hosts, caplog
+):
+    """
+    Verify a minion configured with multimaster hot/hot will pick up a master's
+    dns change if it's been disconnected.
+    """
+
+    etc_hosts.write_text(
+        f"{etc_hosts.orig_text}\n172.16.0.1    master1.local master2.local"
+    )
+
+    log.info("Added hosts record for master1.local and master2.local")
+
+    with salt_mm_minion_1.started(start_timeout=180):
+        with caplog.at_level(logging.INFO):
+            ret = mm_master_1_salt_cli.run("test.ping", minion_tgt="mm-minion-1")
+            assert ret.returncode == 0
+            log.info("Removing secondary master IP address.")
+            etc_hosts.write_text(
+                f"{etc_hosts.orig_text}\n127.0.0.1    master1.local master2.local"
+            )
+            subprocess.check_output(["ip", "addr", "del", "172.16.0.1/32", "dev", "lo"])
+            log.info("Changed hosts record for master1.local and master2.local")
+            time.sleep(15)
+            assert (
+                "Master ip address changed from 172.16.0.1 to 127.0.0.1" in caplog.text
+            )
+            ret = mm_master_1_salt_cli.run("test.ping", minion_tgt="mm-minion-1")
+            assert ret.returncode == 0
+            assert (
+                "Master ip address changed from 172.16.0.1 to 127.0.0.1" in caplog.text
+            )

--- a/tests/pytests/scenarios/dns/multimaster/test_dns.py
+++ b/tests/pytests/scenarios/dns/multimaster/test_dns.py
@@ -9,7 +9,12 @@ log = logging.getLogger(__name__)
 
 @pytest.mark.skip_unless_on_linux
 def test_multimaster_dns(
-    salt_mm_master_1, salt_mm_minion_1, mm_master_1_salt_cli, etc_hosts, caplog
+    salt_mm_master_1,
+    salt_mm_minion_1,
+    mm_master_1_salt_cli,
+    etc_hosts,
+    caplog,
+    master_alive_interval,
 ):
     """
     Verify a minion configured with multimaster hot/hot will pick up a master's
@@ -26,13 +31,15 @@ def test_multimaster_dns(
         with caplog.at_level(logging.INFO):
             ret = mm_master_1_salt_cli.run("test.ping", minion_tgt="mm-minion-1")
             assert ret.returncode == 0
-            log.info("Removing secondary master IP address.")
             etc_hosts.write_text(
                 f"{etc_hosts.orig_text}\n127.0.0.1    master1.local master2.local"
             )
-            subprocess.check_output(["ip", "addr", "del", "172.16.0.1/32", "dev", "lo"])
             log.info("Changed hosts record for master1.local and master2.local")
-            time.sleep(15)
+            subprocess.check_output(["ip", "addr", "del", "172.16.0.1/32", "dev", "lo"])
+            log.info("Removed secondary master IP address.")
+            # Wait for the minion's master_alive_interval, adding a second for
+            # reliablity.
+            time.sleep(master_alive_interval + 1)
             assert (
                 "Master ip address changed from 172.16.0.1 to 127.0.0.1" in caplog.text
             )

--- a/tests/pytests/scenarios/dns/multimaster/test_dns.py
+++ b/tests/pytests/scenarios/dns/multimaster/test_dns.py
@@ -8,6 +8,7 @@ log = logging.getLogger(__name__)
 
 
 @pytest.mark.skip_unless_on_linux
+@pytest.mark.skip_if_not_root
 def test_multimaster_dns(
     salt_mm_master_1,
     salt_mm_minion_1,

--- a/tests/pytests/scenarios/dns/test_dns.py
+++ b/tests/pytests/scenarios/dns/test_dns.py
@@ -8,6 +8,7 @@ log = logging.getLogger(__name__)
 
 
 @pytest.mark.skip_unless_on_linux
+@pytest.mark.skip_if_not_root
 def test_dns_change(master, minion, salt_cli, etc_hosts, caplog, master_alive_interval):
     """
     Verify a minion will pick up a master's dns change if it's been disconnected.

--- a/tests/pytests/scenarios/dns/test_dns.py
+++ b/tests/pytests/scenarios/dns/test_dns.py
@@ -1,0 +1,29 @@
+import logging
+import subprocess
+import time
+
+import pytest
+
+log = logging.getLogger(__name__)
+
+
+@pytest.mark.skip_unless_on_linux
+def test_dns_change(master, minion, salt_cli, etc_hosts, caplog):
+    """
+    Verify a minion will pick up a master's dns change if it's been disconnected.
+    """
+
+    etc_hosts.write_text(f"{etc_hosts.orig_text}\n172.16.0.1    master.local")
+
+    with minion.started(start_timeout=180):
+        with caplog.at_level(logging.INFO):
+            ret = salt_cli.run("test.ping", minion_tgt="minion")
+            assert ret.returncode == 0
+            etc_hosts.write_text(f"{etc_hosts.orig_text}\n127.0.0.1    master.local")
+            subprocess.check_output(["ip", "addr", "del", "172.16.0.1/32", "dev", "lo"])
+            time.sleep(15)
+            assert (
+                "Master ip address changed from 172.16.0.1 to 127.0.0.1" in caplog.text
+            )
+            ret = salt_cli.run("test.ping", minion_tgt="minion")
+            assert ret.returncode == 0

--- a/tests/pytests/scenarios/dns/test_dns.py
+++ b/tests/pytests/scenarios/dns/test_dns.py
@@ -14,6 +14,9 @@ def test_dns_change(master, minion, salt_cli, etc_hosts, caplog, master_alive_in
     Verify a minion will pick up a master's dns change if it's been disconnected.
     """
 
+    if not master.ip_addr_set:
+        pytest.skip("Unable to set additional IP address for master")
+
     etc_hosts.write_text(f"{etc_hosts.orig_text}\n172.16.0.1    master.local")
 
     with minion.started(start_timeout=180):

--- a/tests/pytests/scenarios/failover/multimaster/test_failover_master.py
+++ b/tests/pytests/scenarios/failover/multimaster/test_failover_master.py
@@ -162,10 +162,6 @@ def test_minions_alive_with_no_master(
     """
     Make sure the minions stay alive after all masters have stopped.
     """
-    if grains["os_family"] == "Debian" and grains["osmajorrelease"] == 9:
-        pytest.skip(
-            "Skipping on Debian 9 until flaky issues resolved. See issue #61749"
-        )
     start_time = time.time()
     with salt_mm_failover_master_1.stopped():
         with salt_mm_failover_master_2.stopped():

--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -884,6 +884,8 @@ async def test_master_type_failover(minion_opts):
         assert opts["master"] == "master2"
         return MockPubChannel()
 
+    minion_opts["master_tries"] = 1
+
     with patch("salt.minion.resolve_dns", mock_resolve_dns), patch(
         "salt.channel.client.AsyncPubChannel.factory", mock_channel_factory
     ), patch("salt.loader.grains", MagicMock(return_value=[])):


### PR DESCRIPTION
### What does this PR do?

Backport of upstream PRs: https://github.com/saltstack/salt/pull/66760, https://github.com/saltstack/salt/pull/66757, https://github.com/saltstack/salt/pull/66422

By default `salt-minion` is not able to detect disconnects from the master as callback is not called on disconnet due to the missing possibility with no zeromq monitor socket.

This PR adds the possibility to detect disconnects and react on it.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/24752, https://github.com/SUSE/spacewalk/issues/24871

### Previous Behavior
The minion is unable to switch to the master with the same FQDN but different IP address as it's not resolving IP address after connecting to the master. ZeroMQ socket is handling reconnects internally, but as it has IP address specified to connect to, it's not trying to resolve it anymore.

### New Behavior
The minion is able to reconnect to the master on it's IP address change.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
