### PR TITLE
Potential fix Zypperpkg does not use the version parameter #658

### DIFF
--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -2204,7 +2204,7 @@ def remove(
 
 
 def purge(
-    name=None, pkgs=None, root=None, inclusion_detection=False, **kwargs
+    name=None, pkgs=None, version=None, root=None, inclusion_detection=False, **kwargs
 ):  # pylint: disable=unused-argument
     """
     .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
@@ -2254,7 +2254,7 @@ def purge(
         salt '*' pkg.purge <package1>,<package2>,<package3>
         salt '*' pkg.purge pkgs='["foo", "bar"]'
     """
-    return _uninstall(inclusion_detection, name=name, pkgs=pkgs, root=root)
+    return _uninstall(inclusion_detection, name=name, pkgs=pkgs, version=version, root=root)
 
 
 def list_holds(pattern=None, full=True, root=None, **kwargs):

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -2063,13 +2063,13 @@ def upgrade(
     return ret
 
 
-def _uninstall(inclusion_detection, name=None, pkgs=None, root=None):
+def _uninstall(inclusion_detection, name=None, pkgs=None, version=None, root=None):
     """
     Remove and purge do identical things but with different Zypper commands,
     this function performs the common logic.
     """
     try:
-        pkg_params = __salt__["pkg_resource.parse_targets"](name, pkgs)[0]
+        pkg_params = __salt__["pkg_resource.parse_targets"](name, pkgs, version=version)[0]
     except MinionError as exc:
         raise CommandExecutionError(exc)
 
@@ -2147,7 +2147,7 @@ def normalize_name(name):
 
 
 def remove(
-    name=None, pkgs=None, root=None, inclusion_detection=False, **kwargs
+    name=None, pkgs=None, version=None, root=None, inclusion_detection=False, **kwargs
 ):  # pylint: disable=unused-argument
     """
     .. versionchanged:: 2015.8.12,2016.3.3,2016.11.0
@@ -2200,7 +2200,7 @@ def remove(
 
     Can now remove also PTF packages which require a different handling in the backend.
     """
-    return _uninstall(inclusion_detection, name=name, pkgs=pkgs, root=root)
+    return _uninstall(inclusion_detection, name=name, pkgs=pkgs, version=version, root=root)
 
 
 def purge(

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -2891,7 +2891,7 @@ def _uninstall(
 
     try:
         pkg_params = __salt__["pkg_resource.parse_targets"](
-            name, pkgs, normalize=normalize
+            name, pkgs, normalize=normalize, version=version
         )[0]
     except MinionError as exc:
         return {

--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -705,70 +705,7 @@ def certificate_managed(name, days_remaining=90, append_certs=None, **kwargs):
             "Old": invalid_reason,
             "New": "Certificate will be valid and up to date",
         }
-        private_key_args.update(managed_private_key)
-        kwargs["public_key_passphrase"] = private_key_args["passphrase"]
-
-        if private_key_args["new"]:
-            rotate_private_key = True
-            private_key_args["new"] = False
-
-        if _check_private_key(
-            private_key_args["name"],
-            bits=private_key_args["bits"],
-            passphrase=private_key_args["passphrase"],
-            new=private_key_args["new"],
-            overwrite=private_key_args["overwrite"],
-        ):
-            private_key = __salt__["x509.get_pem_entry"](
-                private_key_args["name"], pem_type="RSA PRIVATE KEY"
-            )
-        else:
-            new_private_key = True
-            private_key = __salt__["x509.create_private_key"](
-                text=True,
-                bits=private_key_args["bits"],
-                passphrase=private_key_args["passphrase"],
-                cipher=private_key_args["cipher"],
-                verbose=private_key_args["verbose"],
-            )
-
-        kwargs["public_key"] = private_key
-
-    current_days_remaining = 0
-    current_comp = {}
-
-    if os.path.isfile(name):
-        try:
-            current = __salt__["x509.read_certificate"](certificate=name)
-            current_comp = copy.deepcopy(current)
-            if "serial_number" not in kwargs:
-                current_comp.pop("Serial Number")
-                if "signing_cert" not in kwargs:
-                    try:
-                        current_comp["X509v3 Extensions"][
-                            "authorityKeyIdentifier"
-                        ] = re.sub(
-                            r"serial:([0-9A-F]{2}:)*[0-9A-F]{2}",
-                            "serial:--",
-                            current_comp["X509v3 Extensions"]["authorityKeyIdentifier"],
-                        )
-                    except KeyError:
-                        pass
-            current_comp.pop("Not Before")
-            current_comp.pop("MD5 Finger Print")
-            current_comp.pop("SHA1 Finger Print")
-            current_comp.pop("SHA-256 Finger Print")
-            current_notafter = current_comp.pop("Not After")
-            current_days_remaining = (
-                datetime.datetime.strptime(current_notafter, "%Y-%m-%d %H:%M:%S")
-                - datetime.datetime.now()
-            ).days
-            if days_remaining == 0:
-                days_remaining = current_days_remaining - 1
-        except salt.exceptions.SaltInvocationError:
-            current = "{} is not a valid Certificate.".format(name)
-    else:
-        current = "{} does not exist.".format(name)
+	return ret
 
     contents = __salt__["x509.create_certificate"](text=True, **kwargs)
     # Check the module actually returned a cert and not an error message as a string


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes: #658 

### Previous Behavior
The zypperpkg module does not use the version parameter to remove only that specified package,
 zypperpkg removes the package by using its name, which results in both versions being removed.

### New Behavior
zypperpkg just removes the specific version of the package, will keep other versions of the package.

### Commits signed with GPG?
Yes

This fix reference & based on upstream commit: 
https://github.com/openSUSE/salt/commit/585145f4b382508ef7a6cc6f1cb33697b9a606b8