### PR TITLE
Read full URI from ldap pillar config

### DIFF
--- a/salt/modules/ldapmod.py
+++ b/salt/modules/ldapmod.py
@@ -190,7 +190,7 @@ class _LDAPConnection:
         self.binddn = binddn
         self.bindpw = bindpw
 
-        if self.uri == "":
+        if self.uri is None or self.uri == "":
             self.uri = "ldap://{}:{}".format(self.server, self.port)
 
         try:

--- a/salt/pillar/pillar_ldap.py
+++ b/salt/pillar/pillar_ldap.py
@@ -271,7 +271,7 @@ def _do_search(conf):
     """
     # Build LDAP connection args
     connargs = {}
-    for name in ["server", "port", "tls", "binddn", "bindpw", "anonymous"]:
+    for name in ["uri", "server", "port", "tls", "binddn", "bindpw", "anonymous"]:
         connargs[name] = _config(name, conf)
     if connargs["binddn"] and connargs["bindpw"]:
         connargs["anonymous"] = False


### PR DESCRIPTION
A full URI allows the user to set a scheme for the ldap connection and enables tls. This is a workaround for the ldap execution module, which is used by the ldap pillar module.

While the ldap auth module supports both "tls" and "starttls" modes, the ldap execution module only supports "starttls", which it calls "tls".

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1254900