### PR TITLE
Skip more tests related to old OpenSSL algorithms

### DIFF
--- a/tests/pytests/functional/modules/test_x509_v2.py
+++ b/tests/pytests/functional/modules/test_x509_v2.py
@@ -1400,7 +1400,10 @@ def test_create_csr_raw(x509, rsa_privkey):
 @pytest.mark.slow_test
 @pytest.mark.parametrize("algo", ["rsa", "ec", "ed25519", "ed448"])
 def test_create_private_key(x509, algo):
-    res = x509.create_private_key(algo=algo)
+    try:
+        res = x509.create_private_key(algo=algo)
+    except UnsupportedAlgorithm:
+        pytest.skip(f"Algorithm '{algo}' is not supported on this OpenSSL version")
     assert res.startswith("-----BEGIN PRIVATE KEY-----")
 
 
@@ -1408,7 +1411,10 @@ def test_create_private_key(x509, algo):
 @pytest.mark.parametrize("algo", ["rsa", "ec", "ed25519", "ed448"])
 def test_create_private_key_with_passphrase(x509, algo):
     passphrase = "hunter2"
-    res = x509.create_private_key(algo=algo, passphrase=passphrase)
+    try:
+        res = x509.create_private_key(algo=algo, passphrase=passphrase)
+    except UnsupportedAlgorithm:
+        pytest.skip(f"Algorithm '{algo}' is not supported on this OpenSSL version")
     assert res.startswith("-----BEGIN ENCRYPTED PRIVATE KEY-----")
     # ensure it can be loaded
     x509.get_private_key_size(res, passphrase=passphrase)

--- a/tests/pytests/functional/states/test_x509_v2.py
+++ b/tests/pytests/functional/states/test_x509_v2.py
@@ -6,6 +6,7 @@ import pytest
 try:
     import cryptography
     import cryptography.x509 as cx509
+    from cryptography.exceptions import UnsupportedAlgorithm
     from cryptography.hazmat.primitives import hashes
     from cryptography.hazmat.primitives.asymmetric import ec, ed448, ed25519, rsa
     from cryptography.hazmat.primitives.serialization import (
@@ -2139,7 +2140,10 @@ def test_private_key_managed(x509, pk_args, algo, encoding, passphrase):
     pk_args["algo"] = algo
     pk_args["encoding"] = encoding
     pk_args["passphrase"] = passphrase
-    ret = x509.private_key_managed(**pk_args)
+    try:
+        ret = x509.private_key_managed(**pk_args)
+    except UnsupportedAlgorithm:
+        pytest.skip(f"Algorithm '{algo}' is not supported on this OpenSSL version")
     _assert_pk_basic(ret, algo, encoding, passphrase)
 
 
@@ -2166,7 +2170,10 @@ def test_private_key_managed_keysize(x509, pk_args, algo, keysize):
     indirect=True,
 )
 def test_private_key_managed_existing(x509, pk_args):
-    ret = x509.private_key_managed(**pk_args)
+    try:
+        ret = x509.private_key_managed(**pk_args)
+    except UnsupportedAlgorithm:
+        pytest.skip(f"Algorithm '{pk_args['algo']}' is not supported on this OpenSSL version")
     _assert_not_changed(ret)
 
 
@@ -2193,7 +2200,10 @@ def test_private_key_managed_existing_new_with_passphrase_change(x509, pk_args):
 @pytest.mark.usefixtures("existing_pk")
 def test_private_key_managed_algo_change(x509, pk_args):
     pk_args["algo"] = "ed25519"
-    ret = x509.private_key_managed(**pk_args)
+    try:
+        ret = x509.private_key_managed(**pk_args)
+    except UnsupportedAlgorithm:
+        pytest.skip("Algorithm ed25519 is not supported on this OpenSSL version")
     _assert_pk_basic(ret, "ed25519")
 
 

--- a/tests/pytests/functional/states/test_x509_v2.py
+++ b/tests/pytests/functional/states/test_x509_v2.py
@@ -692,6 +692,8 @@ def existing_csr_exts(x509, csr_args, csr_args_exts, ca_key, rsa_privkey, reques
 def existing_pk(x509, pk_args, request):
     pk_args.update(request.param)
     ret = x509.private_key_managed(**pk_args)
+    if ret.result == False and "UnsupportedAlgorithm" in ret.comment:
+        pytest.skip(f"Algorithm '{pk_args['algo']}' is not supported on this OpenSSL version")
     _assert_pk_basic(
         ret,
         pk_args.get("algo", "rsa"),
@@ -2140,9 +2142,8 @@ def test_private_key_managed(x509, pk_args, algo, encoding, passphrase):
     pk_args["algo"] = algo
     pk_args["encoding"] = encoding
     pk_args["passphrase"] = passphrase
-    try:
-        ret = x509.private_key_managed(**pk_args)
-    except UnsupportedAlgorithm:
+    ret = x509.private_key_managed(**pk_args)
+    if ret.result == False and "UnsupportedAlgorithm" in ret.comment:
         pytest.skip(f"Algorithm '{algo}' is not supported on this OpenSSL version")
     _assert_pk_basic(ret, algo, encoding, passphrase)
 
@@ -2170,9 +2171,8 @@ def test_private_key_managed_keysize(x509, pk_args, algo, keysize):
     indirect=True,
 )
 def test_private_key_managed_existing(x509, pk_args):
-    try:
-        ret = x509.private_key_managed(**pk_args)
-    except UnsupportedAlgorithm:
+    ret = x509.private_key_managed(**pk_args)
+    if ret.result == False and "UnsupportedAlgorithm" in ret.comment:
         pytest.skip(f"Algorithm '{pk_args['algo']}' is not supported on this OpenSSL version")
     _assert_not_changed(ret)
 
@@ -2200,10 +2200,9 @@ def test_private_key_managed_existing_new_with_passphrase_change(x509, pk_args):
 @pytest.mark.usefixtures("existing_pk")
 def test_private_key_managed_algo_change(x509, pk_args):
     pk_args["algo"] = "ed25519"
-    try:
-        ret = x509.private_key_managed(**pk_args)
-    except UnsupportedAlgorithm:
-        pytest.skip("Algorithm ed25519 is not supported on this OpenSSL version")
+    ret = x509.private_key_managed(**pk_args)
+    if ret.result == False and "UnsupportedAlgorithm" in ret.comment:
+        pytest.skip("Algorithm 'ed25519' is not supported on this OpenSSL version")
     _assert_pk_basic(ret, "ed25519")
 
 


### PR DESCRIPTION
### What does this PR do?

There are some more tests failing in the test suite due to old OpenSSL versions that do not support some algorithms like `ed25519`. 

The same approach was followed in https://github.com/openSUSE/salt/pull/646.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/23286

### Previous Behavior
Failing tests on systems with old OpenSSL.

### New Behavior
Unsupported algorithms skipped on systems with old OpenSSL.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
