### PR TITLE
Fix tests issues seen in Salt Shaker environments

### DIFF
--- a/tests/pytests/integration/minion/test_return_retries.py
+++ b/tests/pytests/integration/minion/test_return_retries.py
@@ -56,6 +56,7 @@ def test_publish_retry(salt_master, salt_minion_retry, salt_cli, salt_run_cli):
 
 
 @pytest.mark.slow_test
+@pytest.mark.flaky(max_runs=4)
 def test_pillar_timeout(salt_master_factory):
     cmd = (
         sys.executable

--- a/tests/pytests/unit/test_master.py
+++ b/tests/pytests/unit/test_master.py
@@ -11,6 +11,16 @@ import salt.utils.platform
 from tests.support.mock import MagicMock, patch
 from tests.support.runtests import RUNTIME_VARS
 
+try:
+    import pygit2  # pylint: disable=unused-import
+
+    HAS_PYGIT2 = True
+except ImportError:
+    HAS_PYGIT2 = False
+
+
+skipif_no_pygit2 = pytest.mark.skipif(not HAS_PYGIT2, reason="Missing pygit2")
+
 
 @pytest.fixture
 def encrypted_requests(tmp_path):
@@ -394,6 +404,7 @@ def allowed_funcs(tmp_path):
     return salt.master.AESFuncs(opts=opts)
 
 
+@skipif_no_pygit2
 def test_on_demand_allowed_command_injection(allowed_funcs, tmp_path, caplog):
     """
     Verify on demand pillars validate remote urls

--- a/tests/pytests/unit/utils/test_gitfs.py
+++ b/tests/pytests/unit/utils/test_gitfs.py
@@ -263,6 +263,7 @@ def test_get_cachedir_basename_pygit2(_prepare_provider):
     assert "_" == _prepare_provider.get_cache_basename()
 
 
+@pytest.mark.skipif(not HAS_PYGIT2, reason="This host lacks proper pygit2 support")
 def test_find_file(tmp_path):
     opts = {
         "cachedir": f"{tmp_path / 'cache'}",
@@ -286,6 +287,7 @@ def test_find_file(tmp_path):
     assert gitfs.find_file("asdf") == {"path": "", "rel": ""}
 
 
+@pytest.mark.skipif(not HAS_PYGIT2, reason="This host lacks proper pygit2 support")
 def test_find_file_bad_path(tmp_path):
     opts = {
         "cachedir": f"{tmp_path / 'cache'}",
@@ -310,6 +312,7 @@ def test_find_file_bad_path(tmp_path):
         gitfs.find_file("sdf/../../../asdf")
 
 
+@pytest.mark.skipif(not HAS_PYGIT2, reason="This host lacks proper pygit2 support")
 def test_find_file_bad_env(tmp_path):
     opts = {
         "cachedir": f"{tmp_path / 'cache'}",
@@ -380,6 +383,7 @@ def test_remote_to_url(remote, result):
     assert salt.utils.gitfs.GitFS.remote_to_url(remote) == result
 
 
+@pytest.mark.skipif(not HAS_PYGIT2, reason="This host lacks proper pygit2 support")
 def test_find_file_subdir(tmp_path):
     root = tmp_path / "root"
     root.mkdir()


### PR DESCRIPTION
### What does this PR do?

This PR fixes some issues detected in our Salt Shaker tests for Salt Bundle after the latest changes for the CVE fixes. as we don't have `pygit2` as part of our Salt Bundle. 

Additionally, it flags `tests/pytests/integration/minion/test_return_retries.py` as flaky with `max_runs=4` as we see this test is randomly failing across different tests executions. For example here: https://ci.suse.de/user/manager/my-views/view/Salt%20Shaker/job/manager-salt-shaker-products-testing-sles15sp4-bundle/ 

Upstream PR: https://github.com/saltstack/salt/pull/68125

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
