### PR TITLE
Enhance find_json garbage filtering (bsc#1231605)

### DIFF
--- a/salt/modules/transactional_update.py
+++ b/salt/modules/transactional_update.py
@@ -984,7 +984,7 @@ def call(function, *args, **kwargs):
                 return local.get("return", local)
             else:
                 return local
-        except ValueError:
+        except (ValueError, AttributeError):
             return {"result": False, "retcode": 1, "comment": ret_stdout}
     finally:
         # Check if reboot is needed

--- a/salt/utils/json.py
+++ b/salt/utils/json.py
@@ -39,6 +39,7 @@ def find_json(raw):
     # Search for possible starts end ends of the json fragments
     for ind, _ in enumerate(lines):
         line = lines[ind].lstrip()
+        line = line[0] if line else line
         if line == "{" or line == "[":
             starts.append((ind, line))
         if line == "}" or line == "]":
@@ -61,10 +62,17 @@ def find_json(raw):
         working = "\n".join(lines[start : end + 1])
         try:
             ret = json.loads(working)
+            return ret
+        except ValueError:
+            pass
+        # Try filtering non-JSON text right after the last closing curly brace
+        end_str = lines[end].lstrip()[0]
+        working = "\n".join(lines[start : end]) + end_str
+        try:
+            ret = json.loads(working)
+            return ret
         except ValueError:
             continue
-        if ret:
-            return ret
 
     # Fall back to old implementation for backward compatibility
     # excpecting json after the text

--- a/tests/unit/utils/test_json.py
+++ b/tests/unit/utils/test_json.py
@@ -109,6 +109,11 @@ class JSONTestCase(TestCase):
         ret = salt.utils.json.find_json(garbage_prepend_json)
         self.assertDictEqual(ret, expected_ret)
 
+        # Pre-pend garbage right after closing bracket of the JSON
+        garbage_prepend_json = "{}{}".format(test_sample_json.rstrip(), LOREM_IPSUM)
+        ret = salt.utils.json.find_json(garbage_prepend_json)
+        self.assertDictEqual(ret, expected_ret)
+
         # Test to see if a ValueError is raised if no JSON is passed in
         self.assertRaises(ValueError, salt.utils.json.find_json, LOREM_IPSUM)
 


### PR DESCRIPTION
### What does this PR do?


In this PR, we enhance the `find_json` function to work with valid JSONs that contain garbage right after the JSON end. This is a problem when the text contains JSON and, for example, deprecation messages, such as:

```
{
    "local": {
        "saltutil_|-sync_states_|-sync_states_|-sync_states": {
            "name": "sync_states",
            "changes": {},
            "result": true,
            "comment": "No updates to sync",
            "__sls__": "util.syncstates",
            "__run_num__": 0,
            "start_time": "14:35:37.150819",
            "duration": 1256.999,
            "__id__": "sync_states"
        },
...JSON continues...
}/usr/lib/python3.6/site-packages/salt/states/x509.py:214: DeprecationWarning: The x509 modules are deprecated. Please migrate to the replacement modules (x509_v2). They are the default from Salt 3008 (Argon) onwards.
  "The x509 modules are deprecated. Please migrate to the replacement "
```

### What issues does this PR fix or reference?
Related to: [#25514](https://github.com/SUSE/spacewalk/issues/25514)
Upstream PR: https://github.com/saltstack/salt/pull/67023

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
