### PR TITLE
test_vultrpy: adjust test expectation to prevent failure

### DIFF
--- a/tests/integration/cloud/clouds/test_vultrpy.py
+++ b/tests/integration/cloud/clouds/test_vultrpy.py
@@ -19,7 +19,7 @@ class VultrTest(CloudTest):
         """
         image_list = self.run_cloud("--list-images {}".format(self.PROVIDER))
 
-        self.assertIn("Debian 10 x64 (buster)", [i.strip() for i in image_list])
+        self.assertIn("Debian 12 x64 (bookworm)", [i.strip() for i in image_list])
 
     def test_list_locations(self):
         """


### PR DESCRIPTION
### What does this PR do?

After  Debian 10 got EOL, this test: `tests/integration/cloud/clouds/test_vultrpy.py::VultrTest::test_list_images` started failing in our Salt Shaker testsuite for all OSes. The tests expectations needs to be adapted.

There is no upstream PR for this, as these tests were dropped from upstream after extensions splitout.

### Merge requirements satisfied?
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
