### PR TITLE
Set virtual grain in Podman systemd container

### DIFF
--- a/changelog/67733.fixed.md
+++ b/changelog/67733.fixed.md
@@ -1,0 +1,1 @@
+Set correct virtual grain in systemd based Podman containers

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -911,6 +911,10 @@ def _virtual(osdata):
                 grains["virtual"] = "container"
                 grains["virtual_subtype"] = "LXC"
                 break
+            elif "podman" in output:
+                grains["virtual"] = "container"
+                grains["virtual_subtype"] = "Podman"
+                break
             elif "amazon" in output:
                 grains["virtual"] = "Nitro"
                 grains["virtual_subtype"] = "Amazon EC2"

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -1753,6 +1753,37 @@ def test_lxc_virtual_with_virt_what():
 
 
 @pytest.mark.skip_on_windows
+def test_podman_virtual_with_systemd_detect_virt():
+    """
+    Test if virtual grains are parsed correctly in Podman using systemd-detect-virt.
+    """
+
+    def _which_side_effect(path):
+        if path == "systemd-detect-virt":
+            return "/usr/bin/systemd-detect-virt"
+        return None
+
+    with patch.object(
+        salt.utils.platform, "is_windows", MagicMock(return_value=False)
+    ), patch.object(
+        salt.utils.path,
+        "which",
+        MagicMock(return_value=True, side_effect=_which_side_effect),
+    ), patch.dict(
+        core.__salt__,
+        {
+            "cmd.run_all": MagicMock(
+                return_value={"pid": 78, "retcode": 0, "stderr": "", "stdout": "podman"}
+            )
+        },
+    ):
+        osdata = {"kernel": "test"}
+        ret = core._virtual(osdata)
+        assert ret["virtual"] == "container"
+        assert ret["virtual_subtype"] == "Podman"
+
+
+@pytest.mark.skip_on_windows
 def test_container_inside_virtual_machine():
     """
     Test if a container inside an hypervisor is shown as a container


### PR DESCRIPTION
### What does this PR do?

Pick upstream patch submitted via https://github.com/saltstack/salt/pull/67734.

### What issues does this PR fix or reference?

https://github.com/saltstack/salt/issues/67733

### Previous Behavior

```
# systemd-detect-virt
podman

# salt-call --local grains.get virtual
local:
    physical
```

### New Behavior

```
# systemd-detect-virt
podman

# salt-call --local grains.get virtual
local:
    container
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
