### PR TITLE
Fix ansible.playbooks extra-vars quoting (bsc#1257831)

### DIFF
--- a/salt/modules/ansiblegate.py
+++ b/salt/modules/ansiblegate.py
@@ -18,6 +18,7 @@ import fnmatch
 import json
 import logging
 import os
+import shlex
 import subprocess
 import sys
 from tempfile import NamedTemporaryFile
@@ -367,9 +368,9 @@ def playbooks(
     if diff:
         command.append("--diff")
     if isinstance(extra_vars, dict):
-        command.append(f"--extra-vars='{json.dumps(extra_vars)}'")
+        command.append(f"--extra-vars={shlex.quote(json.dumps(extra_vars))}")
     elif isinstance(extra_vars, str) and extra_vars.startswith("@"):
-        command.append(f"--extra-vars={extra_vars}")
+        command.append(f"--extra-vars={shlex.quote(extra_vars)}")
     if flush_cache:
         command.append("--flush-cache")
     if inventory:

--- a/tests/pytests/unit/modules/test_ansiblegate.py
+++ b/tests/pytests/unit/modules/test_ansiblegate.py
@@ -1,6 +1,8 @@
 # Author: Bo Maryniuk <bo@suse.de>
 
+import json
 import os
+import shlex
 
 import pytest
 
@@ -351,3 +353,31 @@ def test_ansible_discover_playbooks_multiple_locations():
         "fullpath": os.path.join(playbooks_dir, "example-playbook2/site.yml"),
         "custom_inventory": os.path.join(playbooks_dir, "example-playbook2/hosts"),
     }
+
+
+def test_ansible_playbooks_with_complex_extra_vars():
+    """
+    Test ansible.playbooks execution module function can pass comples extra-vars.
+    """
+    extra_vars = {
+        "test_key1": {
+            "test_subkey1": "single'quote",
+            "test_subkey2": 'double"quote',
+        },
+        "test_key2": {
+            "backquote": "`",
+        },
+    }
+    cmd_run_all = MagicMock(return_value={"retcode": 0, "stdout": '{"foo": "bar"}'})
+    with patch.dict(ansiblegate.__salt__, {"cmd.run_all": cmd_run_all}), patch(
+        "salt.utils.path.which", MagicMock(return_value=True)
+    ):
+        ret = ansiblegate.playbooks("fake-playbook.yml", extra_vars=extra_vars)
+        assert "retcode" in ret
+        cmd_run_all.assert_called_once()
+        passed_extra_vars = {}
+        for arg in shlex.split(cmd_run_all.call_args.kwargs["cmd"]):
+            if arg.startswith("--extra-vars="):
+                passed_extra_vars = arg[13:]
+        passed_extra_vars = json.loads(passed_extra_vars)
+        assert passed_extra_vars == extra_vars


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/saltstack/salt/pull/68787

Fixes the quoting issue on passing complex variables to the playbook execution which could cause issues on passing `--extgra-vars` on running `ansible-playbook`.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/29592

### Previous Behavior
Causing wrong args passing ot `ansible-playbook` in case of using unbalanced quoting and single quotes in general.

### New Behavior
Using proper quoting to pass the args, so no issues.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
