### PR TITLE
Fix DEB822 'NoneType' object has no attribute 'split'

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2807,7 +2807,9 @@ def mod_repo(repo, saltenv="base", aptkey=True, **kwargs):
             if not invalid:
                 repos.append(source)
         else:
-            if HAS_DEB822 and (source.types == [""] or not bool(source.types)):
+            if HAS_DEB822 and (
+                source.types == [""] or not bool(source.types) or not source.type
+            ):
                 # most probably invalid or comment line
                 continue
             repos.append(source)

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -2807,7 +2807,7 @@ def mod_repo(repo, saltenv="base", aptkey=True, **kwargs):
             if not invalid:
                 repos.append(source)
         else:
-            if HAS_DEB822 and source.types == [""]:
+            if HAS_DEB822 and (source.types == [""] or not bool(source.types)):
                 # most probably invalid or comment line
                 continue
             repos.append(source)
@@ -2991,8 +2991,10 @@ def mod_repo(repo, saltenv="base", aptkey=True, **kwargs):
         kwargs["comments"] = salt.utils.pkg.deb.combine_comments(kwargs["comments"])
 
     if not mod_source:
-        if HAS_DEB822:
-            apt_source_file = kwargs.get("file")
+        apt_source_file = kwargs.get("file")
+        if not apt_source_file:
+            raise SaltInvocationError("missing 'file' argument when defining a new repository")
+        if HAS_DEB822 and not apt_source_file.endswith(".list"):
             section = _deb822.Section("")
             section["Types"] = repo_type
             section["URIs"] = repo_uri


### PR DESCRIPTION
### What does this PR do?

Previously, we merged [0] to add support for DEB822. However, we missed two things:

- When filtering invalid repos in `mod_repo`, depending on the version of `python3-aptpkg`, an invalid repo might have `source.types` set to either `[]`, or `[""]`.
- When creating a new repo, Ubuntu doesn't like DEB822-style repositories (multi-line) in a `.lines` file. This seems to be expected as per [1].

[0] https://github.com/openSUSE/salt/pull/692
[1] https://repolib.readthedocs.io/en/latest/deb822-format.html#one-line-style-format


### Previous Behavior
On some systems, creating a repository might fail with `'NoneType' object has no attribute 'split'`.

### New Behavior
The error is fixed.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
