### PR TITLE
Avoid explicit reading of /etc/salt/minion (bsc#1220357)

### DIFF
--- a/salt/utils/azurearm.py
+++ b/salt/utils/azurearm.py
@@ -47,8 +47,6 @@ try:
 except ImportError:
     HAS_AZURE = False
 
-__opts__ = salt.config.minion_config("/etc/salt/minion")
-__salt__ = salt.loader.minion_mods(__opts__)
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
### What does this PR do?

Parcial backport of https://github.com/saltstack/salt/pull/65696 with https://github.com/saltstack/salt/pull/65696/commits/d54407ba6dc664e5e5f3f613e27ae24f828c9648 from upstream PR only.

Upstream PR is messy and contains a list of changes not related to the original description.
I'm closing previous PR https://github.com/openSUSE/salt/pull/641 in favor of this one.

In some cases `salt-call` on the salt-ssh client side is rereading `/etc/salt/minion` explicitly what doesn't make any sense.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/23799

### Previous Behavior
In some cases `salt-call` on the salt-ssh client side is rereading `/etc/salt/minion`.

### New Behavior
Prevent `salt-call` of rereading `/etc/salt/minion` with no reason.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
