### PR TITLE
Add changelog workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,8 +13,11 @@ Remove this section if not relevant
 **[NOTICE] Bug fixes or features added to Salt require tests.**
 <!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
 - [ ] Docs
-- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
 - [ ] Tests written/updated
+
+RPM Changelog files are not yet required:
+
+- [x] No changelog needed
 
 ### Commits signed with GPG?
 Yes/No

--- a/.github/workflows/changelogs.yaml
+++ b/.github/workflows/changelogs.yaml
@@ -1,0 +1,38 @@
+name: Changelogs
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, closed]
+    branches:
+      - openSUSE/release/*
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  changelog_test:
+    name: Changelog tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+    - name: Checkout
+      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
+      with:
+        fetch-depth: 1
+
+    - id: files
+      uses: Ana06/get-changed-files@25f79e676e7ea1868813e21465014798211fad8c #v2.3.0
+      with:
+        filter: 'pkg/suse/changelogs/*.changes'
+
+    - name: Verify .changes file modification
+      if: "!contains(github.event.pull_request.body, '[x] No changelog needed')"
+      run: |
+        if [ -z "${{ steps.files.outputs.added_modified }}" ]; then
+          echo "error: Missing pkg/suse/changelogs/*.changes files."
+          exit 1
+        fi
+        echo "Found modified .changes files: ${{ steps.files.outputs.added_modified }}"


### PR DESCRIPTION
### What does this PR do?

This PR adds the changelog workflow checker that verifies the presence of a `*.changes` files in any given PR. 

This workflow is present, but temporarily disabled with the addition of ` - [x] No changelog needed`  in the PR template until we migrate fully to the Gitea workflow. 

Issue: https://github.com/SUSE/spacewalk/issues/29640