### PR TITLE
Extend fails to warnings until 2027

### DIFF
--- a/salt/_logging/handlers.py
+++ b/salt/_logging/handlers.py
@@ -36,7 +36,7 @@ class TemporaryLoggingHandler(logging.NullHandler):
 
     def __init__(self, level=logging.NOTSET, max_queue_size=10000):
         warn_until_date(
-            "20260101",
+            "20270101",
             "Please stop using '{name}.TemporaryLoggingHandler'. "
             "'{name}.TemporaryLoggingHandler' will go away after "
             "{{date}}.".format(name=__name__),
@@ -229,7 +229,7 @@ if sys.version_info < (3, 7):
         def __init__(self, queue):  # pylint: disable=useless-super-delegation
             super().__init__(queue)
             warn_until_date(
-                "20260101",
+                "20270101",
                 "Please stop using '{name}.QueueHandler' and instead "
                 "use 'logging.handlers.QueueHandler'. "
                 "'{name}.QueueHandler' will go away after "
@@ -287,7 +287,7 @@ else:
         def __init__(self, queue):  # pylint: disable=useless-super-delegation
             super().__init__(queue)
             warn_until_date(
-                "20260101",
+                "20270101",
                 "Please stop using '{name}.QueueHandler' and instead "
                 "use 'logging.handlers.QueueHandler'. "
                 "'{name}.QueueHandler' will go away after "

--- a/salt/log/__init__.py
+++ b/salt/log/__init__.py
@@ -24,7 +24,7 @@ from salt.log.setup import (
 from salt.utils.versions import warn_until_date
 
 warn_until_date(
-    "20260101",
+    "20270101",
     "Please stop using '{name}' and instead use 'salt._logging'. "
     "'{name}' will go away after {{date}}.".format(name=__name__),
     stacklevel=3,

--- a/salt/log/handlers/__init__.py
+++ b/salt/log/handlers/__init__.py
@@ -12,7 +12,7 @@ from salt._logging.handlers import (
 from salt.utils.versions import warn_until_date
 
 warn_until_date(
-    "20260101",
+    "20270101",
     "Please stop using '{name}' and instead use 'salt._logging.handlers'. "
     "'{name}' will go away after {{date}}.".format(name=__name__),
 )

--- a/salt/log/mixins.py
+++ b/salt/log/mixins.py
@@ -11,7 +11,7 @@ from salt.utils.versions import warn_until_date
 # pylint: enable=unused-import
 
 warn_until_date(
-    "20260101",
+    "20270101",
     "Please stop using '{name}' and instead use 'salt._logging.mixins'. "
     "'{name}' will go away after {{date}}.".format(name=__name__),
 )

--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -21,7 +21,7 @@ from salt._logging.impl import set_log_record_factory as setLogRecordFactory
 from salt.utils.versions import warn_until_date
 
 warn_until_date(
-    "20260101",
+    "20270101",
     "Please stop using '{name}' and instead use 'salt._logging'. "
     "'{name}' will go away after {{date}}. Do note however that "
     "'salt._logging' is now considered a non public implementation "
@@ -34,7 +34,7 @@ def _deprecated_warning(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         warn_until_date(
-            "20260101",
+            "20270101",
             "Please stop using 'salt.log.setup.{name}()' as it no longer does anything and "
             "will go away after {{date}}.".format(name=func.__qualname__),
             stacklevel=4,

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -3215,7 +3215,7 @@ def expand_repo_def(**kwargs):
         NOT USABLE IN THE CLI
     """
     warn_until_date(
-        "20260101",
+        "20270101",
         "The pkg.expand_repo_def function is deprecated and set for removal "
         "after {date}. This is only unsed internally by the apt pkg state "
         "module. If that's not the case, please file an new issue requesting "

--- a/salt/modules/cassandra_mod.py
+++ b/salt/modules/cassandra_mod.py
@@ -45,7 +45,7 @@ def __virtual__():
         )
 
     warn_until_date(
-        "20260101",
+        "20270101",
         "The cassandra returner is broken and deprecated, and will be removed"
         " after {date}. Use the cassandra_cql returner instead",
     )

--- a/salt/returners/cassandra_return.py
+++ b/salt/returners/cassandra_return.py
@@ -53,7 +53,7 @@ def __virtual__():
     if not HAS_PYCASSA:
         return False, "Could not import cassandra returner; pycassa is not installed."
     warn_until_date(
-        "20260101",
+        "20270101",
         "The cassandra returner is broken and deprecated, and will be removed"
         " after {date}. Use the cassandra_cql returner instead",
     )

--- a/salt/returners/django_return.py
+++ b/salt/returners/django_return.py
@@ -57,7 +57,7 @@ __virtualname__ = "django"
 
 def __virtual__():
     warn_until_date(
-        "20260101",
+        "20270101",
         "The django returner is broken and deprecated, and will be removed"
         " after {date}.",
     )


### PR DESCRIPTION
### What does this PR do?

Extend warnings for another year, since we still fully support Salt 3006.