### PR TITLE
Fix the default group for new users in SLE 15.6

### DIFF
--- a/tests/pytests/functional/states/test_user.py
+++ b/tests/pytests/functional/states/test_user.py
@@ -139,7 +139,9 @@ def test_user_present_nondefault(grains, modules, states, username, user_home):
         assert user_home.is_dir()
 
     if grains["os_family"] == "Suse" and not (
-        grains.get("transactional", False) or grains.get("osmajorrelease", 0) >= 16
+        grains.get("transactional", False)
+        or grains.get("osmajorrelease", 0) >= 16
+        or grains.get("osrelease_info", ()) >= (15, 6)
     ):
         expected_group_name = "users"
     elif grains["os_family"] == "MacOS":
@@ -388,7 +390,9 @@ def test_user_present_change_groups(
 ):
     expected_groups = [group_2.name, group_1.name]
     if grains["os_family"] == "Suse" and (
-        grains.get("transactional", False) or grains.get("osmajorrelease", 0) >= 16
+        grains.get("transactional", False)
+        or grains.get("osmajorrelease", 0) >= 16
+        or grains.get("osrelease_info", ()) >= (15, 6)
     ):
         expected_groups.append(username)
 
@@ -422,7 +426,9 @@ def test_user_present_change_optional_groups(
 ):
     expected_groups = [group_2.name, group_1.name]
     if grains["os_family"] == "Suse" and (
-        grains.get("transactional", False) or grains.get("osmajorrelease", 0) >= 16
+        grains.get("transactional", False)
+        or grains.get("osmajorrelease", 0) >= 16
+        or grains.get("osrelease_info", ()) >= (15, 6)
     ):
         expected_groups.append(username)
 


### PR DESCRIPTION
### What does this PR do?

In SLE 15.6 and newer, the default group changed from users(100) to $username(1000)

This is not yet failing in our VM-based tests (Salt Shaker) because we don't update the environment before testing. If we run `zypper dup` before testing, we'll see these fails as well. We should prepare an accompanying PR to Sumaform to update the system before testing so that this change won't fix GH tests but cause fails in Salt Shaker. 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes
