### PR TITLE
Fix x509 test fails on old openssl systems

### DIFF
--- a/tests/pytests/functional/modules/test_x509_v2.py
+++ b/tests/pytests/functional/modules/test_x509_v2.py
@@ -1,6 +1,5 @@
 import base64
 import datetime
-import ssl
 
 import pytest
 
@@ -679,13 +678,16 @@ def crl_revoked():
 
 @pytest.mark.parametrize("algo", ["rsa", "ec", "ed25519", "ed448"])
 def test_create_certificate_self_signed(x509, algo, request):
-    if algo in ["ed25519", "ed448"] and ssl.OPENSSL_VERSION_INFO < (1, 1):
-        pytest.skip(f"Algorithm '{algo}' is not supported on this OpenSSL version")
     privkey = request.getfixturevalue(f"{algo}_privkey")
     try:
         res = x509.create_certificate(signing_private_key=privkey, CN="success")
     except (UnsupportedAlgorithm, NotImplementedError):
         pytest.skip(f"Algorithm '{algo}' is not supported on this OpenSSL version")
+    except salt.exceptions.CommandExecutionError as e:
+        if "Could not load PEM-encoded" in e.error:
+            pytest.skip(f"Algorithm '{algo}' is not supported on this OpenSSL version")
+        else:
+            raise e
     assert res.startswith("-----BEGIN CERTIFICATE-----")
     cert = _get_cert(res)
     assert cert.subject.rfc4514_string() == "CN=success"
@@ -749,8 +751,6 @@ def test_create_certificate_raw(x509, rsa_privkey):
 
 @pytest.mark.parametrize("algo", ["rsa", "ec", "ed25519", "ed448"])
 def test_create_certificate_from_privkey(x509, ca_key, ca_cert, algo, request):
-    if algo in ["ed25519", "ed448"] and ssl.OPENSSL_VERSION_INFO < (1, 1):
-        pytest.skip(f"Algorithm '{algo}' is not supported on this OpenSSL version")
     privkey = request.getfixturevalue(f"{algo}_privkey")
     try:
         res = x509.create_certificate(
@@ -761,6 +761,11 @@ def test_create_certificate_from_privkey(x509, ca_key, ca_cert, algo, request):
         )
     except (UnsupportedAlgorithm, NotImplementedError):
         pytest.skip(f"Algorithm '{algo}' is not supported on this OpenSSL version")
+    except salt.exceptions.CommandExecutionError as e:
+        if "Could not load PEM-encoded" in e.error:
+            pytest.skip(f"Algorithm '{algo}' is not supported on this OpenSSL version")
+        else:
+            raise e
     assert res.startswith("-----BEGIN CERTIFICATE-----")
     cert = _get_cert(res)
     assert cert.subject.rfc4514_string() == "CN=success"
@@ -799,8 +804,6 @@ def test_create_certificate_from_encrypted_privkey_with_encrypted_privkey(
 
 @pytest.mark.parametrize("algo", ["rsa", "ec", "ed25519", "ed448"])
 def test_create_certificate_from_pubkey(x509, ca_key, ca_cert, algo, request):
-    if algo in ["ed25519", "ed448"] and ssl.OPENSSL_VERSION_INFO < (1, 1):
-        pytest.skip(f"Algorithm '{algo}' is not supported on this OpenSSL version")
     pubkey = request.getfixturevalue(f"{algo}_pubkey")
     try:
         res = x509.create_certificate(
@@ -811,6 +814,11 @@ def test_create_certificate_from_pubkey(x509, ca_key, ca_cert, algo, request):
         )
     except (UnsupportedAlgorithm, NotImplementedError):
         pytest.skip(f"Algorithm '{algo}' is not supported on this OpenSSL version")
+    except salt.exceptions.CommandExecutionError as e:
+        if "Could not load PEM-encoded" in e.error:
+            pytest.skip(f"Algorithm '{algo}' is not supported on this OpenSSL version")
+        else:
+            raise e
     assert res.startswith("-----BEGIN CERTIFICATE-----")
     cert = _get_cert(res)
     assert cert.subject.rfc4514_string() == "CN=success"
@@ -1345,13 +1353,16 @@ def test_create_crl_raw(x509, crl_args):
 
 @pytest.mark.parametrize("algo", ["rsa", "ec", "ed25519", "ed448"])
 def test_create_csr(x509, algo, request):
-    if algo in ["ed25519", "ed448"] and ssl.OPENSSL_VERSION_INFO < (1, 1):
-        pytest.skip(f"Algorithm '{algo}' is not supported on this OpenSSL version")
     privkey = request.getfixturevalue(f"{algo}_privkey")
     try:
         res = x509.create_csr(private_key=privkey)
     except (UnsupportedAlgorithm, NotImplementedError):
         pytest.skip(f"Algorithm '{algo}' is not supported on this OpenSSL version")
+    except salt.exceptions.CommandExecutionError as e:
+        if "Could not load PEM-encoded" in e.error:
+            pytest.skip(f"Algorithm '{algo}' is not supported on this OpenSSL version")
+        else:
+            raise e
     assert res.startswith("-----BEGIN CERTIFICATE REQUEST-----")
 
 
@@ -1471,13 +1482,16 @@ def test_create_private_key_raw(x509):
     "algo,expected", [("rsa", 2048), ("ec", 256), ("ed25519", None), ("ed448", None)]
 )
 def test_get_private_key_size(x509, algo, expected, request):
-    if algo in ["ed25519", "ed448"] and ssl.OPENSSL_VERSION_INFO < (1, 1):
-        pytest.skip(f"Algorithm '{algo}' is not supported on this OpenSSL version")
     privkey = request.getfixturevalue(f"{algo}_privkey")
     try:
         res = x509.get_private_key_size(privkey)
     except (UnsupportedAlgorithm, NotImplementedError):
         pytest.skip(f"Algorithm '{algo}' is not supported on this OpenSSL version")
+    except salt.exceptions.CommandExecutionError as e:
+        if "Could not load PEM-encoded" in e.error:
+            pytest.skip(f"Algorithm '{algo}' is not supported on this OpenSSL version")
+        else:
+            raise e
     assert res == expected
 
 

--- a/tests/pytests/scenarios/performance/test_performance.py
+++ b/tests/pytests/scenarios/performance/test_performance.py
@@ -10,7 +10,13 @@ from saltfactories.utils import random_string
 
 from salt.version import SaltVersionsInfo, __version__
 
-pytestmark = [pytest.mark.skip_if_binaries_missing("docker")]
+pytestmark = [
+    pytest.mark.skip_if_binaries_missing("docker"),
+    pytest.mark.skipif(
+        os.environ.get("GITHUB_ACTIONS", "") == "true",
+        reason="Cannot spawn containers in GH actions run",
+    ),
+]
 
 
 class ContainerMaster(SaltDaemon, master.SaltMaster):


### PR DESCRIPTION
### What does this PR do?

This PR:
- fixes our failing x509 tests on SLES12SP5 and CentOS7
- also fixes the test_performance test, which cannot run in GH CI (it was previously skipped in CI due to the missing `docker` binary, which we now provide)

Note: We're already diverging in the x509 tests from upstream, because upstream does not test Salt on old systems (like Centos7 or SLES12). Not sure if we need to upstream these changes (or if they are relevant to upstream), but I'm open to at least attempting it.

### What issues does this PR fix or reference?
Relates to: https://github.com/SUSE/spacewalk/issues/23286


### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
