### PR TITLE
Fix test failures

### DIFF
--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -740,9 +740,9 @@ def absent(name, **kwargs):
         # architectures of the matched repo to the architectures specified in
         # the repo string passed to this state. If the architectures do not
         # match, then invalidate the match by setting repo to an empty dict.
-        import salt.modules.aptpkg
+        from salt.modules.aptpkg import _split_repo_str
 
-        if set(salt.modules.aptpkg._split_repo_str(stripname)["architectures"]) != set(
+        if set(_split_repo_str(stripname)["architectures"]) != set(
             repo["architectures"]
         ):
             repo = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1717,11 +1717,15 @@ def reap_stray_processes():
         if alive:
             # Give up
             for child in alive:
-                log.warning(
-                    "Process %s survived SIGKILL, giving up:\n%s",
-                    child,
-                    pprint.pformat(child.as_dict()),
-                )
+                try:
+                    log.warning(
+                        "Process %s survived SIGKILL, giving up:\n%s",
+                        child,
+                        pprint.pformat(child.as_dict()),
+                    )
+                except psutil.NoSuchProcess:
+                    # Process killed between the alive check and the log statement
+                    continue
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/modules/test_gem.py
+++ b/tests/integration/modules/test_gem.py
@@ -2,6 +2,7 @@
 Integration tests for Ruby Gem module
 """
 
+import subprocess
 import pytest
 
 from tornado.httpclient import HTTPClient
@@ -79,11 +80,22 @@ class GemModuleTest(ModuleCase):
         self.run_function("gem.uninstall", [self.GEM])
         self.assertFalse(self.run_function("gem.list", [self.GEM]))
 
+    def _get_ruby_version(self):
+        try:
+            output = subprocess.check_output(["ruby", "-v"]).decode("utf-8")
+            version_str = output.split()[1]
+            major_version = int(version_str.split('.')[0])
+            return major_version
+        except (IndexError, subprocess.CalledProcessError, FileNotFoundError):
+            return 0
+
     @pytest.mark.slow_test
     def test_list(self):
         """
         gem.list
         """
+        if self._get_ruby_version() < 3:
+            self.skipTest("Cannot install brass, skipping")
         self.run_function("gem.install", [" ".join(self.GEM_LIST)])
 
         all_ret = self.run_function("gem.list")
@@ -135,7 +147,21 @@ class GemModuleTest(ModuleCase):
 
         self.run_function("gem.update", [self.OLD_GEM])
         gem_list = self.run_function("gem.list", [self.OLD_GEM])
-        self.assertEqual({self.OLD_GEM: [self.NEW_VERSION, self.OLD_VERSION]}, gem_list)
+        installed_versions = gem_list.get(self.OLD_GEM, [])
+
+        if installed_versions == [self.OLD_VERSION]:
+            # gem update may be unable to install a newer version when the
+            # only available release requires a Ruby version not present on
+            # this system (e.g. brass >= 1.3.0 requires Ruby >= 3.1).
+            self.skipTest(
+                "gem update did not install a newer version of {}; the "
+                "latest release may require a newer Ruby version".format(self.OLD_GEM)
+            )
+
+        self.assertEqual(
+            {self.OLD_GEM: [self.NEW_VERSION, self.OLD_VERSION]},
+            gem_list,
+        )
 
         self.run_function("gem.uninstall", [self.OLD_GEM])
         self.assertFalse(self.run_function("gem.list", [self.OLD_GEM]))

--- a/tests/pytests/functional/modules/test_pkg.py
+++ b/tests/pytests/functional/modules/test_pkg.py
@@ -223,11 +223,12 @@ def test_which(grains, modules):
     """
     test finding the package owning a file
     """
-    if grains["os_family"] in ["Debian", "RedHat"]:
-        file = "/bin/mknod"
-    else:
-        file = "/usr/local/bin/salt-call"
-    ret = modules.pkg.which(file)
+    binary = "/bin/ls"
+    if grains["os"] == "Ubuntu" and grains["osmajorrelease"] >= 24:
+        binary = "/usr/bin/ls"
+    elif grains["os"] == "Debian" and grains["osmajorrelease"] >= 13:
+        binary = "/usr/bin/ls"
+    ret = modules.pkg.which(binary)
     assert len(ret) != 0
 
 

--- a/tests/pytests/unit/modules/test_aptpkg.py
+++ b/tests/pytests/unit/modules/test_aptpkg.py
@@ -16,7 +16,6 @@ import pytest
 
 import salt.modules.aptpkg as aptpkg
 import salt.modules.pkg_resource as pkg_resource
-import salt.utils.path
 from salt.exceptions import (
     CommandExecutionError,
     CommandNotFoundError,
@@ -1497,7 +1496,7 @@ def test_sourceslist_multiple_comps():
     """
     repo_line = "deb http://archive.ubuntu.com/ubuntu/ focal-updates main restricted"
     with patch("salt.utils.files.fopen", mock_open(read_data=repo_line)), patch(
-        "pathlib.Path.is_file", side_effect=[True, False]
+        "os.path.isdir", MagicMock(return_value=False)
     ):
         sources = aptpkg.SourcesList()
         for source in sources:
@@ -1523,15 +1522,16 @@ def test_sourceslist_architectures(repo_line):
     """
     Test SourcesList when architectures is in repo
     """
-    with patch("salt.utils.files.fopen", mock_open(read_data=repo_line)):
-        with patch("pathlib.Path.is_file", side_effect=[True, False]):
-            sources = aptpkg.SourcesList()
-            for source in sources:
-                assert source.type == "deb"
-                assert source.uri == "http://archive.ubuntu.com/ubuntu/"
-                assert source.comps == ["main", "restricted"]
-                assert source.dist == "focal-updates"
-                if "," in repo_line:
-                    assert source.architectures == ["amd64", "armel"]
-                else:
-                    assert source.architectures == ["amd64"]
+    with patch("salt.utils.files.fopen", mock_open(read_data=repo_line)), patch(
+        "os.path.isdir", MagicMock(return_value=False)
+    ):
+        sources = aptpkg.SourcesList()
+        for source in sources:
+            assert source.type == "deb"
+            assert source.uri == "http://archive.ubuntu.com/ubuntu/"
+            assert source.comps == ["main", "restricted"]
+            assert source.dist == "focal-updates"
+            if "," in repo_line:
+                assert source.architectures == ["amd64", "armel"]
+            else:
+                assert source.architectures == ["amd64"]


### PR DESCRIPTION
This PR fixes a number of test failures in Salt Bundle pipelines, namely:

`salt/states/pkgrepo.py`:
- https://github.com/saltstack/salt/commit/919994f2b0ce50d5ce89a36e9273fc61013ccc8d 

`tests/pytests/functional/modules/test_pkg.py`:
- https://github.com/saltstack/salt/commit/7835f3acb1179bbe00e8af28a7f3af67fa30afab
- https://github.com/saltstack/salt/commit/6dc6cc3b595de454e68e413308c9875151108d67 

`tests/integration/modules/test_gem.py`:
- Started failing because after several years, brass released a new version
- https://github.com/saltstack/salt/commit/1d4f9dcc40f1845b3fa942794177a671df03f90e

`tests/pytests/unit/modules/test_aptpkg.py`:
- Was broken after our latest code upgrade

Conftest change:
- Backported to upstream at https://github.com/saltstack/salt/pull/68928
