### PR TITLE
Add python3.11 as preferable for salt-ssh to avoid tests fails

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -157,7 +157,7 @@ SSH_PY_CODE='import base64;
 if [ -n "$DEBUG" ]
     then set -x
 fi
-PYTHON_CMDS="/var/tmp/venv-salt-minion/bin/python python3 /usr/libexec/platform-python python27 python2.7 python26 python2.6 python2 python"
+PYTHON_CMDS="/var/tmp/venv-salt-minion/bin/python python3.11 python3 /usr/libexec/platform-python python27 python2.7 python26 python2.6 python2 python"
 for py_cmd in $PYTHON_CMDS
 do
     if command -v "$py_cmd" >/dev/null 2>&1 && "$py_cmd" -c "import sys; sys.exit(not (sys.version_info >= (2, 6)));"


### PR DESCRIPTION
### What does this PR do?

With `salt-ssh` the shim is used on the client side. With `Uyuni` or `SUSE Multi Linux Manager` we are using Salt Bundle only for now, so it doesn't make any sense to try to run the shim with the interpreter which is in EoL for a long time already.
For testing it should be fine to choose python 3.11 as preferred one.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/26171

### Previous Behavior
Some salt-ssh related tests were failing as salt ssh shim was running in the testing environment with python 3.6 even if the flavor of test was selected as python 3.11

### New Behavior
No failing tests due to the issue of selecting wrong interpreter

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
