### PR TITLE
Use versioned python interpreter for salt-ssh

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -157,7 +157,7 @@ SSH_PY_CODE='import base64;
 if [ -n "$DEBUG" ]
     then set -x
 fi
-PYTHON_CMDS="/var/tmp/venv-salt-minion/bin/python python3.11 python3 /usr/libexec/platform-python python27 python2.7 python26 python2.6 python2 python"
+PYTHON_CMDS="/var/tmp/venv-salt-minion/bin/python {{PY3XX_CMD}}python3 /usr/libexec/platform-python python27 python2.7 python26 python2.6 python2 python"
 for py_cmd in $PYTHON_CMDS
 do
     if command -v "$py_cmd" >/dev/null 2>&1 && "$py_cmd" -c "import sys; sys.exit(not (sys.version_info >= (2, 6)));"
@@ -1533,6 +1533,7 @@ ARGS = {arguments}\n'''.format(
                 SSH_PY_CODE=py_code_enc,
                 HOST_PY_MAJOR=sys.version_info[0],
                 SET_PATH=self.set_path,
+                PY3XX_CMD=f"python3.{sys.version_info.minor} " if sys.version_info >= (3, 11) else "",
             )
         else:
             cmd = saltwinshell.gen_shim(py_code_enc)


### PR DESCRIPTION
### What does this PR do?

https://github.com/openSUSE/salt/pull/730 was incomplete and not covering the case when 3.6 and 3.11 python flavors can be used on the same client.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/26171

### Previous Behavior
`salt-ssh` tests were failing when using `3.6` flavor on clients with `3.11` pyhon installed.

### New Behavior
Using the same python flavor for salt-ssh shim as for salt-master.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
