### PR TITLE
Make x509 module compatible with M2Crypto 0.44.0

### DIFF
--- a/salt/modules/x509.py
+++ b/salt/modules/x509.py
@@ -42,8 +42,14 @@ from salt.utils.odict import OrderedDict
 
 try:
     import M2Crypto
+
+    # These imports intended to be used from M2Crypto,
+    # but not loaded by-default with recent M2Crypto version.
+    from M2Crypto import ASN1, BIO, EVP, RSA, X509, m2  # pylint: disable=unused-import
+
+    HAS_M2 = True
 except ImportError:
-    M2Crypto = None
+    HAS_M2 = False
 
 try:
     import OpenSSL
@@ -92,7 +98,7 @@ def __virtual__():
     if __opts__.get("features", {}).get("x509_v2"):
         return (False, "Superseded, using x509_v2")
     return (
-        __virtualname__ if M2Crypto is not None else False,
+        __virtualname__ if HAS_M2 else False,
         "Could not load x509 module, m2crypto unavailable",
     )
 


### PR DESCRIPTION
### What does this PR do?

Even if the module is specified as deprecated, we need to keep it working until it gets removed with 3009.
With the most recent M2Crypto version there are differences in the exported objects, so it's better to align import to make it compatible.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/26233
Upstream PR: https://github.com/saltstack/salt/pull/67782

### Previous Behavior
Exceptions on loading the module with new M2Crypto version due to the differences in exports

### New Behavior
Now is compatible with new and the previous versions

### Merge requirements satisfied?
No need to adjust the tests as they were failing with the recent M2Crypto version.

**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
