### PR TITLE
[salt-shaker] Fix debian tests

### DIFF
--- a/tests/pytests/functional/modules/test_pkg.py
+++ b/tests/pytests/functional/modules/test_pkg.py
@@ -118,7 +118,7 @@ def test_mod_del_repo(grains, modules, refresh_db):
 
     try:
         # ppa:otto-kesselgulasch/gimp-edge has no Ubuntu 22.04 repo
-        if grains["os"] == "Ubuntu" and grains["osmajorrelease"] != 22:
+        if grains["os"] == "Ubuntu" and grains["osmajorrelease"] < 22:
             repo = "ppa:otto-kesselgulasch/gimp-edge"
             uri = "http://ppa.launchpad.net/otto-kesselgulasch/gimp-edge/ubuntu"
             ret = modules.pkg.mod_repo(repo, "comps=main")
@@ -208,7 +208,8 @@ def test_owner(modules):
     """
     test finding the package owning a file
     """
-    ret = modules.pkg.owner("/bin/ls")
+    binary = shutil.which("ls")
+    ret = modules.pkg.owner(binary)
     assert len(ret) != 0
 
 

--- a/tests/pytests/functional/modules/test_system.py
+++ b/tests/pytests/functional/modules/test_system.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import os
+import shutil
 import signal
 import subprocess
 import textwrap
@@ -119,6 +120,9 @@ def hwclock_has_compare(cmdmod):
     systems where it's not present so that we can skip the
     comparison portion of the test.
     """
+    hwclock = shutil.which("hwclock")
+    if hwclock is None:
+        pytest.skip("The 'hwclock' binary could not be found")
     res = cmdmod.run_all(cmd="hwclock -h")
     _hwclock_has_compare_ = res["retcode"] == 0 and res["stdout"].find("--compare") > 0
     return _hwclock_has_compare_

--- a/tests/pytests/functional/states/pkgrepo/test_debian.py
+++ b/tests/pytests/functional/states/pkgrepo/test_debian.py
@@ -647,7 +647,7 @@ class Repo:
 
     @repo_url.default
     def _default_repo_url(self):
-        return f"https://repo.saltproject.io/py3/{self.fullname}/{self.grains['osrelease']}/{self.grains['osarch']}/latest"
+        return "https://packages.broadcom.com/artifactory/saltproject-deb/"
 
     @repo_content.default
     def _default_repo_content(self):

--- a/tests/pytests/functional/states/pkgrepo/test_debian.py
+++ b/tests/pytests/functional/states/pkgrepo/test_debian.py
@@ -4,11 +4,12 @@ import os
 import pathlib
 import shutil
 import sys
-from sysconfig import get_path
+import sysconfig
 
 import _pytest._version
 import attr
 import pytest
+import requests
 
 import salt.utils.files
 from tests.conftest import CODE_DIR
@@ -136,7 +137,7 @@ def system_aptsources(request, grains):
                     "{}".format(*sys.version_info),
                     "{}.{}".format(*sys.version_info),
                 ]
-                session_site_packages_dir = get_path(
+                session_site_packages_dir = sysconfig.get_path(
                     "purelib"
                 )  # note: platlib and purelib could differ
                 session_site_packages_dir = os.path.relpath(
@@ -606,6 +607,7 @@ class Repo:
     key_file = attr.ib()
     sources_list_file = attr.ib()
     repo_file = attr.ib()
+    repo_url = attr.ib()
     repo_content = attr.ib()
     key_url = attr.ib()
 
@@ -643,6 +645,10 @@ class Repo:
     def _default_repo_file(self):
         return self.sources_list_file
 
+    @repo_url.default
+    def _default_repo_url(self):
+        return f"https://repo.saltproject.io/py3/{self.fullname}/{self.grains['osrelease']}/{self.grains['osarch']}/latest"
+
     @repo_content.default
     def _default_repo_content(self):
         if self.alt_repo:
@@ -660,24 +666,25 @@ class Repo:
                 opts = "[arch={arch} signed-by=/usr/share/keyrings/salt-archive-keyring.gpg]".format(
                     arch=self.grains["osarch"]
                 )
-            repo_content = "deb {opts} https://repo.saltproject.io/py3/{}/{}/{arch}/latest {} main".format(
-                self.fullname,
-                self.grains["osrelease"],
-                self.grains["oscodename"],
-                arch=self.grains["osarch"],
-                opts=opts,
+            repo_content = (
+                f"deb {opts} {self.repo_url} {self.grains['oscodename']} main"
             )
         return repo_content
 
     @key_url.default
     def _default_key_url(self):
-        key_url = "https://repo.saltproject.io/py3/{}/{}/{}/latest/salt-archive-keyring.gpg".format(
-            self.fullname, self.grains["osrelease"], self.grains["osarch"]
-        )
-
+        key_url = f"{self.repo_url}/salt-archive-keyring.gpg"
         if self.alt_repo:
             key_url = "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
         return key_url
+
+    @property
+    def exists(self):
+        """
+        Return True if the repository path exists.
+        """
+        response = requests.head(self.key_url, timeout=30)
+        return response.status_code == 200
 
 
 @pytest.fixture
@@ -686,10 +693,14 @@ def repo(request, grains, sources_list_file):
     if "signedby" in request.node.name:
         signedby = True
     repo = Repo(grains=grains, sources_list_file=sources_list_file, signedby=signedby)
-    yield repo
-    for key in [repo.key_file, repo.key_file.parent / "salt-alt-key.gpg"]:
-        if key.is_file():
-            key.unlink()
+    if not repo.exists:
+        pytest.skip(f"The repo url '{repo.repo_url}' does not exist")
+    try:
+        yield repo
+    finally:
+        for key in [repo.key_file, repo.key_file.parent / "salt-alt-key.gpg"]:
+            if key.is_file():
+                key.unlink()
 
 
 def test_adding_repo_file_signedby(pkgrepo, states, repo, subtests):

--- a/tests/pytests/unit/modules/test_aptpkg.py
+++ b/tests/pytests/unit/modules/test_aptpkg.py
@@ -920,10 +920,11 @@ def test_show():
     not (pathlib.Path("/etc") / "apt" / "sources.list").is_file(),
     reason="Requires sources.list file",
 )
-def test_mod_repo_enabled():
+def test_mod_repo_enabled(tmp_path):
     """
     Checks if a repo is enabled or disabled depending on the passed kwargs.
     """
+    file = tmp_path / "repo.list"
     with patch.dict(
         aptpkg.__salt__,
         {"config.option": MagicMock(), "no_proxy": MagicMock(return_value=False)},
@@ -937,19 +938,19 @@ def test_mod_repo_enabled():
                         "salt.modules.aptpkg.SourceEntry", MagicMock(), create=True
                     ):
                         with patch("pathlib.Path", MagicMock()):
-                            repo = aptpkg.mod_repo("foo", enabled=False)
+                            repo = aptpkg.mod_repo("foo", file=file, enabled=False)
                             data_is_true.assert_called_with(False)
                             # with disabled=True; should call salt.utils.data.is_true True
                             data_is_true.reset_mock()
-                            repo = aptpkg.mod_repo("foo", disabled=True)
+                            repo = aptpkg.mod_repo("foo", file=file, disabled=True)
                             data_is_true.assert_called_with(True)
                             # with enabled=True; should call salt.utils.data.is_true with False
                             data_is_true.reset_mock()
-                            repo = aptpkg.mod_repo("foo", enabled=True)
+                            repo = aptpkg.mod_repo("foo", file=file, enabled=True)
                             data_is_true.assert_called_with(True)
                             # with disabled=True; should call salt.utils.data.is_true False
                             data_is_true.reset_mock()
-                            repo = aptpkg.mod_repo("foo", disabled=False)
+                            repo = aptpkg.mod_repo("foo", file=file, disabled=False)
                             data_is_true.assert_called_with(False)
 
 

--- a/tests/pytests/unit/modules/test_kmod.py
+++ b/tests/pytests/unit/modules/test_kmod.py
@@ -4,7 +4,7 @@ import pytest
 
 import salt.modules.kmod as kmod
 from salt.exceptions import CommandExecutionError
-from tests.support.mock import MagicMock, patch
+from tests.support.mock import MagicMock, mock_open, patch
 
 
 @pytest.fixture
@@ -17,7 +17,7 @@ def test_available():
     Tests return a list of all available kernel modules
     """
     with patch("salt.modules.kmod.available", MagicMock(return_value=["kvm"])):
