### PR TITLE
Fix test_debian to work in our infrastructure

### DIFF
--- a/tests/pytests/functional/states/pkgrepo/test_debian.py
+++ b/tests/pytests/functional/states/pkgrepo/test_debian.py
@@ -205,7 +205,7 @@ def ubuntu_state_tree(system_aptsources, state_tree, grains):
         - dist: {{ codename }}
         - file: /etc/apt/sources.list.d/firefox-beta.list
         - keyid: CE49EC21
-        - keyserver: keyserver.ubuntu.com
+        - keyserver: hkp://keyserver.ubuntu.com:80
     {%- endif %}
 
     {%- if backports %}{%- do ubuntu_repos.append('kubuntu-ppa') %}


### PR DESCRIPTION
### What does this PR do?

By default, the `keyserver.ubuntu.com` gpg uses the `11371` port. This port seems to be blocked by SUSE IT's firewall. With this change, we force the tests to use the keyserver on port `80`, which makes it pass.

Note: I'm not backporting the change to upstream since it is SUSE-specific. 

### What issues does this PR fix or reference?
Related to: https://github.com/SUSE/spacewalk/issues/23286

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
