### PR TITLE
Fix broken "pkg.info_installed" after moving to salt.utils.timeutil

### DIFF
--- a/salt/modules/dpkg_lowpkg.py
+++ b/salt/modules/dpkg_lowpkg.py
@@ -246,10 +246,9 @@ def _get_pkg_build_time(name):
     if os.path.exists(changelog_dir):
         for fname in os.listdir(changelog_dir):
             try:
-                iso_time_t = int(os.path.getmtime(os.path.join(changelog_dir, fname)))
-                iso_time = (
-                    datetime.datetime.utcfromtimestamp(iso_time_t).isoformat() + "Z"
-                )
+                iso_time = salt.utils.timeutil.utcfromtimestamp(
+                    int(os.path.getmtime(os.path.join(changelog_dir, fname)))
+                ).isoformat() + "Z"
                 break
             except OSError:
                 pass
@@ -261,10 +260,9 @@ def _get_pkg_build_time(name):
         ).splitlines():
             if "changelog" in pkg_f_path.lower() and os.path.exists(pkg_f_path):
                 try:
-                    iso_time_t = int(os.path.getmtime(pkg_f_path))
-                    iso_time = (
-                        datetime.datetime.utcfromtimestamp(iso_time_t).isoformat() + "Z"
-                    )
+                    iso_time = salt.utils.timeutil.utcfromtimestamp(
+                        int(os.path.getmtime(pkg_f_path))
+                    ).isoformat() + "Z"
                     break
                 except OSError:
                     pass


### PR DESCRIPTION
### What does this PR do?

This PR fixes an error introduced by https://github.com/openSUSE/salt/pull/762 due some `datetime` references not existing in the backported PR:

```
Module function pkg.info_installed threw an exception. Exception: name 'datetime' is not defined
``` 

We see this at least on Debian clients.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
