### PR TITLE
Add `x86_64_v2` as a possible package architecture

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -473,10 +473,9 @@ def normalize_name(name):
             return name
     except ValueError:
         return name
-    if arch in (__grains__["osarch"], "noarch") or salt.utils.pkg.rpm.check_32(
-        arch, osarch=__grains__["osarch"]
-    ):
-        return name[: -(len(arch) + 1)]
+    stripped_name = name[: -(len(arch) + 1)]
+    if salt.utils.pkg.rpm.resolve_name(stripped_name, arch) == stripped_name:
+        return stripped_name
     return name
 
 

--- a/salt/utils/pkg/rpm.py
+++ b/salt/utils/pkg/rpm.py
@@ -13,7 +13,8 @@ import salt.utils.stringutils
 log = logging.getLogger(__name__)
 
 # These arches compiled from the rpmUtils.arch python module source
-ARCHES_64 = ("x86_64", "athlon", "amd64", "ia32e", "ia64", "geode")
+ARCHES_X86_64 = ("x86_64", "x86_64_v2")
+ARCHES_64 = ARCHES_X86_64 + ("athlon", "amd64", "ia32e", "ia64", "geode")
 ARCHES_32 = ("i386", "i486", "i586", "i686")
 ARCHES_PPC = ("ppc", "ppc64", "ppc64le", "ppc64iseries", "ppc64pseries")
 ARCHES_S390 = ("s390", "s390x")
@@ -105,8 +106,12 @@ def resolve_name(name, arch, osarch=None):
     if osarch is None:
         osarch = get_osarch()
 
-    if not check_32(arch, osarch) and arch not in (osarch, "noarch"):
-        name += ".{}".format(arch)
+    if (
+        not check_32(arch, osarch)
+        and arch not in (osarch, "noarch")
+        and not (arch in ARCHES_X86_64 and osarch in ARCHES_X86_64)
+    ):
+        name += f".{arch}"
     return name
 
 

--- a/tests/pytests/unit/modules/test_yumpkg.py
+++ b/tests/pytests/unit/modules/test_yumpkg.py
@@ -2150,3 +2150,19 @@ def test_59705_version_as_accidental_float_should_become_text(
         yumpkg.install("fnord", version=new)
         call = cmd_mock.mock_calls[0][1][0]
         assert call == expected_cmd
+
+
+def test_normalize_name_with_arch_x86_64_v2():
+    """
+    Test if `salt.modules.yumpkg.normalize_name` is able to identify x86_64_v2
+    as a possible package architecture and remove it from name in case of
+    using it on x86_64 and not in any other cases.
+    """
+    with patch("salt.utils.pkg.rpm.get_osarch", MagicMock(return_value="x86_64")):
+        assert yumpkg.normalize_name("chrony.x86_64_v2") == "chrony"
+    with patch("salt.utils.pkg.rpm.get_osarch", MagicMock(return_value="x86_64")):
+        assert yumpkg.normalize_name("chrony.x86_64") == "chrony"
+    with patch("salt.utils.pkg.rpm.get_osarch", MagicMock(return_value="amd64")):
+        assert yumpkg.normalize_name("chrony.x86_64") == "chrony.x86_64"
+    with patch("salt.utils.pkg.rpm.get_osarch", MagicMock(return_value="x86_64")):
+        assert yumpkg.normalize_name("rootfiles.noarch") == "rootfiles"


### PR DESCRIPTION
### What does this PR do?

Port of https://github.com/saltstack/salt/pull/68789

`x86_64_v2` is used by some Linux vendors as a package architecture compatible with `x86_64` and the repos could contain both `x86_64` and `x86_64_v2`.

`yumpkg` module should handle it properly.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/29847

### Previous Behavior
On attempt to install the package, it could be installed, but wrongly reported as not installed.

### New Behavior
No issues with package name normalization.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
