### PR TITLE
Handle logger flushing already closed file

### DIFF
--- a/salt/_logging/handlers.py
+++ b/salt/_logging/handlers.py
@@ -95,6 +95,9 @@ class DeferredStreamHandler(StreamHandler):
         super().__init__(stream)
         self.__messages = deque(maxlen=max_queue_size)
         self.__emitting = False
+        import traceback
+
+        self.stack = "".join(traceback.format_stack())
 
     def handle(self, record):
         self.acquire()
@@ -116,6 +119,7 @@ class DeferredStreamHandler(StreamHandler):
                 super().handle(record)
             finally:
                 self.__emitting = False
+        # This will raise a ValueError if the file handle has been closed.
         super().flush()
 
     def sync_with_handlers(self, handlers=()):

--- a/salt/_logging/impl.py
+++ b/salt/_logging/impl.py
@@ -488,7 +488,15 @@ def setup_temp_handler(log_level=None):
             break
     else:
         handler = DeferredStreamHandler(sys.stderr)
-        atexit.register(handler.flush)
+
+        def tryflush():
+            try:
+                handler.flush()
+            except ValueError:
+                # File handle has already been closed.
+                pass
+
+        atexit.register(tryflush)
     handler.setLevel(log_level)
 
     # Set the default temporary console formatter config


### PR DESCRIPTION
This is a partial cherry-pick of
https://github.com/saltstack/salt/commit/9683260d61668da8559ecde6caf63a52fedd8790

Note: Test failures are unrelated, fixed with https://github.com/openSUSE/salt-packaging/pull/100

### What does this PR do?

Fixes intermittent test failures.

### What issues does this PR fix or reference?
Related to https://github.com/SUSE/spacewalk/issues/23286


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
