### PR TITLE
Add subsystem filter to udev.exportdb (bsc#1236621)

### DIFF
--- a/salt/modules/udev.py
+++ b/salt/modules/udev.py
@@ -9,7 +9,7 @@ import logging
 
 import salt.modules.cmdmod
 import salt.utils.path
-from salt.exceptions import CommandExecutionError
+from salt.exceptions import CommandExecutionError, SaltInvocationError
 
 __salt__ = {
     "cmd.run_all": salt.modules.cmdmod.run_all,
@@ -162,16 +162,36 @@ def links(dev):
     return info(dev).get("S", None)
 
 
-def exportdb():
-    """
-    Return all the udev database
+def _filter_subsystems(udevadm_info, subsystems):
+    """Filter udevadm_info, keep entries that match any of the passed subsystems."""
+
+    ret = []
+    for entry in udevadm_info:
+        if entry["E"]["SUBSYSTEM"] in subsystems:
+            ret.append(entry)
+    return ret
+
+
+def exportdb(subsystems=None):
+    """Return the complete udev database.
+
+    :param list subsystems: This parameter limits the returned data to specified
+        subsystems such as "pci", "usb", "block", etc.
+
+        .. versionadded :: 3008
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' udev.exportdb
+        salt '*' udev.exportdb subsystems='[usb, block]'
+
     """
+
+    if subsystems is not None:
+        if not isinstance(subsystems, list):
+            raise SaltInvocationError("subsystems must be a list")
 
     cmd = "udevadm info --export-db"
     udev_result = __salt__["cmd.run_all"](cmd, output_loglevel="quiet")
@@ -179,4 +199,8 @@ def exportdb():
     if udev_result["retcode"]:
         raise CommandExecutionError(udev_result["stderr"])
 
-    return _parse_udevadm_info(udev_result["stdout"])
+    ret = _parse_udevadm_info(udev_result["stdout"])
+    if subsystems is not None:
+        ret = _filter_subsystems(ret, subsystems)
+
+    return ret

--- a/tests/pytests/unit/modules/test_udev.py
+++ b/tests/pytests/unit/modules/test_udev.py
@@ -187,3 +187,63 @@ def test_normalize_info():
         "some": "data",
         "key": ["value", "here"],
     }
+
+
+def test_udev_subsystem_filter():
+    udev_db = [
+        {
+            "P": "/devices/LNXSYSTM:00/LNXPWRBN:00",
+            "E": {
+                "MODALIAS": "acpi:LNXPWRBN:",
+                "SUBSYSTEM": "acpi",
+                "DRIVER": "button",
+                "DEVPATH": "/devices/LNXSYSTM:00/LNXPWRBN:00",
+            },
+        },
+        {
+            "P": "/devices/LNXSYSTM:00/LNXPWRBN:00/input/input2",
+            "E": {
+                "SUBSYSTEM": "input",
+                "PRODUCT": "19/0/1/0",
+                "PHYS": '"LNXPWRBN/button/input0"',
+                "NAME": '"Power Button"',
+                "ID_INPUT": 1,
+                "DEVPATH": "/devices/LNXSYSTM:00/LNXPWRBN:00/input/input2",
+                "MODALIAS": "input:b0019v0000p0001e0000-e0,1,k74,ramlsfw",
+                "ID_PATH_TAG": "acpi-LNXPWRBN_00",
+                "TAGS": ":seat:",
+                "PROP": 0,
+                "ID_FOR_SEAT": "input-acpi-LNXPWRBN_00",
+                "KEY": "10000000000000 0",
+                "USEC_INITIALIZED": 2010022,
+                "ID_PATH": "acpi-LNXPWRBN:00",
+                "EV": 3,
+                "ID_INPUT_KEY": 1,
+            },
+        },
+        {
+            "P": "/devices/LNXSYSTM:00/LNXPWRBN:00/input/input2/event2",
+            "E": {
+                "SUBSYSTEM": "input",
+                "XKBLAYOUT": "us",
+                "MAJOR": 13,
+                "ID_INPUT": 1,
+                "DEVPATH": "/devices/LNXSYSTM:00/LNXPWRBN:00/input/input2/event2",
+                "ID_PATH_TAG": "acpi-LNXPWRBN_00",
+                "DEVNAME": "/dev/input/event2",
+                "TAGS": ":power-switch:",
+                "BACKSPACE": "guess",
+                "MINOR": 66,
+                "USEC_INITIALIZED": 2076101,
+                "ID_PATH": "acpi-LNXPWRBN:00",
+                "XKBMODEL": "pc105",
+                "ID_INPUT_KEY": 1,
+            },
+            "N": "input/event2",
+        },
+    ]
+
+    filtered = udev._filter_subsystems(udev_db, ["acpi", "usb"])
+
+    assert len(filtered) == 1
+    assert filtered[0]["P"] == "/devices/LNXSYSTM:00/LNXPWRBN:00"


### PR DESCRIPTION
### What does this PR do?
Add a _subsystem_ filter to `udev.exportdb`. udev databases can be very large and exceed [`max_event_size`](https://docs.saltproject.io/en/3006/ref/configuration/minion.html#max-event-size), triggering `salt.utils.dicttrim.trim_dict()`.

This PR adds a new argument, which is a list of subsystems. `udev.exportdb`'s output is filtered, keeping only data for the specified subsystems.

Upstream PR: https://github.com/saltstack/salt/pull/68047

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/26320
