### PR TITLE
Allow NamedLoaderContexts to be returned from loader

### DIFF
--- a/salt/loader/lazy.py
+++ b/salt/loader/lazy.py
@@ -1246,7 +1246,10 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             self.parent_loader = current_loader
         token = salt.loader.context.loader_ctxvar.set(self)
         try:
-            return _func_or_method(*args, **kwargs)
+            ret = _func_or_method(*args, **kwargs)
+            if isinstance(ret, salt.loader.context.NamedLoaderContext):
+                ret = ret.value()
+            return ret
         finally:
             self.parent_loader = None
             salt.loader.context.loader_ctxvar.reset(token)

--- a/tests/pytests/integration/modules/test_config.py
+++ b/tests/pytests/integration/modules/test_config.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+@pytest.mark.slow_test
+def test_config_items(salt_cli, salt_minion):
+    ret = salt_cli.run("config.items", minion_tgt=salt_minion.id)
+    assert ret.returncode == 0
+    assert isinstance(ret.data, dict)

--- a/tests/pytests/unit/loader/test_loader.py
+++ b/tests/pytests/unit/loader/test_loader.py
@@ -62,3 +62,16 @@ def test_raw_mod_functions():
     ret = salt.loader.raw_mod(opts, "grains", "get")
     for k, v in ret.items():
         assert isinstance(v, salt.loader.lazy.LoadedFunc)
+
+
+def test_return_named_context_from_loaded_func(tmp_path):
+    opts = {
+        "optimization_order": [0],
+    }
+    contents = """
+    def foobar():
+        return __test__
+    """
+    with pytest.helpers.temp_file("mymod.py", contents, directory=tmp_path):
+        loader = salt.loader.LazyLoader([tmp_path], opts, pack={"__test__": "meh"})
+        assert loader["mymod.foobar"]() == "meh"


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/saltstack/salt/pull/66649

It is useful in some cases to return NamedLoaderContexts from loaded functions. Instead of choking or requireing implimenters to call the context's value() method before being de-scoped, detect when a NamedLoaderContext has been returned and return the value from the current context.

### What issues does this PR fix or reference?
https://github.com/saltstack/salt/pull/66364 was opened for upstream before, but they decided to put the fix to `3006.x` and a bit different way.
There was an unrelated bug opened when such behavior appered while testing. So no reference for now.

### Previous Behavior
Could return the following instead of the proper `dict`:
```
demo.example.org:
    <salt.loader.context.NamedLoaderContext object at 0x7f31461b80a0>
```

### New Behavior
Return the expected `dict` output

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
