### PR TITLE
Decode binary pillars for salt-ssh to avoid exceptions (bsc#1263822)

### DIFF
--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -15,6 +15,7 @@ import salt.loader
 import salt.minion
 import salt.roster
 import salt.state
+import salt.utils.data
 import salt.utils.files
 import salt.utils.json
 import salt.utils.path
@@ -203,6 +204,7 @@ def prep_trans_tar(
         salt.utils.json.dump(chunks, fp_)
     if pillar:
         with salt.utils.files.fopen(pillarfn, "w+") as fp_:
+            pillar = salt.utils.data.decode_dict(pillar)
             salt.utils.json.dump(pillar, fp_)
     if roster_grains:
         with salt.utils.files.fopen(roster_grainsfn, "w+") as fp_:

--- a/tests/pytests/unit/client/ssh/test_state.py
+++ b/tests/pytests/unit/client/ssh/test_state.py
@@ -1,0 +1,56 @@
+import pytest
+
+from salt.client.ssh.state import prep_trans_tar
+from tests.support.mock import patch
+
+
+@pytest.mark.parametrize(
+    "inpt,expected",
+    [
+        (
+            {
+                "pillar_data_n1": 1,
+                "pillar_data_t2": "text2",
+                "pillar_data_d3": {
+                    "text1": "text1",
+                    "text2": "text2",
+                },
+            },
+            {
+                "pillar_data_n1": 1,
+                "pillar_data_t2": "text2",
+                "pillar_data_d3": {
+                    "text1": "text1",
+                    "text2": "text2",
+                },
+            },
+        ),
+        (
+            {
+                "pillar_data_n1": 1,
+                "pillar_data_t2": "text2",
+                "pillar_data_b3": b"text3",
+                "pillar_data_d4": {
+                    "bin1": b"bin1",
+                    "bin2": b"bin2",
+                },
+            },
+            {
+                "pillar_data_n1": 1,
+                "pillar_data_t2": "text2",
+                "pillar_data_b3": "text3",
+                "pillar_data_d4": {
+                    "bin1": "bin1",
+                    "bin2": "bin2",
+                },
+            },
+        ),
+    ],
+)
+def test_prep_trans_tar_with_binary_pillar(inpt, expected):
+    """
+    Test binary pillar serialization
+    """
+    with patch("salt.utils.json.dump", return_value="") as json_dump_mock:
+        trans_tar = prep_trans_tar(None, [], [], pillar=inpt)
+        assert expected == json_dump_mock.call_args[0][0]


### PR DESCRIPTION
### What does this PR do?

In case if any pillar module is producing binary pillar data it could lead to exception on writing pillar data with JSON on creating tarball for `salt-ssh` client, while `salt-minion` doesn't have such issue as while pillar data is processed with `msgpack` during the transfer all the binary entries are converted to strings and not causing any issues.

This change is intended to align behaviour for `salt-ssh` case to make it possible to be processed as in case of `salt-minion`.

### What issues does this PR fix or reference?
Upstream PR: https://github.com/saltstack/salt/pull/69405
Tracks: https://github.com/SUSE/spacewalk/issues/30548

### Previous Behavior
Possible exceptions on producing pillar data with byte strings.

### New Behavior
Processing byte strings as normal strings the same way as it is with `salt-minion`.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
