### PR TITLE
Fix tests failures after "repo.saltproject.io" deprecation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,9 @@ for more information.
 
 To download and install Salt, see:
 * `The Salt install guide <https://docs.saltproject.io/salt/install-guide/en/latest/index.html>`_
-* `Salt Project repository <https://repo.saltproject.io/>`_
+* `Salt Project repository <https://packages.broadcom.com/artifactory/saltproject-generic/>`_
+* `Salt Project debian repository <https://packages.broadcom.com/artifactory/saltproject-deb/>`_
+* `Salt Project redhat repository <https://packages.broadcom.com/artifactory/saltproject-rpm/>`_
 
 
 Technical support

--- a/doc/_themes/saltstack2/layout.html
+++ b/doc/_themes/saltstack2/layout.html
@@ -157,16 +157,11 @@
                     <!-- Collect the nav links, forms, and other content for toggling -->
                     <div class="collapse navbar-collapse" id="navbarCollapse">
                         <ul class="nav navbar-nav">
-                <li><a href="/en/latest/">Overview</a></li>
-                <li><a href="https://docs.saltproject.io/salt/user-guide/en/latest/">Salt User Guide</a></li>
-                <li><a href="/en/latest/contents.html">Documentation</a></li>
-                <li><a href="https://repo.saltproject.io">Downloads</a></li>
-                <li><a href="/en/latest/topics/development/">Develop</a></li>
-                            <!--<li><a href="/en/2016.3/faq/">FAQ</a></li>
-                            <li><a href="/en/2016.3/samples/">Code Samples</a></li>-->
-                            <!--                <li><a href="https://repo.saltproject.io" target="_blank">Downloads</a></li>-->
-                            <!--<li><a href="http://saltstack.com/training" target="_blank">Training</a></li>
-                            <li><a href="http://saltstack.com/support" target="_blank">Support</a></li>-->
+                            <li><a href="/en/latest/">Overview</a></li>
+                            <li><a href="https://docs.saltproject.io/salt/user-guide/en/latest/">Salt User Guide</a></li>
+                            <li><a href="/en/latest/contents.html">Documentation</a></li>
+                            <li><a href="https://packages.broadcom.com/artifactory/saltproject-generic/">Downloads</a></li>
+                            <li><a href="/en/latest/topics/development/">Develop</a></li>
                         </ul>
                     </div>
                 </div>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -178,17 +178,17 @@ rst_prolog = """\
 .. |windownload| raw:: html
 
      <p>Python3 x86: <a
-     href="https://repo.saltproject.io/windows/Salt-Minion-{release}-Py3-x86-Setup.exe"><strong>Salt-Minion-{release}-x86-Setup.exe</strong></a>
-      | <a href="https://repo.saltproject.io/windows/Salt-Minion-{release}-Py3-x86-Setup.exe.md5"><strong>md5</strong></a></p>
+     href="https://packages.broadcom.com/artifactory/saltproject-generic/windows/{release}/Salt-Minion-{release}-Py3-x86-Setup.exe"><strong>Salt-Minion-{release}-x86-Setup.exe</strong></a>
+      | <a href="https://packages.broadcom.com/artifactory/saltproject-generic/windows/{release}/Salt-Minion-{release}-Py3-x86-Setup.exe.md5"><strong>md5</strong></a></p>
 
      <p>Python3 AMD64: <a
-     href="https://repo.saltproject.io/windows/Salt-Minion-{release}-Py3-AMD64-Setup.exe"><strong>Salt-Minion-{release}-AMD64-Setup.exe</strong></a>
-      | <a href="https://repo.saltproject.io/windows/Salt-Minion-{release}-Py3-AMD64-Setup.exe.md5"><strong>md5</strong></a></p>
+     href="https://packages.broadcom.com/artifactory/saltproject-generic/windows/{release}/Salt-Minion-{release}-Py3-AMD64-Setup.exe"><strong>Salt-Minion-{release}-AMD64-Setup.exe</strong></a>
+      | <a href="https://packages.broadcom.com/artifactory/saltproject-generic/windows/{release}/Salt-Minion-{release}-Py3-AMD64-Setup.exe.md5"><strong>md5</strong></a></p>
 
 .. |osxdownloadpy3| raw:: html
 
-     <p>x86_64: <a href="https://repo.saltproject.io/osx/salt-{release}-py3-x86_64.pkg"><strong>salt-{release}-py3-x86_64.pkg</strong></a>
-      | <a href="https://repo.saltproject.io/osx/salt-{release}-py3-x86_64.pkg.md5"><strong>md5</strong></a></p>
+     <p>x86_64: <a href="https://packages.broadcom.com/artifactory/saltproject-generic/macos/{release}/salt-{release}-py3-x86_64.pkg"><strong>salt-{release}-py3-x86_64.pkg</strong></a>
+      | <a href="https://packages.broadcom.com/artifactory/saltproject-generic/macos/{release}/salt-{release}-py3-x86_64.pkg.md5"><strong>md5</strong></a></p>
 
 """.format(
     release=stripped_release

--- a/doc/ref/configuration/delta_proxy.rst
+++ b/doc/ref/configuration/delta_proxy.rst
@@ -146,10 +146,8 @@ Before installing the delta proxy minion, ensure that:
 Install or upgrade Salt
 -----------------------
 Ensure your Salt masters are running at least Salt version 3004. For instructions
-on installing or upgrading Salt, see `repo.saltproject.io
-<http://repo.saltproject.io/>`_. For RedHat systems, see `Install or Upgrade Salt
-<https://enterprise.saltproject.io/en/latest/docs/install-salt.html>`_.
-
+on installing or upgrading Salt, see the `Salt install guide
+<https://docs.saltproject.io/salt/install-guide>`_.
 
 
 .. _delta-proxy-install:

--- a/doc/topics/cloud/windows.rst
+++ b/doc/topics/cloud/windows.rst
@@ -62,7 +62,7 @@ from saltstack.com:
 
 * `SaltStack Download Area`__
 
-.. __: https://repo.saltproject.io/windows/
+.. __: https://packages.broadcom.com/artifactory/saltproject-generic/windows/
 
 .. _new-pywinrm:
 

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -128,8 +128,8 @@ def _sync(form, saltenv=None, extmod_whitelist=None, extmod_blacklist=None):
 def update(version=None):
     """
     Update the salt minion from the URL defined in opts['update_url']
-    VMware, Inc provides the latest builds here:
-    update_url: https://repo.saltproject.io/windows/
+    Broadcom, Inc provides the latest builds here:
+    update_url: https://packages.broadcom.com/artifactory/saltproject-generic/windows/
 
     Be aware that as of 2014-8-11 there's a bug in esky such that only the
     latest version available in the update_url can be downloaded and installed.

--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -772,7 +772,7 @@ def bootstrap_psexec(
 
     installer_url
         URL of minion installer executable. Defaults to the latest version from
-        https://repo.saltproject.io/windows/
+        https://packages.broadcom.com/artifactory/saltproject-generic/windows/
 
     username
         Optional user name for login on remote computer.
@@ -790,6 +790,9 @@ def bootstrap_psexec(
         salt-run manage.bootstrap_psexec hosts='host1,host2' installer_url='http://exampledomain/salt-installer.exe'
     """
 
+    # TODO: Need to make this gets the latest version from the new repo location
+    # TODO: Similar to tests/support/win_installer.py
+    # TODO: Maybe need to move that ^^^^ to a salt util
     if not installer_url:
         base_url = "https://repo.saltproject.io/windows/"
         source = urllib.request.urlopen(base_url).read()

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -99,17 +99,17 @@ Using ``aptkey: False`` with ``key_url`` example:
 
 .. code-block:: yaml
 
-    deb [signed-by=/etc/apt/keyrings/salt-archive-keyring.gpg arch=amd64] https://repo.saltproject.io/py3/ubuntu/18.04/amd64/latest bionic main:
+    deb [signed-by=/etc/apt/keyrings/salt-archive-keyring.gpg arch=amd64] https://packages.broadcom.com/artifactory/saltproject-deb/ bionic main:
       pkgrepo.managed:
         - file: /etc/apt/sources.list.d/salt.list
-        - key_url: https://repo.saltproject.io/py3/ubuntu/18.04/amd64/latest/salt-archive-keyring.gpg
+        - key_url: https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public
         - aptkey: False
 
 Using ``aptkey: False`` with ``keyserver`` and ``keyid``:
 
 .. code-block:: yaml
 
-    deb [signed-by=/etc/apt/keyrings/salt-archive-keyring.gpg arch=amd64] https://repo.saltproject.io/py3/ubuntu/18.04/amd64/latest bionic main:
+    deb [signed-by=/etc/apt/keyrings/salt-archive-keyring.gpg arch=amd64] https://packages.broadcom.com/artifactory/saltproject-deb/ bionic main:
       pkgrepo.managed:
         - file: /etc/apt/sources.list.d/salt.list
         - keyserver: keyserver.ubuntu.com

--- a/tests/integration/modules/test_cp.py
+++ b/tests/integration/modules/test_cp.py
@@ -231,10 +231,15 @@ class CPModuleTest(ModuleCase):
         """
         cp.get_url with https:// source given
         """
-        self.run_function("cp.get_url", ["https://www.broadcom.com", tgt])
+        self.run_function(
+            "cp.get_url",
+            ["https://packages.broadcom.com/artifactory/saltproject-generic/", tgt],
+        )
         with salt.utils.files.fopen(tgt, "r") as instructions:
             data = salt.utils.stringutils.to_unicode(instructions.read())
-        self.assertIn("Broadcom Inc. is a global technology leader", data)
+        self.assertIn("Index of saltproject", data)
+        self.assertIn("onedir", data)
+        self.assertIn("Artifactory Online Server", data)
         self.assertNotIn("AYBABTU", data)
 
     @pytest.mark.slow_test
@@ -242,11 +247,16 @@ class CPModuleTest(ModuleCase):
         """
         cp.get_url with https:// source given and destination omitted.
         """
-        ret = self.run_function("cp.get_url", ["https://www.broadcom.com"])
+        ret = self.run_function(
+            "cp.get_url",
+            ["https://packages.broadcom.com/artifactory/saltproject-generic/"],
+        )
 
         with salt.utils.files.fopen(ret, "r") as instructions:
             data = salt.utils.stringutils.to_unicode(instructions.read())
-        self.assertIn("Broadcom Inc. is a global technology leader", data)
+        self.assertIn("Index of saltproject", data)
+        self.assertIn("onedir", data)
+        self.assertIn("Artifactory Online Server", data)
         self.assertNotIn("AYBABTU", data)
 
     @pytest.mark.slow_test
@@ -259,13 +269,20 @@ class CPModuleTest(ModuleCase):
         sleep = 5
         tgt = None
         while time.time() - start <= timeout:
-            ret = self.run_function("cp.get_url", ["https://www.broadcom.com", tgt])
+            ret = self.run_function(
+                "cp.get_url",
+                ["https://packages.broadcom.com/artifactory/saltproject-generic/", tgt],
+            )
             if ret.find("HTTP 599") == -1:
                 break
             time.sleep(sleep)
         if ret.find("HTTP 599") != -1:
-            raise Exception("https://www.broadcom.com returned 599 error")
-        self.assertIn("Broadcom Inc. is a global technology leader", ret)
+            raise Exception(
+                "https://packages.broadcom.com/artifactory/saltproject-generic/ returned 599 error"
+            )
+        self.assertIn("Index of saltproject", ret)
+        self.assertIn("onedir", ret)
+        self.assertIn("Artifactory Online Server", ret)
         self.assertNotIn("AYBABTU", ret)
 
     @pytest.mark.slow_test
@@ -334,9 +351,11 @@ class CPModuleTest(ModuleCase):
         """
         cp.get_file_str with https:// source given
         """
-        src = "https://www.broadcom.com"
+        src = "https://packages.broadcom.com/artifactory/saltproject-generic/"
         ret = self.run_function("cp.get_file_str", [src])
-        self.assertIn("Broadcom Inc. is a global technology leader", ret)
+        self.assertIn("Index of saltproject", ret)
+        self.assertIn("onedir", ret)
+        self.assertIn("Artifactory Online Server", ret)
         self.assertNotIn("AYBABTU", ret)
 
     @pytest.mark.slow_test

--- a/tests/integration/modules/test_cp.py
+++ b/tests/integration/modules/test_cp.py
@@ -231,12 +231,10 @@ class CPModuleTest(ModuleCase):
         """
         cp.get_url with https:// source given
         """
-        self.run_function("cp.get_url", ["https://repo.saltproject.io/index.html", tgt])
+        self.run_function("cp.get_url", ["https://www.broadcom.com", tgt])
         with salt.utils.files.fopen(tgt, "r") as instructions:
             data = salt.utils.stringutils.to_unicode(instructions.read())
-        self.assertIn("Salt Project", data)
-        self.assertIn("Package", data)
-        self.assertIn("Repo", data)
+        self.assertIn("Broadcom Inc. is a global technology leader", data)
         self.assertNotIn("AYBABTU", data)
 
     @pytest.mark.slow_test
@@ -244,15 +242,11 @@ class CPModuleTest(ModuleCase):
         """
         cp.get_url with https:// source given and destination omitted.
         """
-        ret = self.run_function(
-            "cp.get_url", ["https://repo.saltproject.io/index.html"]
-        )
+        ret = self.run_function("cp.get_url", ["https://www.broadcom.com"])
 
         with salt.utils.files.fopen(ret, "r") as instructions:
             data = salt.utils.stringutils.to_unicode(instructions.read())
-        self.assertIn("Salt Project", data)
-        self.assertIn("Package", data)
-        self.assertIn("Repo", data)
+        self.assertIn("Broadcom Inc. is a global technology leader", data)
         self.assertNotIn("AYBABTU", data)
 
     @pytest.mark.slow_test
@@ -265,17 +259,13 @@ class CPModuleTest(ModuleCase):
         sleep = 5
         tgt = None
         while time.time() - start <= timeout:
-            ret = self.run_function(
-                "cp.get_url", ["https://repo.saltproject.io/index.html", tgt]
-            )
+            ret = self.run_function("cp.get_url", ["https://www.broadcom.com", tgt])
             if ret.find("HTTP 599") == -1:
                 break
             time.sleep(sleep)
         if ret.find("HTTP 599") != -1:
-            raise Exception("https://repo.saltproject.io/index.html returned 599 error")
-        self.assertIn("Salt Project", ret)
-        self.assertIn("Package", ret)
-        self.assertIn("Repo", ret)
+            raise Exception("https://www.broadcom.com returned 599 error")
+        self.assertIn("Broadcom Inc. is a global technology leader", ret)
         self.assertNotIn("AYBABTU", ret)
 
     @pytest.mark.slow_test
@@ -344,11 +334,9 @@ class CPModuleTest(ModuleCase):
         """
         cp.get_file_str with https:// source given
         """
-        src = "https://repo.saltproject.io/index.html"
+        src = "https://www.broadcom.com"
         ret = self.run_function("cp.get_file_str", [src])
-        self.assertIn("Salt Project", ret)
-        self.assertIn("Package", ret)
-        self.assertIn("Repo", ret)
+        self.assertIn("Broadcom Inc. is a global technology leader", ret)
         self.assertNotIn("AYBABTU", ret)
 
     @pytest.mark.slow_test

--- a/tests/pytests/functional/modules/test_pkg.py
+++ b/tests/pytests/functional/modules/test_pkg.py
@@ -130,12 +130,8 @@ def test_mod_del_repo(grains, modules, refresh_db):
         elif grains["os_family"] == "RedHat":
             repo = "saltstack"
             name = "SaltStack repo for RHEL/CentOS {}".format(grains["osmajorrelease"])
-            baseurl = "https://repo.saltproject.io/py3/redhat/{}/x86_64/latest/".format(
-                grains["osmajorrelease"]
-            )
-            gpgkey = "https://repo.saltproject.io/py3/redhat/{}/x86_64/latest/SALTSTACK-GPG-KEY.pub".format(
-                grains["osmajorrelease"]
-            )
+            baseurl = "https://packages.broadcom.com/artifactory/saltproject-rpm/"
+            gpgkey = "https://packages.broadcom.com/artifactory/api/security/keypair/SaltProjectKey/public"
             gpgcheck = 1
             enabled = 1
             ret = modules.pkg.mod_repo(

--- a/tests/pytests/functional/states/pkgrepo/test_debian.py
+++ b/tests/pytests/functional/states/pkgrepo/test_debian.py
@@ -616,8 +616,8 @@ class Repo:
     @alt_repo.default
     def _default_alt_repo(self):
         """
-        Use an alternative repo, packages do not
-        exist for the OS on repo.saltproject.io
+        Use an alternative repo, packages do not exist for the OS on
+        packages.broadcom.com
         """
         if (
             self.grains["osfullname"] == "Ubuntu"
@@ -777,7 +777,7 @@ def test_adding_repo_file_signedby_alt_file(pkgrepo, states, repo):
     assert repo.repo_content in ret.comment
 
     key_file = repo.key_file.parent / "salt-alt-key.gpg"
-    repo_content = "deb [arch=amd64 signed-by={}] https://repo.saltproject.io/py3/debian/10/amd64/latest buster main".format(
+    repo_content = "deb [arch=amd64 signed-by={}] https://packages.broadcom.com/artifactory/saltproject-deb/ buster main".format(
         str(key_file)
     )
     ret = states.pkgrepo.managed(

--- a/tests/pytests/integration/netapi/test_ssh_client.py
+++ b/tests/pytests/integration/netapi/test_ssh_client.py
@@ -149,7 +149,8 @@ def test_shell_inject_ssh_priv(
     """
     # ZDI-CAN-11143
     path = tmp_path / "test-11143"
-    tgts = ["repo.saltproject.io", "www.zerodayinitiative.com"]
+    tgts = ["packages.broadcom.com", "www.zerodayinitiative.com"]
+    ret = None
     for tgt in tgts:
         low = {
             "roster": "cache",

--- a/tests/support/win_installer.py
+++ b/tests/support/win_installer.py
@@ -10,6 +10,7 @@
 """
 
 import hashlib
+from html.parser import HTMLParser
 
 import requests
 


### PR DESCRIPTION
### What does this PR do?

This PR backports https://github.com/saltstack/salt/commit/58f448405b7f46505b2047ecda72abb42b6df9d1 and https://github.com/saltstack/salt/commit/79d4ff772a162b5b8e602e3437c13b90a25bc190 in order to fix current tests failures we have in the Salt Shaker CI after the deprecation of `repo.saltproject.io`.

```
04:08:43  FAILED tests/integration/modules/test_cp.py::CPModuleTest::test_get_file_str_https - AssertionError: 'Salt Project' not found in 'The minion function caused an ...
04:08:43  FAILED tests/integration/modules/test_cp.py::CPModuleTest::test_get_url_https - AssertionError: 'Salt Project' not found in ''
04:08:43  FAILED tests/integration/modules/test_cp.py::CPModuleTest::test_get_url_https_dest_empty - FileNotFoundError: [Errno 2] No such file or directory: 'The minion functio...
04:08:43  FAILED tests/integration/modules/test_cp.py::CPModuleTest::test_get_url_https_no_dest - AssertionError: 'Salt Project' not found in 'The minion function caused an ...
```

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
