### PR TITLE
Timezone-aware datetime objects

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -2877,12 +2877,12 @@ def ip_fqdn():
         if not ret["ipv" + ipv_num]:
             ret[key] = []
         else:
+            start_time = datetime.datetime.now(tz=datetime.timezone.utc)
             try:
-                start_time = datetime.datetime.utcnow()
                 info = socket.getaddrinfo(_fqdn, None, socket_type)
                 ret[key] = list({item[4][0] for item in info})
             except (OSError, UnicodeError):
-                timediff = datetime.datetime.utcnow() - start_time
+                timediff = datetime.datetime.now(tz=datetime.timezone.utc) - start_time
                 if timediff.seconds > 5 and __opts__["__role"] == "master":
                     log.warning(
                         'Unable to find IPv%s record for "%s" causing a %s '

--- a/salt/state.py
+++ b/salt/state.py
@@ -175,11 +175,9 @@ def _calculate_fake_duration():
     Generate a NULL duration for when states do not run
     but we want the results to be consistent.
     """
-    utc_start_time = datetime.datetime.utcnow()
-    local_start_time = utc_start_time - (
-        datetime.datetime.utcnow() - datetime.datetime.now()
-    )
-    utc_finish_time = datetime.datetime.utcnow()
+    utc_start_time = datetime.datetime.now(tz=datetime.timezone.utc)
+    local_start_time = utc_start_time.astimezone()
+    utc_finish_time = datetime.datetime.now(tz=datetime.timezone.utc)
     start_time = local_start_time.time().isoformat()
     delta = utc_finish_time - utc_start_time
     # duration in milliseconds.microseconds
@@ -2116,7 +2114,7 @@ class State:
             instance = cls(**init_kwargs)
         # we need to re-record start/end duration here because it is impossible to
         # correctly calculate further down the chain
-        utc_start_time = datetime.datetime.utcnow()
+        utc_start_time = datetime.datetime.now(tz=datetime.timezone.utc)
 
         instance.format_slots(cdata)
         tag = _gen_tag(low)
@@ -2136,10 +2134,9 @@ class State:
                 "comment": "An exception occurred in this state: {}".format(trb),
             }
 
-        utc_finish_time = datetime.datetime.utcnow()
-        timezone_delta = datetime.datetime.utcnow() - datetime.datetime.now()
-        local_finish_time = utc_finish_time - timezone_delta
-        local_start_time = utc_start_time - timezone_delta
+        utc_finish_time = datetime.datetime.now(tz=datetime.timezone.utc)
+        local_finish_time = utc_finish_time.astimezone()
+        local_start_time = utc_start_time.astimezone()
         ret["start_time"] = local_start_time.time().isoformat()
         delta = utc_finish_time - utc_start_time
         # duration in milliseconds.microseconds
@@ -2171,8 +2168,8 @@ class State:
                         *cdata["args"], **cdata["kwargs"]
                     )
 
-                    utc_start_time = datetime.datetime.utcnow()
-                    utc_finish_time = datetime.datetime.utcnow()
+                    utc_start_time = datetime.datetime.now(tz=datetime.timezone.utc)
+                    utc_finish_time = datetime.datetime.now(tz=datetime.timezone.utc)
                     delta = utc_finish_time - utc_start_time
                     duration = (delta.seconds * 1000000 + delta.microseconds) / 1000.0
                     retry_ret["duration"] = duration
@@ -2263,6 +2260,8 @@ class State:
         local_start_time = utc_start_time - (
             datetime.datetime.utcnow() - datetime.datetime.now()
         )
+        low_name = low.get("name")
+        log_low_name = low_name.strip() if isinstance(low_name, str) else low_name
         log.info(
             "Running state [%s] at time %s",
             low["name"].strip() if isinstance(low["name"], str) else low["name"],
@@ -2461,10 +2460,9 @@ class State:
         self.__run_num += 1
         format_log(ret)
         self.check_refresh(low, ret)
-        utc_finish_time = datetime.datetime.utcnow()
-        timezone_delta = datetime.datetime.utcnow() - datetime.datetime.now()
-        local_finish_time = utc_finish_time - timezone_delta
-        local_start_time = utc_start_time - timezone_delta
+        utc_finish_time = datetime.datetime.now(tz=datetime.timezone.utc)
+        local_finish_time = utc_finish_time.astimezone()
+        local_start_time = utc_start_time.astimezone()
         ret["start_time"] = local_start_time.time().isoformat()
         delta = utc_finish_time - utc_start_time
         # duration in milliseconds.microseconds

--- a/salt/utils/jid.py
+++ b/salt/utils/jid.py
@@ -16,7 +16,7 @@ def _utc_now():
     """
     Helper method so tests do not have to patch the built-in method.
     """
-    return datetime.datetime.utcnow()
+    return datetime.datetime.now(tz=datetime.timezone.utc)
 
 
 def gen_jid(opts):

--- a/salt/utils/pkg/rpm.py
+++ b/salt/utils/pkg/rpm.py
@@ -135,7 +135,10 @@ def parse_pkginfo(line, osarch=None):
 
     if install_time not in ("(none)", "0"):
         install_date = (
-            datetime.datetime.utcfromtimestamp(int(install_time)).isoformat() + "Z"
+            datetime.datetime.fromtimestamp(
+                int(install_time), datetime.timezone.utc
+            ).isoformat()
+            + "Z"
         )
         install_date_time_t = int(install_time)
     else:

--- a/tests/pytests/unit/grains/test_core.py
+++ b/tests/pytests/unit/grains/test_core.py
@@ -15,6 +15,7 @@ import socket
 import sys
 import tempfile
 import textwrap
+import warnings
 from collections import namedtuple
 
 import pytest
@@ -2176,7 +2177,8 @@ def _run_fqdn_tests(
         salt.utils.network, "ip_addrs6", MagicMock(return_value=net_ip6_mock)
     ), patch.object(
         core.socket, "getaddrinfo", side_effect=_getaddrinfo
-    ):
+    ), warnings.catch_warnings():
+        warnings.simplefilter("error")
         get_fqdn = core.ip_fqdn()
         ret_keys = ["fqdn_ip4", "fqdn_ip6", "ipv4", "ipv6"]
         for key in ret_keys:

--- a/tests/unit/utils/test_jid.py
+++ b/tests/unit/utils/test_jid.py
@@ -5,6 +5,7 @@ Tests for salt.utils.jid
 
 import datetime
 import os
+import warnings
 
 import salt.utils.jid
 from tests.support.mock import patch
@@ -50,3 +51,8 @@ class JidTestCase(TestCase):
             self.assertEqual(
                 str(no_opts), "gen_jid() missing 1 required positional argument: 'opts'"
             )
+
+    def test_deprecation_65604(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            salt.utils.jid.gen_jid({})


### PR DESCRIPTION
Cherry-pick upstream patch from https://github.com/saltstack/salt/pull/66902 to solve some, if not all, of the `DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).` messages.