### PR TITLE
Use non vendored tornado with Python 3.11 (bsc#1257583, bsc#1259700)

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -12,7 +12,7 @@ if sys.version_info < (3,):
     )
     sys.stderr.flush()
 
-USE_VENDORED_TORNADO = sys.version_info < (3,12)
+USE_VENDORED_TORNADO = sys.version_info < (3,11)
 
 
 class TornadoImporter:


### PR DESCRIPTION
### What does this PR do?

Enforce using NON-vendored tornado in case of running `salt` with `Python 3.11` and higher.
It causes minion to got stuck with higher versions than `3.11`, but with `3.11` is causing memory leak with the combination of old `tornado` shipped as `salt.ext.tornado` and `pyzmq`.
On the `salt-master` side the situation looks very similar.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/29558, https://github.com/SUSE/spacewalk/issues/30032

### Previous Behavior
Memory leak while using `salt` with `Python 3.11`

### New Behavior
No memory leak.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
