### PR TITLE
Fix tornado's httputil_test syntax for Python 3.6

### DIFF
--- a/salt/ext/tornado/test/httputil_test.py
+++ b/salt/ext/tornado/test/httputil_test.py
@@ -266,7 +266,7 @@ Foo
         d1 = f(1_000)
         d2 = f(10_000)
         if d2 / d1 > 20:
-            self.fail(f"Disposition param parsing is not linear: {d1=} vs {d2=}")
+            self.fail(f"Disposition param parsing is not linear: d1={d1} vs d2={d2}")
 
 
 class HTTPHeadersTest(unittest.TestCase):


### PR DESCRIPTION
### What does this PR do?

Fix f-string syntax for Python 3.6 in `httputil_test`