### PR TITLE
Fix the SELinux context for Salt Minion service (bsc#1219041)

### DIFF
--- a/pkg/common/salt-minion.service
+++ b/pkg/common/salt-minion.service
@@ -9,6 +9,7 @@ Type=notify
 NotifyAccess=all
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-minion
+SELinuxContext=system_u:system_r:unconfined_t:s0
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/old/deb/salt-minion.service
+++ b/pkg/old/deb/salt-minion.service
@@ -8,6 +8,7 @@ KillMode=process
 NotifyAccess=all
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-minion
+SELinuxContext=system_u:system_r:unconfined_t:s0
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/old/suse/salt-minion.service
+++ b/pkg/old/suse/salt-minion.service
@@ -10,6 +10,7 @@ ExecStart=/usr/bin/salt-minion
 KillMode=process
 Restart=on-failure
 RestartSec=15
+SELinuxContext=system_u:system_r:unconfined_t:s0
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/old/suse/salt-minion.service.rhel7
+++ b/pkg/old/suse/salt-minion.service.rhel7
@@ -9,6 +9,7 @@ ExecStart=/usr/bin/salt-minion
 KillMode=process
 Restart=on-failure
 RestartSec=15
+SELinuxContext=system_u:system_r:unconfined_t:s0
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### What does this PR do?

Currently there are no SELinux policies for Salt.

By default, the Salt Minion service runs as `unconfined_service_t` when SELinux is enabled. This works fine in most cases but generates a problem then trying to transition to an `unconfined_t`, i.a. when running `cmd.run env runas=nobody`.

Then we see this denied in audit logs:

```
type=AVC msg=audit(1722870119.142:718): avc:  denied  { transition } for  pid=3421 comm="su" path="/usr/bin/bash" dev="vda3" ino=28565 scontext=system_u:system_r:unconfined_service_t:s0 tcontext=unconfined_u:unconfined_r:unconfined_t:s0 tclass=process permissive=0
```

(This happens for cmd.run at the time of trying to invoke a shell as a different user to gather the environment variables from this particular user)

The issue show produces an ERROR message in the logs but the execution works fine (but the expected environment variables are not really there in place at the time of executing the env)

Fixing the SELinuxContext for the Salt Minion systemd service to a general `unconfined_t` workarounds this situation.

SELinuxContext attribute was added on systemd version 209.

Upstream PR: (not yet)
Tracks: https://github.com/SUSE/spacewalk/issues/23541

### Previous Behavior
```console
# su -c env nobody
[... all expected environment variables ...]

# salt MINION cmd.run env runas=nobody
[... NOT all expected environment variables ..]
```

And denied AVC message on `/var/log/audit.log`.

### New Behavior
```console
# su -c env nobody
[... all expected environment variables ...]

# salt MINION cmd.run env runas=nobody
[... all expected environment variables ...]
``` 

No denied message seen.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
