### PR TITLE
Fix refresh of osrelease and related grains on Python 3.10+

### DIFF
--- a/changelog/67932.fixed.md
+++ b/changelog/67932.fixed.md
@@ -1,0 +1,1 @@
+Fix refresh of osrelease and related grains on Python 3.10+

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2170,6 +2170,11 @@ def _linux_distribution_data():
 
     log.trace("Getting OS name, release, and codename from freedesktop_os_release")
     try:
+        # If using platform.freedesktop_os_release we must invalidate
+        # the internal platform os_release cache to allow grains to be
+        # actually recalculated during grains_refresh
+        if hasattr(platform, "_os_release_cache"):
+            platform._os_release_cache = None
         os_release = _freedesktop_os_release()
         grains.update(_os_release_to_grains(os_release))
 

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -407,6 +407,47 @@ def test__linux_lsb_distrib_data():
 
 
 @pytest.mark.skip_unless_on_linux
+@pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="platform.freedesktop_os_release not available in Python < 3.10",
+)
+def test__freedesktop_os_release_cache_is_invalidated():
+    OS_RELEASE_DATA = {
+        "NAME": "openSUSE Leap",
+        "ID": "opensuse-leap",
+        "PRETTY_NAME": "openSUSE Leap 15.6",
+        "VERSION": "15.6",
+        "ID_LIKE": "suse opensuse",
+        "VERSION_ID": "15.6",
+        "ANSI_COLOR": "0;32",
+        "CPE_NAME": "cpe:/o:opensuse:leap:15.6",
+        "BUG_REPORT_URL": "https://bugs.opensuse.org",
+        "HOME_URL": "https://www.opensuse.org/",
+        "DOCUMENTATION_URL": "https://en.opensuse.org/Portal:Leap",
+        "LOGO": "distributor-logo-Leap",
+    }
+
+    class FreeDesktopOSReleaseMock:
+        def __call__(self):
+            if hasattr(platform, "_os_release_cache"):
+                assert platform._os_release_cache is None
+            return OS_RELEASE_DATA
+
+    with patch.object(
+        core, "_linux_lsb_distrib_data", MagicMock(return_value=({}, None))
+    ), patch.object(
+        core, "_freedesktop_os_release", FreeDesktopOSReleaseMock()
+    ), patch.object(
+        core,
+        "_legacy_linux_distribution_data",
+        MagicMock(return_value={"osrelease": "15.6"}),
+    ):
+        platform._os_release_cache = {"this-cache-should-be-invalidated": "foobar"}
+        ret = core._linux_distribution_data()
+        assert ret == {"osrelease": "15.6"}
+
+
+@pytest.mark.skip_unless_on_linux
 def test_gnu_slash_linux_in_os_name():
     """
     Test to return a list of all enabled services


### PR DESCRIPTION
### What does this PR do?

This PR backports https://github.com/saltstack/salt/pull/67933 to `openSUSE/release/3006.0` branch.

---
This PR fixes an issue introduced by https://github.com/saltstack/salt/commit/dab8ea5b45323a8f0f814db60ea6d6fcc6daa406 , as the `platform` library contains an internal os release cache.

This internal cache causes that the `osrelease` and other related grains are not getting refreshed when running `saltutil.refresh_grains`.

This PR fixes this issue, by invalidating the internal cache, if existing, at the time of calculating  the os related grains.


