### PR TITLE
Remove password from shell after functional text matching

### DIFF
--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -386,6 +386,13 @@ class Shell:
             cmd_lst.append("/bin/sh {}".format(cmd_part))
         return cmd_lst
 
+    def _sanitize_str(self, text, sanitize_text):
+        """Remove all occurrences of sanitize_text from text"""
+        if not sanitize_text:
+            return text
+        replace_str = "*" * 6
+        return re.sub(r"\b" + re.escape(sanitize_text) + r"\b", replace_str, text)
+
     def _run_cmd(self, cmd, key_accept=False, passwd_retries=3):
         """
         Execute a shell command via VT. This is blocking and assumes that ssh
@@ -417,15 +424,11 @@ class Shell:
             while term.has_unread_data:
                 stdout, stderr = term.recv()
                 if stdout:
-                    if self.passwd:
-                        stdout = stdout.replace(self.passwd, ("*" * 6))
                     ret_stdout += stdout
                     buff = old_stdout + stdout
                 else:
                     buff = stdout
                 if stderr:
-                    if self.passwd:
-                        stderr = stderr.replace(self.passwd, ("*" * 6))
                     ret_stderr += stderr
                 if buff and RSTR_RE.search(buff):
                     # We're getting results back, don't try to send passwords
@@ -458,7 +461,7 @@ class Shell:
                         ret_stdout = (
                             "The host key needs to be accepted, to "
                             "auto accept run salt-ssh with the -i "
-                            "flag:\n{}".format(stdout)
+                            f"flag:\n{self._sanitize_str(stdout, self.passwd)}"
                         )
                         return ret_stdout, "", 254
                 elif buff and SUDO_PROMPT_RE.search(buff):
@@ -484,6 +487,8 @@ class Shell:
                     # as we just need to ensure the child process in term finished
                     # to get proper term.exitstatus instead of None
                     pass
+            ret_stdout = self._sanitize_str(ret_stdout, self.passwd)
+            ret_stderr = self._sanitize_str(ret_stderr, self.passwd)
             return ret_stdout, ret_stderr, term.exitstatus
         finally:
             term.close(terminate=True, kill=True)


### PR DESCRIPTION
### What does this PR do?

### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/22543

Upstream port: https://github.com/saltstack/salt/pull/67754

### Previous Behavior
When user used the `password` or `Password` keywords as the password for `salt-ssh`, Salt would replace all occurrences of the word, which would cause further text processing to fail.

### New Behavior
We first process the text (i.e. match whether SSH is asking for password), and do password removal as the last step before returning the text to user.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
