### PR TITLE
Speedup wheel key.finger call (bsc#1240532)

### DIFF
--- a/salt/key.py
+++ b/salt/key.py
@@ -543,12 +543,13 @@ class Key:
         for dir_ in key_dirs:
             if dir_ is None:
                 continue
-            ret[os.path.basename(dir_)] = []
+            base_dir = os.path.basename(dir_)
+            ret[base_dir] = []
             try:
                 for fn_ in salt.utils.data.sorted_ignorecase(os.listdir(dir_)):
                     if not fn_.startswith("."):
                         if os.path.isfile(os.path.join(dir_, fn_)):
-                            ret[os.path.basename(dir_)].append(
+                            ret[base_dir].append(
                                 salt.utils.stringutils.to_unicode(fn_)
                             )
             except OSError:

--- a/salt/key.py
+++ b/salt/key.py
@@ -491,16 +491,15 @@ class Key:
         ret = {}
         if "," in match and isinstance(match, str):
             match = match.split(",")
+        if not isinstance(match, list):
+            match = [match]
         for status, keys in matches.items():
+            if match == ["*"] and keys:
+                ret[status] = keys
+                continue
             for key in salt.utils.data.sorted_ignorecase(keys):
-                if isinstance(match, list):
-                    for match_item in match:
-                        if fnmatch.fnmatch(key, match_item):
-                            if status not in ret:
-                                ret[status] = []
-                            ret[status].append(key)
-                else:
-                    if fnmatch.fnmatch(key, match):
+                for match_item in match:
+                    if fnmatch.fnmatch(key, match_item):
                         if status not in ret:
                             ret[status] = []
                         ret[status].append(key)

--- a/salt/master.py
+++ b/salt/master.py
@@ -2094,7 +2094,14 @@ class ClearFuncs(TransportMethods):
             }
 
             self.event.fire_event(data, tagify([jid, "new"], "wheel"))
-            clear_load["print_event"] = clear_load.get("print_event", False)
+            clear_load.update(
+                {
+                    "__jid__": jid,
+                    "__tag__": tag,
+                    "__user__": username,
+                    "print_event": clear_load.get("print_event", False),
+                }
+            )
             ret = self.wheel_.call_func(fun, full_return=True, **clear_load)
             data["return"] = ret["return"]
             data["success"] = ret["success"]

--- a/salt/master.py
+++ b/salt/master.py
@@ -2094,6 +2094,7 @@ class ClearFuncs(TransportMethods):
             }
 
             self.event.fire_event(data, tagify([jid, "new"], "wheel"))
+            clear_load["print_event"] = clear_load.get("print_event", False)
             ret = self.wheel_.call_func(fun, full_return=True, **clear_load)
             data["return"] = ret["return"]
             data["success"] = ret["success"]

--- a/salt/master.py
+++ b/salt/master.py
@@ -2092,8 +2092,6 @@ class ClearFuncs(TransportMethods):
                 "tag": tag,
                 "user": username,
             }
-
-            self.event.fire_event(data, tagify([jid, "new"], "wheel"))
             clear_load.update(
                 {
                     "__jid__": jid,
@@ -2105,7 +2103,6 @@ class ClearFuncs(TransportMethods):
             ret = self.wheel_.call_func(fun, full_return=True, **clear_load)
             data["return"] = ret["return"]
             data["success"] = ret["success"]
-            self.event.fire_event(data, tagify([jid, "ret"], "wheel"))
             return {"tag": tag, "data": data}
         except Exception as exc:  # pylint: disable=broad-except
             log.error("Exception occurred while introspecting %s: %s", fun, exc)


### PR DESCRIPTION
### What does this PR do?

There are some performance issues with `key.finger` which is used on accessing `Salt Keys` page in Uyuni/MLM and in some condition just a single call can take more than 8 seconds. These changes help to reduce the time of processing almost twice.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/23526, https://github.com/SUSE/spacewalk/issues/26998
Upstream PR: https://github.com/saltstack/salt/pull/68251

### Previous Behavior
The wheel `key.finger` call is too slow and in case of having 20-30K minions registered could take up to 8 seconds

### New Behavior
With this change instead of 8 seconds, it takes about 4-5 seconds with the same amount of minions

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
