### PR TITLE
Improve error handling with different OpenSSL versions

### DIFF
--- a/salt/utils/x509.py
+++ b/salt/utils/x509.py
@@ -695,7 +695,8 @@ def load_privkey(pk, passphrase=None, get_encoding=False):
                 return pk, "pem", None
             return pk
         except ValueError as err:
-            if "Bad decrypt" in str(err):
+            str_err = str(err)
+            if "Bad decrypt" in str_err or "Could not deserialize key data" in str_err:
                 raise SaltInvocationError(
                     "Bad decrypt - is the password correct?"
                 ) from err

--- a/tests/pytests/functional/states/test_x509_v2.py
+++ b/tests/pytests/functional/states/test_x509_v2.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import pytest
 
+from tests.support.mock import patch
+
 try:
     import cryptography
     import cryptography.x509 as cx509
@@ -2826,3 +2828,30 @@ def _get_privkey(pk, encoding="pem", passphrase=None):
             pk = base64.b64decode(pk)
         return pkcs12.load_pkcs12(pk, passphrase).key
     raise ValueError("Need correct encoding")
+
+
+@pytest.mark.usefixtures("existing_pk")
+@pytest.mark.parametrize("existing_pk", [{"passphrase": "password"}], indirect=True)
+def test_exceptions_on_calling_load_pem_private_key(x509, pk_args):
+    pk_args["passphrase"] = "hunter1"
+    pk_args["overwrite"] = True
+
+    with patch(
+        "cryptography.hazmat.primitives.serialization.load_pem_private_key",
+        side_effect=ValueError("Bad decrypt. Incorrect password?"),
+    ):
+        ret = x509.private_key_managed(**pk_args)
+    _assert_pk_basic(ret, "rsa", passphrase="hunter1")
+
+    with patch(
+        "cryptography.hazmat.primitives.serialization.load_pem_private_key",
+        side_effect=ValueError(
+            "Could not deserialize key data. The data may be in an incorrect format, "
+            "the provided password may be incorrect, "
+            "it may be encrypted with an unsupported algorithm, "
+            "or it may be an unsupported key type "
+            "(e.g. EC curves with explicit parameters)."
+        ),
+    ):
+        ret = x509.private_key_managed(**pk_args)
+    _assert_pk_basic(ret, "rsa", passphrase="hunter1")

--- a/tests/pytests/integration/states/test_x509_v2.py
+++ b/tests/pytests/integration/states/test_x509_v2.py
@@ -195,6 +195,13 @@ Certificate:
     """
     with x509_salt_master.state_tree.base.temp_file("manage_cert.sls", state):
         ret = x509_salt_call_cli.run("state.apply", "manage_cert")
+        if (
+            ret.returncode == 1
+            and "NotImplementedError: ECDSA keys with unnamed curves" in ret.stdout
+        ):
+            pytest.skip(
+                "The version of OpenSSL doesn't support ECDSA keys with unnamed curves"
+            )
         assert ret.returncode == 0
         assert ret.data[next(iter(ret.data))]["changes"]
         assert (tmp_path / "priv.key").exists()


### PR DESCRIPTION
### What does this PR do?

Backports https://github.com/saltstack/salt/pull/66818

With the most recent versions of `cryptography` module the exception value which is checked here https://github.com/saltstack/salt/blob/246d0664577ef72da8bd1f0c4dff0d18b4428b23/salt/utils/x509.py#L704 is different.
The latest version of `cryptography` is returning https://github.com/pyca/cryptography/blob/932b8a3f67810140a6e178f7b676e1cb9c3585b1/src/rust/src/backend/utils.rs#L463

It could also be returned with the lower version of `cryptography` depending on the combination with the OpenSSL version it's used with.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/24859

### Previous Behavior
`x509.private_key_managed` state function could fail with the comment `Could not load PEM-encoded private key`
The following tests could fail as well:
```
tests/pytests/functional/states/test_x509_v2.py::test_private_key_managed_passphrase_changed_overwrite
tests/pytests/functional/states/test_x509_v2.py::test_private_key_managed_passphrase_changed_not_overwrite
```

### New Behavior
No test fails and `x509.private_key_managed` state with most recent `cryptography` or some other OpenSSL versions which can produce different errors on such cases.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
