### PR TITLE
Do not break signature verification on latest M2Crypto versions (bsc#1251776)

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -243,7 +243,7 @@ def sign_message(privkey_path, message, passphrase=None):
         md = EVP.MessageDigest("sha1")
         md.update(salt.utils.stringutils.to_bytes(message))
         digest = md.final()
-        return key.sign(digest)
+        return key.sign(digest, algo="sha1")
     else:
         signer = PKCS1_v1_5.new(key)
         return signer.sign(SHA.new(salt.utils.stringutils.to_bytes(message)))
@@ -262,7 +262,7 @@ def verify_signature(pubkey_path, message, signature):
         md.update(salt.utils.stringutils.to_bytes(message))
         digest = md.final()
         try:
-            return pubkey.verify(digest, signature)
+            return pubkey.verify(digest, signature, algo="sha1")
         except RSA.RSAError as exc:
             log.debug("Signature verification failed: %s", exc.args[0])
             return False


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue caused on recent versions of M2Crypto, where the default sign/verify signature algorithm has been changed from `sha1` to `sha256`, leading to broken communication between master and minions where the default algorithm in M2Crypto are not consistent:

```
salt-minion[234565]: [CRITICAL] The payload signature did not validate.
```

We need to make Salt to explicitely set the algorithm to be used during signing and signature verification, so it is the same regardless of the M2Crypto version used in the master or minions.

NOTE: There is no upstream PR for this, as upstream Salt switched already to Cryptography.

Tracks: https://github.com/SUSE/spacewalk/issues/28697

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
