### PR TITLE
Fix failed to stat '/root/.gitconfig' issue on gitfs (bsc#1230944) (bsc#1234881)

### DIFF
--- a/changelog/64121.fixed.md
+++ b/changelog/64121.fixed.md
@@ -1,0 +1,1 @@
+Ensure the right HOME environment value is set during Pygit2 remote initialization.

--- a/salt/utils/gitfs.py
+++ b/salt/utils/gitfs.py
@@ -1885,7 +1885,12 @@ class Pygit2(GitProvider):
         """
         # https://github.com/libgit2/pygit2/issues/339
         # https://github.com/libgit2/libgit2/issues/2122
+        # https://github.com/saltstack/salt/issues/64121
         home = os.path.expanduser("~")
+        if "HOME" not in os.environ:
+            # Make sure $HOME env variable is set to prevent
+            # _pygit2.GitError: error loading known_hosts in some libgit2 versions.
+            os.environ["HOME"] = home
         pygit2.settings.search_path[pygit2.GIT_CONFIG_LEVEL_GLOBAL] = home
         new = False
         if not os.listdir(self._cachedir):
@@ -1990,10 +1995,6 @@ class Pygit2(GitProvider):
             # pruning only available in pygit2 >= 0.26.2
             pass
         try:
-            # Make sure $HOME env variable is set to prevent
-            # _pygit2.GitError: error loading known_hosts in some libgit2 versions.
-            if "HOME" not in os.environ:
-                os.environ["HOME"] = salt.syspaths.HOME_DIR
             fetch_results = origin.fetch(**fetch_kwargs)
         except GitError as exc:  # pylint: disable=broad-except
             exc_str = get_error_message(exc).lower()

--- a/tests/pytests/unit/utils/test_gitfs.py
+++ b/tests/pytests/unit/utils/test_gitfs.py
@@ -251,7 +251,6 @@ def test_checkout_pygit2_with_home_env_unset(_prepare_provider):
     with patched_environ(__cleanup__=["HOME"]):
         assert "HOME" not in os.environ
         provider.init_remote()
-        provider.fetch()
         assert "HOME" in os.environ
 
 


### PR DESCRIPTION
### What does this PR do?

This PR ensures the right value for `HOME` environment is set during Pygit2 remote initialization, otherwise there are chances that it gets a wrong value depending on the execution stack.

Upstream PR: https://github.com/saltstack/salt/pull/67186

### Previous Behavior
The previous way of setting the HOME value for pygit2 gitfs remotes was done at `_fetch` function, there are chances, i.a. when fetching a non-existing branch, that `HOME` value gets wrongly replaced by `/root/` in the corresponding MWorker, leading to errors like:

```console
_pygit2.GitError: /var/cache/salt/master/git_pillar/xxxxx/master: failed to stat '/root/.gitconfig'
```

This error starts happening randomly until all the MWorker processes get the `HOME` value polluted and therefore leading always to get this exception when fetching from the gitfs remote.

### New Behavior
The right value is set for `HOME` environment: `/var/lib/salt/`, and the value gets preserved on the MWorker processes even if there are exceptions fetching non-existing remotes.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
