### PR TITLE
Even more reliable pillar timeout test

### DIFF
--- a/tests/pytests/integration/minion/test_return_retries.py
+++ b/tests/pytests/integration/minion/test_return_retries.py
@@ -59,10 +59,8 @@ def test_publish_retry(salt_master, salt_minion_retry, salt_cli, salt_run_cli):
 @pytest.mark.slow_test
 @pytest.mark.flaky(max_runs=4)
 def test_pillar_timeout(salt_master_factory, tmp_path):
-    cmd = 'print(\'{"foo": "bar"}\');\n'
-
     with salt.utils.files.fopen(tmp_path / "script.py", "w") as fp:
-        fp.write(cmd)
+        fp.write('print(\'{"foo": "bar"}\');\n')
 
     master_overrides = {
         "ext_pillar": [
@@ -115,9 +113,8 @@ def test_pillar_timeout(salt_master_factory, tmp_path):
     with master.started(), minion1.started(), minion2.started(), minion3.started(), minion4.started(), (
         sls_tempfile
     ):
-        cmd = 'import time; time.sleep(6); print(\'{"foo": "bang"}\');\n'
         with salt.utils.files.fopen(tmp_path / "script.py", "w") as fp:
-            fp.write(cmd)
+            fp.write('import time; time.sleep(6); print(\'{"foo": "bang"}\');\n')
         proc = cli.run("state.sls", sls_name, minion_tgt="*")
         # At least one minion should have a Pillar timeout
         print(proc)

--- a/tests/pytests/integration/minion/test_return_retries.py
+++ b/tests/pytests/integration/minion/test_return_retries.py
@@ -5,6 +5,7 @@ import pytest
 from saltfactories.utils import random_string
 
 from tests.support.helpers import dedent
+import salt.utils.files
 
 
 @pytest.fixture(scope="function")
@@ -57,14 +58,15 @@ def test_publish_retry(salt_master, salt_minion_retry, salt_cli, salt_run_cli):
 
 @pytest.mark.slow_test
 @pytest.mark.flaky(max_runs=4)
-def test_pillar_timeout(salt_master_factory):
-    cmd = (
-        sys.executable
-        + ' -c "import time; time.sleep(4.8); print(\'{\\"foo\\": \\"bar\\"}\');"'
-    ).strip()
+def test_pillar_timeout(salt_master_factory, tmp_path):
+    cmd = 'print(\'{"foo": "bar"}\');\n'
+
+    with salt.utils.files.fopen(tmp_path / "script.py", "w") as fp:
+        fp.write(cmd)
+
     master_overrides = {
         "ext_pillar": [
-            {"cmd_json": cmd},
+            {"cmd_json": f"{sys.executable} {tmp_path / 'script.py'}"},
         ],
         "auto_accept": True,
         "worker_threads": 3,
@@ -110,7 +112,12 @@ def test_pillar_timeout(salt_master_factory):
     sls_tempfile = master.state_tree.base.temp_file(
         "{}.sls".format(sls_name), sls_contents
     )
-    with master.started(), minion1.started(), minion2.started(), minion3.started(), minion4.started(), sls_tempfile:
+    with master.started(), minion1.started(), minion2.started(), minion3.started(), minion4.started(), (
+        sls_tempfile
+    ):
+        cmd = 'import time; time.sleep(6); print(\'{"foo": "bang"}\');\n'
+        with salt.utils.files.fopen(tmp_path / "script.py", "w") as fp:
+            fp.write(cmd)
         proc = cli.run("state.sls", sls_name, minion_tgt="*")
         # At least one minion should have a Pillar timeout
         print(proc)


### PR DESCRIPTION
### What does this PR do?

This PR fixes a flaky test: ` tests/pytests/integration/minion/test_return_retries.py::test_pillar_timeout` that we see regularly in our Salt Shaker tests.

Upstream commit: https://github.com/saltstack/salt/pull/65696/commits/6c74be3b9e78b2502fbf7deceb4f6fb67d3f4548

Additional upstream PR with the `sys.executable` change: https://github.com/saltstack/salt/pull/68331

(NOTE: I'm not backporting the entire upstream PR as it contains also other non-related changes)

### Merge requirements satisfied?
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
