### PR TITLE
Add 'show_changes' to "file.append" and "file.prepend" state functions

### DIFF
--- a/changelog/59329.added.md
+++ b/changelog/59329.added.md
@@ -1,0 +1,1 @@
+Add 'show_changes' arg for file.append and file.prepend states to hide output

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -6317,6 +6317,7 @@ def append(
     defaults=None,
     context=None,
     ignore_whitespace=True,
+    show_changes=True,
 ):
     """
     Ensure that some text appears at the end of a file.
@@ -6407,6 +6408,12 @@ def append(
         Spaces and Tabs in text are ignored by default, when searching for the
         appending content, one space or multiple tabs are the same for salt.
         Set this option to ``False`` if you want to change this behavior.
+
+    show_changes
+        .. versionadded:: 3008.0
+
+        Output a unified diff of the old file and the new file.
+        Set this option to  ``False` to disable this.
 
     Multi-line example:
 
@@ -6544,6 +6551,8 @@ def append(
         if slines != nlines:
             if not __utils__["files.is_text"](name):
                 ret["changes"]["diff"] = "Replace binary file"
+            elif not show_changes:
+                ret["changes"]["diff"] = "<show_changes=False>"
             else:
                 # Changes happened, add them
                 ret["changes"]["diff"] = "\n".join(difflib.unified_diff(slines, nlines))
@@ -6566,6 +6575,8 @@ def append(
     if slines != nlines:
         if not __utils__["files.is_text"](name):
             ret["changes"]["diff"] = "Replace binary file"
+        elif not show_changes:
+            ret["changes"]["diff"] = "<show_changes=False>"
         else:
             # Changes happened, add them
             ret["changes"]["diff"] = "\n".join(difflib.unified_diff(slines, nlines))
@@ -6587,6 +6598,7 @@ def prepend(
     defaults=None,
     context=None,
     header=None,
+    show_changes=True,
 ):
     """
     Ensure that some text appears at the beginning of a file
@@ -6677,6 +6689,12 @@ def prepend(
         Spaces and Tabs in text are ignored by default, when searching for the
         appending content, one space or multiple tabs are the same for salt.
         Set this option to ``False`` if you want to change this behavior.
+
+    show_changes
+        .. versionadded:: 3008.0
+
+        Output a unified diff of the old file and the new file.
+        Set this option to  ``False` to disable this.
 
     Multi-line example:
 
@@ -6830,6 +6848,8 @@ def prepend(
         if slines != nlines:
             if not __utils__["files.is_text"](name):
                 ret["changes"]["diff"] = "Replace binary file"
+            elif not show_changes:
+                ret["changes"]["diff"] = "<show_changes=False>"
             else:
                 # Changes happened, add them
                 ret["changes"]["diff"] = "".join(difflib.unified_diff(slines, nlines))
@@ -6869,6 +6889,8 @@ def prepend(
     if slines != nlines:
         if not __utils__["files.is_text"](name):
             ret["changes"]["diff"] = "Replace binary file"
+        elif not show_changes:
+            ret["changes"]["diff"] = "<show_changes=False>"
         else:
             # Changes happened, add them
             ret["changes"]["diff"] = "".join(difflib.unified_diff(slines, nlines))

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -6413,7 +6413,7 @@ def append(
         .. versionadded:: 3008.0
 
         Output a unified diff of the old file and the new file.
-        Set this option to  ``False` to disable this.
+        Set this option to  ``False`` to disable this.
 
     Multi-line example:
 
@@ -6694,7 +6694,7 @@ def prepend(
         .. versionadded:: 3008.0
 
         Output a unified diff of the old file and the new file.
-        Set this option to  ``False` to disable this.
+        Set this option to  ``False`` to disable this.
 
     Multi-line example:
 

--- a/tests/pytests/functional/states/file/test_append.py
+++ b/tests/pytests/functional/states/file/test_append.py
@@ -160,3 +160,26 @@ append_in_file:
         for state_run in ret:
             assert state_run.result is False
             assert state_run.comment == "check_cmd determined the state failed"
+
+
+@pytest.mark.parametrize("show_changes", (None, True, False))
+def test_append_show_changes(file, show_changes, tmp_path):
+    """
+    Test show_changes argument for file.append
+    """
+
+    name = tmp_path / "testfile-show_changes"
+    name.write_text("#salty!")
+    if show_changes is None:
+        ret = file.append(name=str(name), text="cheese")
+    else:
+        ret = file.append(name=str(name), text="cheese", show_changes=show_changes)
+
+    assert ret.result is True
+    assert name.exists()
+
+    if show_changes in [True, None]:
+        assert "diff" in ret.changes
+        assert "cheese" in ret.changes["diff"]
+    else:
+        assert ret.changes["diff"] == "<show_changes=False>"

--- a/tests/pytests/functional/states/file/test_prepend.py
+++ b/tests/pytests/functional/states/file/test_prepend.py
@@ -34,3 +34,26 @@ def test_prepend_issue_27401_makedirs(file, tmp_path):
     assert name.is_file()
     assert name.read_text() == "cheese\n"
     assert name.parent.is_dir()
+
+
+@pytest.mark.parametrize("show_changes", (None, True, False))
+def test_prepend_show_changes(file, show_changes, tmp_path):
+    """
+    Test show_changes argument for file.prepend
+    """
+
+    name = tmp_path / "testfile-prepend-show_changes"
+    name.write_text("#salty!")
+    if show_changes is None:
+        ret = file.prepend(name=str(name), text="cheese")
+    else:
+        ret = file.prepend(name=str(name), text="cheese", show_changes=show_changes)
+
+    assert ret.result is True
+    assert name.exists()
+
+    if show_changes in [True, None]:
+        assert "diff" in ret.changes
+        assert "cheese" in ret.changes["diff"]
+    else:
+        assert ret.changes["diff"] == "<show_changes=False>"


### PR DESCRIPTION
### What does this PR do?

This PR adds the `show_changes` argument to `file.append` and `file.prepend` state functions in order to allow hiding the diff of the content as part of the output. Same behavior that `file.managed` state and others.

Upstream PR: https://github.com/saltstack/salt/pull/69141

### Previous Behavior
The output from `file.append` and `file.prepend` executions always contains a "diff" when files are text files.

### New Behavior
By default, the "diff" is included, but this can be skipped when `show_changes` is set to `False`.


### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [x] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