-        assert ["kvm"] == kmod.available()
+        assert kmod.available() == ["kvm"]
 
 
 def test_check_available():
@@ -42,7 +42,7 @@ def test_lsmod():
     ), patch.dict(kmod.__salt__, {"cmd.run": mock_cmd}):
         with pytest.raises(CommandExecutionError):
             kmod.lsmod()
-        assert expected == kmod.lsmod()
+        assert kmod.lsmod() == expected
 
 
 @pytest.mark.skipif(
@@ -55,15 +55,12 @@ def test_mod_list():
     with patch(
         "salt.modules.kmod._get_modules_conf",
         MagicMock(return_value="/etc/modules"),
-    ):
-        with patch(
-            "salt.modules.kmod._strip_module_name", MagicMock(return_value="lp")
-        ):
-            assert ["lp"] == kmod.mod_list(True)
+    ), patch("salt.utils.files.fopen", mock_open(read_data="lp")):
+        assert kmod.mod_list(True) == ["lp"]
 
     mock_ret = [{"size": 100, "module": None, "depcount": 10, "deps": None}]
     with patch("salt.modules.kmod.lsmod", MagicMock(return_value=mock_ret)):
-        assert [None] == kmod.mod_list(False)
+        assert kmod.mod_list(False) == [None]
 
 
 def test_load():
@@ -90,12 +87,10 @@ def test_load():
                 kmod.load(mod, True)
 
             with patch.dict(kmod.__salt__, {"cmd.run_all": mock_run_all_0}):
-                assert [mod] == kmod.load(mod, True)
+                assert kmod.load(mod, True) == [mod]
 
             with patch.dict(kmod.__salt__, {"cmd.run_all": mock_run_all_1}):
-                assert "Error loading module {}: {}".format(mod, err_msg) == kmod.load(
-                    mod
-                )
+                assert kmod.load(mod) == f"Error loading module {mod}: {err_msg}"
 
 
 def test_is_loaded():
@@ -128,11 +123,11 @@ def test_remove():
                 with pytest.raises(CommandExecutionError):
                     kmod.remove(mod)
 
-                assert [mod] == kmod.remove(mod, True)
+                assert kmod.remove(mod, True) == [mod]
 
-                assert [] == kmod.remove(mod)
+                assert kmod.remove(mod) == []
 
             with patch.dict(kmod.__salt__, {"cmd.run_all": mock_run_all_1}):
-                assert "Error removing module {}: {}".format(
-                    mod, err_msg
-                ) == kmod.remove(mod, True)
+                assert (
+                    kmod.remove(mod, True) == f"Error removing module {mod}: {err_msg}"
+                )


### PR DESCRIPTION
### What does this PR do?

This PR:
1. cherry-picks the upstream's 6d02d8336104d03858e819e4e0b7c907f888c25c commit to fix failing Debian-based tests.
2. Fixes the `mod_repo_enabled` test.

### What issues does this PR fix or reference?
Related to: https://github.com/SUSE/spacewalk/issues/27141

