### PR TITLE
Enable service.enabled/disabled for TU minions

### DIFF
--- a/salt/modules/systemd_service.py
+++ b/salt/modules/systemd_service.py
@@ -102,9 +102,8 @@ def _check_available(name):
     Returns boolean telling whether or not the named service is available
     """
     if offline():
-        raise CommandExecutionError(
-            "Cannot run in offline mode. Failed to get information on unit '%s'" % name
-        )
+        units = get_all()
+        return name in units
 
     _status = _systemctl_status(name)
     sd_version = salt.utils.systemd.version(__context__)


### PR DESCRIPTION
### What does this PR do?

Fixes the systemd service module such that `service.enabled` and `service.disabled` work for inside of a transaction.

TODO: Upstream the change

### What issues does this PR fix or reference?
Related to: https://github.com/SUSE/spacewalk/issues/25185


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
