### PR TITLE
Detect openEuler as RedHat family OS

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1845,6 +1845,7 @@ _OS_FAMILY_MAP = {
     "Alinux": "RedHat",
     "Mendel": "Debian",
     "OSMC": "Debian",
+    "openEuler": "RedHat",
 }
 
 

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -1425,6 +1425,33 @@ def test_astralinuxse_os_grains():
     _run_os_grains_tests(_os_release_data, {}, expectation)
 
 
+@pytest.mark.skip_unless_on_linux
+def test_openeuler_os_grains():
+    """
+    Test that OS grains are parsed correctly for openEuler
+    """
+    # /etc/os-release data taken from openEuler 24.03 (LTS-SP1)
+    _os_release_data = {
+        "PRETTY_NAME": "openEuler 24.03 (LTS-SP1)",
+        "NAME": "openEuler",
+        "ID": "openEuler",
+        "ANSI_COLOR": "0;31",
+        "VERSION": "24.03 (LTS-SP1)",
+        "VERSION_ID": "24.03",
+    }
+    expectation = {
+        "os": "openEuler",
+        "os_family": "RedHat",
+        "oscodename": "openEuler 24.03 (LTS-SP1)",
+        "osfullname": "openEuler",
+        "osrelease": "24.03",
+        "osrelease_info": (24, 3),
+        "osmajorrelease": 24,
+        "osfinger": "openEuler-24",
+    }
+    _run_os_grains_tests(_os_release_data, {}, expectation)
+
+
 @pytest.mark.skip_unless_on_windows
 def test_windows_platform_data():
     """


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/saltstack/salt/pull/67796

Adds openEuler as RedHat family distro (https://www.openeuler.org/)

### What issues does this PR fix or reference?
Upstream PR: https://github.com/saltstack/salt/pull/67796
Tracks: https://github.com/SUSE/spacewalk/issues/26467

### Previous Behavior
Identifying `os_family` as `openEuler` even if it's a RedHat clone

### New Behavior
Identifying `os_family` as `RedHat`


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
