### PR TITLE
Skip test_executor with Python 3.11 as it is flaky

### DIFF
--- a/tests/integration/minion/test_executor.py
+++ b/tests/integration/minion/test_executor.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 import pytest
 
@@ -12,6 +13,10 @@ class ExecutorTest(ModuleCase, ShellCase):
         self.run_function("saltutil.sync_all")
 
     @pytest.mark.slow_test
+    @pytest.mark.skipif(
+        sys.version_info.minor == 11 and "venv-salt-minion" not in sys.executable,
+        reason="Flaky with Python 3.11",
+    )
     def test_executor(self):
         """
         test that dunders are set


### PR DESCRIPTION
### What does this PR do?

With Salt Shaker `tests.integration.minion.test_executor.py::ExecutorTest::test_executor` is always failing while running in CI, but not reproducible with manual runs. For some reason `arg.py` executor module used in the test environment couldn't be syncronised in time, but only in case of running the test with Salt Shaker using Python 3.11.

For some reason adding extra sleeps to wait for the sync to be fully completed doesn't really help and running it few times with marking as `flaky` also doesn't work and it's almost impossible to debug as it is reproducible only while triggering the job with CI.

It should be safe to skip it as there is another bit more complex test **test_executor_with_multijob** which works fine and not flaky.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/26171

### Previous Behavior
`tests.integration.minion.test_executor.py::ExecutorTest::test_executor` fails each time on running with Python 3.11 inside Salt Shaker environment.

### New Behavior
Flaky test skipped

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
