### PR TITLE
Fix functional.states.test_user for SLES 16 and Micro systems

### DIFF
--- a/tests/pytests/functional/states/test_user.py
+++ b/tests/pytests/functional/states/test_user.py
@@ -138,7 +138,9 @@ def test_user_present_nondefault(grains, modules, states, username, user_home):
     if not salt.utils.platform.is_darwin() and not salt.utils.platform.is_windows():
         assert user_home.is_dir()
 
-    if grains["os_family"] in ("Suse",) and not grains.get("transactional", False):
+    if grains["os_family"] == "Suse" and not (
+        grains.get("transactional", False) or grains.get("osmajorrelease", 0) >= 16
+    ):
         expected_group_name = "users"
     elif grains["os_family"] == "MacOS":
         expected_group_name = "staff"
@@ -381,11 +383,15 @@ def test_user_present_existing(states, username):
 
 
 @pytest.mark.skip_unless_on_linux(reason="underlying functionality only runs on Linux")
-@pytest.mark.skipif(
-    bool(salt.utils.path.which("transactional-update")),
-    reason="Skipping on transactional systems",
-)
-def test_user_present_change_groups(modules, states, username, group_1, group_2):
+def test_user_present_change_groups(
+    grains, modules, states, username, group_1, group_2
+):
+    expected_groups = [group_2.name, group_1.name]
+    if grains["os_family"] == "Suse" and (
+        grains.get("transactional", False) or grains.get("osmajorrelease", 0) >= 16
+    ):
+        expected_groups.append(username)
+
     ret = states.user.present(
         name=username,
         groups=[group_1.name, group_2.name],
@@ -394,7 +400,9 @@ def test_user_present_change_groups(modules, states, username, group_1, group_2)
 
     user_info = modules.user.info(username)
     assert user_info
-    assert user_info["groups"] == [group_2.name, group_1.name]
+    assert sorted(user_info["groups"]) == sorted(expected_groups)
+
+    expected_groups.remove(group_2.name)
 
     # run again and remove group_2
     ret = states.user.present(
@@ -405,17 +413,19 @@ def test_user_present_change_groups(modules, states, username, group_1, group_2)
 
     user_info = modules.user.info(username)
     assert user_info
-    assert user_info["groups"] == [group_1.name]
+    assert sorted(user_info["groups"]) == sorted(expected_groups)
 
 
 @pytest.mark.skip_unless_on_linux(reason="underlying functionality only runs on Linux")
-@pytest.mark.skipif(
-    bool(salt.utils.path.which("transactional-update")),
-    reason="Skipping on transactional systems",
-)
 def test_user_present_change_optional_groups(
-    modules, states, username, group_1, group_2
+    grains, modules, states, username, group_1, group_2
 ):
+    expected_groups = [group_2.name, group_1.name]
+    if grains["os_family"] == "Suse" and (
+        grains.get("transactional", False) or grains.get("osmajorrelease", 0) >= 16
+    ):
+        expected_groups.append(username)
+
     ret = states.user.present(
         name=username,
         optional_groups=[group_1.name, group_2.name],
@@ -424,7 +434,9 @@ def test_user_present_change_optional_groups(
 
     user_info = modules.user.info(username)
     assert user_info
-    assert user_info["groups"] == [group_2.name, group_1.name]
+    assert sorted(user_info["groups"]) == sorted(expected_groups)
+
+    expected_groups.remove(group_2.name)
 
     # run again and remove group_2
     ret = states.user.present(
@@ -435,7 +447,7 @@ def test_user_present_change_optional_groups(
 
     user_info = modules.user.info(username)
     assert user_info
-    assert user_info["groups"] == [group_1.name]
+    assert sorted(user_info["groups"]) == sorted(expected_groups)
 
 
 @pytest.mark.skip_unless_on_linux(reason="underlying functionality only runs on Linux")


### PR DESCRIPTION
### What does this PR do?

Upstream PR containing the fix: https://github.com/saltstack/salt/pull/66630

There is a couple of tests set to skip on TU systems with https://github.com/openSUSE/salt/pull/657, this PR make them running on TU systems as well as on SLES 16 where the group named identical to the user is created by-default.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/27660

### Previous Behavior
Fails of certain tests on SLES 16 and SL Micro 6.2:
```
FAILED tests/pytests/functional/states/test_user.py::test_user_present_nondefault - AssertionError: assert 'new-account-xjguvb' == 'users'
FAILED tests/pytests/functional/states/test_user.py::test_user_present_change_groups - AssertionError: assert ['group-aepc68', 'new-account-1tlro2', 'users'] == ['group-aepc68', 'users']
FAILED tests/pytests/functional/states/test_user.py::test_user_present_change_optional_groups - AssertionError: assert ['group-lpbcl0', 'new-account-1qx2ew', 'users'] == ['group-lpbcl0', 'users']
```

### New Behavior
Tests are successful on SLES 16 and SL Micro 6.2 and also not skipped with the previous versions of SL Micro.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
