### PR TITLE
Repair fstab_present test mode

### DIFF
--- a/changelog/67065.fixed.md
+++ b/changelog/67065.fixed.md
@@ -1,0 +1,1 @@
+Repaired mount.fstab_present always returning pending changes

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -1228,6 +1228,7 @@ def fstab_present(
         if out == "present":
             msg = "{} entry is already in {}."
             ret["comment"].append(msg.format(fs_file, config))
+            ret["result"] = True
         elif out == "new":
             msg = "{} entry will be written in {}."
             ret["comment"].append(msg.format(fs_file, config))

--- a/tests/pytests/unit/states/test_mount.py
+++ b/tests/pytests/unit/states/test_mount.py
@@ -701,7 +701,7 @@ def test_fstab_present_macos_test_present():
     """
     ret = {
         "name": "/dev/sda1",
-        "result": None,
+        "result": True,
         "changes": {},
         "comment": ["/home entry is already in /etc/auto_salt."],
     }
@@ -730,7 +730,7 @@ def test_fstab_present_aix_test_present():
     """
     ret = {
         "name": "/dev/sda1",
-        "result": None,
+        "result": True,
         "changes": {},
         "comment": ["/home entry is already in /etc/filesystems."],
     }
@@ -761,7 +761,7 @@ def test_fstab_present_test_present():
     """
     ret = {
         "name": "/dev/sda1",
-        "result": None,
+        "result": True,
         "changes": {},
         "comment": ["/home entry is already in /etc/fstab."],
     }


### PR DESCRIPTION
### What does this PR do?

Pick upstream patch submitted via https://github.com/saltstack/salt/pull/67066.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/67065

### Previous Behavior

Stray pending changes upon using `mount.fstab_present`.

### New Behavior

No stray pending changes upon using `mount.fstab_present`.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
