### PR TITLE
Implement multiple inventory for `ansible.targets`

### DIFF
--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -423,7 +423,7 @@ def playbooks(
     return retdata
 
 
-def targets(inventory="/etc/ansible/hosts", yaml=False, export=False):
+def targets(inventory=None, inventories=None, yaml=False, export=False):
     """
     .. versionadded:: 3005
 
@@ -431,6 +431,10 @@ def targets(inventory="/etc/ansible/hosts", yaml=False, export=False):
 
     :param inventory:
         The inventory file to read the inventory from. Default: "/etc/ansible/hosts"
+
+    :param inventories:
+        The list of inventory files to read the inventory from.
+        Uses `inventory` in case if `inventories` is not specified.
 
     :param yaml:
         Return the inventory as yaml output. Default: False
@@ -446,7 +450,9 @@ def targets(inventory="/etc/ansible/hosts", yaml=False, export=False):
         salt 'ansiblehost' ansible.targets inventory=my_custom_inventory
 
     """
-    return salt.utils.ansible.targets(inventory=inventory, yaml=yaml, export=export)
+    return salt.utils.ansible.targets(
+        inventory=inventory, inventories=inventories, yaml=yaml, export=export
+    )
 
 
 def discover_playbooks(

--- a/tests/pytests/unit/modules/test_ansiblegate.py
+++ b/tests/pytests/unit/modules/test_ansiblegate.py
@@ -189,6 +189,125 @@ def test_ansible_targets(minion_opts):
             assert len(ret["ungrouped"]["hosts"]) == 2
 
 
+def test_ansible_targets_multiple_inventories(minion_opts):
+    """
+    Test ansible.targets execution module function with multiple inventories.
+    :return:
+    """
+    ansible_inventory1_ret = """
+{
+    "_meta": {
+        "hostvars": {
+            "uyuni-stable-ansible-centos7-1.tf.local": {
+                "ansible_ssh_private_key_file": "/etc/ansible/my_ansible_private_key"
+            },
+            "uyuni-stable-ansible-centos7-2.tf.local": {
+                "ansible_ssh_private_key_file": "/etc/ansible/my_ansible_private_key"
+            }
+        }
+    },
+    "all": {
+        "children": [
+            "ungrouped"
+        ]
+    },
+    "ungrouped": {
+        "hosts": [
+            "uyuni-stable-ansible-centos7-1.tf.local",
+            "uyuni-stable-ansible-centos7-2.tf.local"
+        ]
+    }
+}
+    """
+    ansible_inventory2_ret = """
+{
+    "_meta": {
+        "hostvars": {
+            "uyuni-stable-ansible-alma9-1.tf.local": {
+                "ansible_ssh_private_key_file": "/etc/ansible/my_ansible_private_key"
+            },
+            "uyuni-stable-ansible-alma9-2.tf.local": {
+                "ansible_ssh_private_key_file": "/etc/ansible/my_ansible_private_key"
+            }
+        }
+    },
+    "all": {
+        "children": [
+            "ungrouped"
+        ]
+    },
+    "ungrouped": {
+        "hosts": [
+            "uyuni-stable-ansible-alma9-1.tf.local",
+            "uyuni-stable-ansible-alma9-2.tf.local"
+        ]
+    }
+}
+    """
+    ansible_inventory_mock = MagicMock(
+        side_effect=[ansible_inventory1_ret, ansible_inventory2_ret]
+    )
+    with patch("salt.utils.path.which", MagicMock(return_value=True)):
+        utils = salt.loader.utils(minion_opts, whitelist=["ansible"])
+        with patch("salt.modules.cmdmod.run", ansible_inventory_mock), patch.dict(
+            ansiblegate.__utils__, utils
+        ), patch("os.path.isfile", MagicMock(return_value=True)):
+            ret = ansiblegate.targets(
+                inventories=["/etc/ansible/hosts1", "/etc/ansible/hosts2"]
+            )
+            assert ansible_inventory_mock.call_args
+            assert ansible_inventory_mock.call_args
+            assert len(ret.keys()) == 2
+            assert "/etc/ansible/hosts1" in ret.keys()
+            assert "/etc/ansible/hosts2" in ret.keys()
+            assert "_meta" in ret["/etc/ansible/hosts1"]
+            assert "_meta" in ret["/etc/ansible/hosts2"]
+            assert (
+                "uyuni-stable-ansible-centos7-1.tf.local"
+                in ret["/etc/ansible/hosts1"]["_meta"]["hostvars"]
+            )
+            assert (
+                "uyuni-stable-ansible-centos7-2.tf.local"
+                in ret["/etc/ansible/hosts1"]["_meta"]["hostvars"]
+            )
+            assert (
+                "uyuni-stable-ansible-alma9-1.tf.local"
+                in ret["/etc/ansible/hosts2"]["_meta"]["hostvars"]
+            )
+            assert (
+                "uyuni-stable-ansible-alma9-2.tf.local"
+                in ret["/etc/ansible/hosts2"]["_meta"]["hostvars"]
+            )
+            assert (
+                "ansible_ssh_private_key_file"
+                in ret["/etc/ansible/hosts1"]["_meta"]["hostvars"][
+                    "uyuni-stable-ansible-centos7-1.tf.local"
+                ]
+            )
+            assert (
+                "ansible_ssh_private_key_file"
+                in ret["/etc/ansible/hosts1"]["_meta"]["hostvars"][
+                    "uyuni-stable-ansible-centos7-2.tf.local"
+                ]
+            )
+            assert (
+                "ansible_ssh_private_key_file"
+                in ret["/etc/ansible/hosts2"]["_meta"]["hostvars"][
+                    "uyuni-stable-ansible-alma9-1.tf.local"
+                ]
+            )
+            assert (
+                "ansible_ssh_private_key_file"
+                in ret["/etc/ansible/hosts2"]["_meta"]["hostvars"][
+                    "uyuni-stable-ansible-alma9-2.tf.local"
+                ]
+            )
+            assert "all" in ret["/etc/ansible/hosts1"]
+            assert "all" in ret["/etc/ansible/hosts2"]
+            assert len(ret["/etc/ansible/hosts1"]["ungrouped"]["hosts"]) == 2
+            assert len(ret["/etc/ansible/hosts2"]["ungrouped"]["hosts"]) == 2
+
+
 def test_ansible_discover_playbooks_single_path():
     playbooks_dir = os.path.join(
         RUNTIME_VARS.TESTS_DIR, "unit/files/playbooks/example_playbooks/"


### PR DESCRIPTION
### What does this PR do?

Adds `inventories` parameter for `ansible.targets` in case if the list passed to this parameter the function will return the dict with the inventory filenames as the keys and the content inside.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/26439
Upstream PR: https://github.com/saltstack/salt/pull/67776

### Previous Behavior
`ansible.targets` returns the content of only one single inventory

### New Behavior
`ansible.targets` can return the content of multiple inventory files

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
