### PR TITLE
Add `minion_legacy_req_warnings` option to avoid noisy warnings

### DIFF
--- a/salt/channel/server.py
+++ b/salt/channel/server.py
@@ -819,7 +819,7 @@ class ReqServerChannel:
                 ret["aes"] = cipher.encrypt(aes)
                 ret["session"] = cipher.encrypt(salt.utils.stringutils.to_bytes(self.session_key(load["id"])))
 
-        if version < 3:
+        if version < 3 and self.opts.get("minion_legacy_req_warnings", True):
             log.warning(
                 "Minion using legacy request server protocol, please upgrade %s",
                 load["id"],

--- a/tests/pytests/unit/transport/test_zeromq.py
+++ b/tests/pytests/unit/transport/test_zeromq.py
@@ -1034,7 +1034,7 @@ async def test_req_chan_decode_data_dict_entry_v2_bad_key(pki_dir, master_opts, 
     assert "Key verification failed." == excinfo.value.message
 
 
-async def test_req_serv_auth_v1(pki_dir, master_opts, minion_opts):
+async def test_req_serv_auth_v1(pki_dir, master_opts, minion_opts, caplog):
     minion_opts.update(
         {
             "master_uri": "tcp://127.0.0.1:4506",
@@ -1088,8 +1088,24 @@ async def test_req_serv_auth_v1(pki_dir, master_opts, minion_opts):
         "token": token,
         "pub": pub_key,
     }
-    ret = server._auth(load, sign_messages=False)
-    assert "load" not in ret
+    with caplog.at_level(logging.WARNING):
+        ret = server._auth(load, sign_messages=False)
+        assert "Minion using legacy request server protocol, please upgrade minion" in caplog.text
+        assert "load" not in ret
+
+    caplog.clear()
+
+    with caplog.at_level(logging.WARNING), patch.dict(server.opts, {"minion_legacy_req_warnings": False}):
+        ret = server._auth(load, sign_messages=False)
+        assert "Minion using legacy request server protocol, please upgrade minion" not in caplog.text
+        assert "load" not in ret
+
+    caplog.clear()
+
+    with caplog.at_level(logging.WARNING), patch.dict(server.opts, {"minion_legacy_req_warnings": True}):
+        ret = server._auth(load, sign_messages=False)
+        assert "Minion using legacy request server protocol, please upgrade minion" in caplog.text
+        assert "load" not in ret
 
 
 async def test_req_serv_auth_v2(pki_dir, master_opts, minion_opts):


### PR DESCRIPTION
### What does this PR do?

The logging could be very noisy especially in case of large scale deployments.
`minion_legacy_req_warnings` option for the master is set to `True` by default, so it will keep writing the messages like:
```
2025-07-03 07:39:42,090 [salt.channel.server:825 ][WARNING ][8515] Minion using legacy request server protocol, please upgrade minion-test1.example.org
2025-07-03 07:39:42,093 [salt.channel.server:825 ][WARNING ][8502] Minion using legacy request server protocol, please upgrade other-minion.example.org
```
It will be possible to suppress such messages with setting `minion_legacy_req_warnings: False` in the master's config.

### Previous Behavior
No any option to suppress noisy messages

### New Behavior
With `minion_legacy_req_warnings: False` it's possible to avoid noisy logging.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
