### PR TITLE
Revert setting SELinux context for minion service (bsc#1233667)

### DIFF
--- a/pkg/common/salt-minion.service
+++ b/pkg/common/salt-minion.service
@@ -9,7 +9,6 @@ Type=notify
 NotifyAccess=all
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-minion
-SELinuxContext=system_u:system_r:unconfined_t:s0
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/old/deb/salt-minion.service
+++ b/pkg/old/deb/salt-minion.service
@@ -8,7 +8,6 @@ KillMode=process
 NotifyAccess=all
 LimitNOFILE=8192
 ExecStart=/usr/bin/salt-minion
-SELinuxContext=system_u:system_r:unconfined_t:s0
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/old/suse/salt-minion.service
+++ b/pkg/old/suse/salt-minion.service
@@ -10,7 +10,6 @@ ExecStart=/usr/bin/salt-minion
 KillMode=process
 Restart=on-failure
 RestartSec=15
-SELinuxContext=system_u:system_r:unconfined_t:s0
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/old/suse/salt-minion.service.rhel7
+++ b/pkg/old/suse/salt-minion.service.rhel7
@@ -9,7 +9,6 @@ ExecStart=/usr/bin/salt-minion
 KillMode=process
 Restart=on-failure
 RestartSec=15
-SELinuxContext=system_u:system_r:unconfined_t:s0
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
### What does this PR do?

This reverts commit d933c8f0795fdada84a01a2cc754586fa720993d.

It just reverts https://github.com/openSUSE/salt/pull/670 because it's causing way more sensitive issues than is intended to fix.

We need to fix possible SELinux issues with the proper SELinux profile shipped as a SELinux module package (TBD)

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/25852 https://github.com/SUSE/spacewalk/issues/25850

### Previous Behavior
On some of the clients `venv-salt-minion` service is unable to start because of the context transition denied by SELinux

### New Behavior
`venv-salt-minion` is able to start as before, but https://github.com/SUSE/spacewalk/issues/23541 will appear again.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
