### PR TITLE
Make users with backslash working for salt-ssh (bsc#1254629)

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1059,7 +1059,10 @@ class Single:
             self.python_env = kwargs.get("ssh_python_env")
         else:
             if user:
-                thin_dir = DEFAULT_THIN_DIR.replace("%%USER%%", user)
+                thin_dir = DEFAULT_THIN_DIR.replace(
+                    "%%USER%%",
+                    re.sub(r"[^a-zA-Z0-9\._\-@]", "_", user),
+                )
             else:
                 thin_dir = DEFAULT_THIN_DIR.replace("%%USER%%", "root")
             self.thin_dir = thin_dir.replace(

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -151,7 +151,7 @@ class Shell:
         if self.priv and self.priv != "agent-forwarding":
             options.append("IdentityFile={}".format(self.priv))
         if self.user:
-            options.append("User={}".format(self.user))
+            options.append("User={}".format(shlex.quote(self.user)))
         if self.identities_only:
             options.append("IdentitiesOnly=yes")
 
@@ -197,7 +197,7 @@ class Shell:
         if self.port:
             options.append("Port={}".format(self.port))
         if self.user:
-            options.append("User={}".format(self.user))
+            options.append("User={}".format(shlex.quote(self.user)))
         if self.identities_only:
             options.append("IdentitiesOnly=yes")
 

--- a/tests/pytests/unit/client/ssh/test_shell.py
+++ b/tests/pytests/unit/client/ssh/test_shell.py
@@ -52,3 +52,18 @@ def test_ssh_shell_exec_cmd(caplog):
         ret = _shell.exec_cmd("ls {}".format(passwd))
         assert not any([x for x in ret if passwd in str(x)])
         assert passwd not in caplog.text
+
+
+def test_ssh_using_user_with_backslash():
+    _shell = shell.Shell(
+        opts={"_ssh_version": (4, 9)},
+        host="host.example.org",
+        user="exampledomain\\user",
+        passwd="password",
+    )
+    with patch.object(
+        _shell, "_run_cmd", return_value=(None, None, None)
+    ) as mock_run_cmd:
+        cmd_string = _shell.exec_cmd("whoami")
+        args, _ = mock_run_cmd.call_args
+        assert " User='exampledomain\\user' " in args[0]

--- a/tests/pytests/unit/client/ssh/test_single.py
+++ b/tests/pytests/unit/client/ssh/test_single.py
@@ -871,3 +871,21 @@ def test_ssh_single__cmd_str_sudo_passwd_user(opts):
     )
 
     assert expected in cmd
+
+
+def test_check_thin_dir_with_backslash_user(opts):
+    """
+    Test `thin_dir` path generation for the user with backslash in the name
+    """
+    single = ssh.Single(
+        opts,
+        opts["argv"],
+        "host.example.org",
+        "host.example.org",
+        user="exampledomain\\user",
+        mods={},
+        fsclient=None,
+        mine=False,
+    )
+    assert single.thin_dir == single.opts["thin_dir"]
+    assert ".exampledomain_user_" in single.thin_dir


### PR DESCRIPTION
### What does this PR do?

In some cases it's required to use credentials for the users from AD in DOMAIN\USER format, and it could cause issues with running salt-ssh on the remote system.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/29164
Upstream PR: https://github.com/saltstack/salt/pull/68790

### Previous Behavior
salt-ssh was failing with imporper calculation of target directory or either improper passing the username to ssh/scp commands used internally requiring extra quoting for the username (with extra quoting it was working fine to connect to remote system but was failing with directory path calculation)

### New Behavior
salt-ssh is able to work properly with DOMAIN\USER notation of the username.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
