### PR TITLE
Fix x509 private key tests and test_suse on SLE12

### DIFF
--- a/tests/pytests/functional/modules/test_x509_v2.py
+++ b/tests/pytests/functional/modules/test_x509_v2.py
@@ -1442,14 +1442,22 @@ def test_create_private_key_with_passphrase(x509, algo):
 
 @pytest.mark.slow_test
 def test_create_private_key_der(x509):
-    res = x509.create_private_key(algo="ec", encoding="der")
+    try:
+        res = x509.create_private_key(algo="ec", encoding="der")
+    except NotImplementedError:
+        pytest.skip("Algorithm 'ec' is not supported on this OpenSSL version")
     assert base64.b64decode(res)
 
 
 @pytest.mark.slow_test
 @pytest.mark.parametrize("passphrase", [None, "hunter2"])
 def test_create_private_key_pkcs12(x509, passphrase):
-    res = x509.create_private_key(algo="ec", encoding="pkcs12", passphrase=passphrase)
+    try:
+        res = x509.create_private_key(
+            algo="ec", encoding="pkcs12", passphrase=passphrase
+        )
+    except NotImplementedError:
+        pytest.skip("Algorithm 'ec' is not supported on this OpenSSL version")
     assert base64.b64decode(res)
 
 

--- a/tests/pytests/functional/states/pkgrepo/test_suse.py
+++ b/tests/pytests/functional/states/pkgrepo/test_suse.py
@@ -28,14 +28,14 @@ def suse_state_tree(grains, pkgrepo, state_tree):
         - comments:
           - '# Salt Test'
         - refresh: 1
-    {% if grains['osmajorrelease'] == 15 %}
-        - baseurl: https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP4/standard/
-        - humanname: openSUSE Backports for SLE 15 SP4
-        - gpgkey: https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP4/standard/repodata/repomd.xml.key
-    {% elif grains['osfullname'] == 'openSUSE Tumbleweed' %}
+    {% if grains['osfullname'] == 'openSUSE Tumbleweed' %}
         - baseurl: http://download.opensuse.org/tumbleweed/repo/oss/
         - humanname: openSUSE Tumbleweed OSS
         - gpgkey: https://download.opensuse.org/tumbleweed/repo/oss/repodata/repomd.xml.key
+    {% else %}
+        - baseurl: https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP4/standard/
+        - humanname: openSUSE Backports for SLE 15 SP4
+        - gpgkey: https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP4/standard/repodata/repomd.xml.key
     {% endif %}
     """
 
@@ -53,14 +53,14 @@ def suse_state_tree(grains, pkgrepo, state_tree):
         - comments:
           - '# Salt Test (modified)'
         - refresh: 1
-    {% if grains['osmajorrelease'] == 15 %}
-        - baseurl: https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP4/standard/
-        - humanname: Salt modified Backports
-        - gpgkey: https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP4/standard/repodata/repomd.xml.key
-    {% elif grains['osfullname'] == 'openSUSE Tumbleweed' %}
+    {% if grains['osfullname'] == 'openSUSE Tumbleweed' %}
         - baseurl: http://download.opensuse.org/tumbleweed/repo/oss/
         - humanname: Salt modified OSS
         - gpgkey: https://download.opensuse.org/tumbleweed/repo/oss/repodata/repomd.xml.key
+    {% else %}
+        - baseurl: https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP4/standard/
+        - humanname: Salt modified Backports
+        - gpgkey: https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP4/standard/repodata/repomd.xml.key
     {% endif %}
     """
 


### PR DESCRIPTION
### What does this PR do?

This PR is related to https://github.com/openSUSE/salt/pull/682.

For x509 tests, I forgot to include two tests.

For the `test_suse.py` test, the problem there is that on SLE12, none of the if/else paths matched. I simplified it so that we use the SLE15 SP4 repo URL, since the tests check whether we can manipulate with repositories (e.g. add, modify, remove, ...) but does not install any packages (so the repository URL shouldn't matter, we just need to provide one)

### What issues does this PR fix or reference?
Relates to: https://github.com/SUSE/spacewalk/issues/23286

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
