### PR TITLE
Fix virtualenv call in test helper to use proper python version

### DIFF
--- a/tests/support/helpers.py
+++ b/tests/support/helpers.py
@@ -1742,12 +1742,14 @@ class VirtualEnv:
         return data
 
     def _create_virtualenv(self):
-        virtualenv = shutil.which("virtualenv")
-        if not virtualenv:
-            pytest.fail("'virtualenv' binary not found")
+        pyexec = self.get_real_python()
+        if not pyexec:
+            pytest.fail("'python' binary not found for virtualenv")
         cmd = [
-            virtualenv,
-            "--python={}".format(self.get_real_python()),
+            pyexec,
+            "-m",
+            "virtualenv",
+            f"--python={pyexec}",
         ]
         if self.system_site_packages:
             cmd.append("--system-site-packages")


### PR DESCRIPTION
### What does this PR do?

Backport of: https://github.com/saltstack/salt/pull/68494

Forces using proper python version for `virtualenv` call in the test helper.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/28972

### Previous Behavior
Tests using `virtualenv` call could fail in case if `virtualenv` symbolic link is pointing to the flavored python tool for different version of python than used for the current test.

### New Behavior
Tests are using proper version of python and the `virtualenv` module for this version.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
