### PR TITLE
Remove deprecated code from Test mode in x509.certificate_managed (#617)

### DIFF
--- a/salt/states/x509.py
+++ b/salt/states/x509.py
@@ -705,70 +705,7 @@ def certificate_managed(name, days_remaining=90, append_certs=None, **kwargs):
             "Old": invalid_reason,
             "New": "Certificate will be valid and up to date",
         }
-        private_key_args.update(managed_private_key)
-        kwargs["public_key_passphrase"] = private_key_args["passphrase"]
-
-        if private_key_args["new"]:
-            rotate_private_key = True
-            private_key_args["new"] = False
-
-        if _check_private_key(
-            private_key_args["name"],
-            bits=private_key_args["bits"],
-            passphrase=private_key_args["passphrase"],
-            new=private_key_args["new"],
-            overwrite=private_key_args["overwrite"],
-        ):
-            private_key = __salt__["x509.get_pem_entry"](
-                private_key_args["name"], pem_type="RSA PRIVATE KEY"
-            )
-        else:
-            new_private_key = True
-            private_key = __salt__["x509.create_private_key"](
-                text=True,
-                bits=private_key_args["bits"],
-                passphrase=private_key_args["passphrase"],
-                cipher=private_key_args["cipher"],
-                verbose=private_key_args["verbose"],
-            )
-
-        kwargs["public_key"] = private_key
-
-    current_days_remaining = 0
-    current_comp = {}
-
-    if os.path.isfile(name):
-        try:
-            current = __salt__["x509.read_certificate"](certificate=name)
-            current_comp = copy.deepcopy(current)
-            if "serial_number" not in kwargs:
-                current_comp.pop("Serial Number")
-                if "signing_cert" not in kwargs:
-                    try:
-                        current_comp["X509v3 Extensions"][
-                            "authorityKeyIdentifier"
-                        ] = re.sub(
-                            r"serial:([0-9A-F]{2}:)*[0-9A-F]{2}",
-                            "serial:--",
-                            current_comp["X509v3 Extensions"]["authorityKeyIdentifier"],
-                        )
-                    except KeyError:
-                        pass
-            current_comp.pop("Not Before")
-            current_comp.pop("MD5 Finger Print")
-            current_comp.pop("SHA1 Finger Print")
-            current_comp.pop("SHA-256 Finger Print")
-            current_notafter = current_comp.pop("Not After")
-            current_days_remaining = (
-                datetime.datetime.strptime(current_notafter, "%Y-%m-%d %H:%M:%S")
-                - datetime.datetime.now()
-            ).days
-            if days_remaining == 0:
-                days_remaining = current_days_remaining - 1
-        except salt.exceptions.SaltInvocationError:
-            current = "{} is not a valid Certificate.".format(name)
-    else:
-        current = "{} does not exist.".format(name)
+	return ret
 
     contents = __salt__["x509.create_certificate"](text=True, **kwargs)
     # Check the module actually returned a cert and not an error message as a string


### PR DESCRIPTION
### What does this PR do?
Remove deprecated code from Test mode in x509.certificate_managed
add in https://github.com/openSUSE/salt/commit/094b34760a85c3ee27bf64783624b17bd3bbca0

### What issues does this PR fix or reference?
Fixes: #617

### Previous Behavior
Test mode will failed with "name 'private_key_args' is not defined"

### New Behavior
Test mode will success with result = 'None'

### Commits signed with GPG?
Yes
