### PR TITLE
Fix file fetching with `cp` on non-vendored tornado

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -12,7 +12,6 @@ import string
 import urllib.error
 import urllib.parse
 
-from salt import USE_VENDORED_TORNADO
 from tornado.httputil import HTTPHeaders, HTTPInputError, parse_response_start_line
 
 import salt.channel.client
@@ -745,8 +744,10 @@ class Client:
                 # Check the status line of the HTTP request
                 if write_body[0] is None:
                     try:
-                        hdr = hdr if USE_VENDORED_TORNADO else hdr.strip()
-                        hdr = parse_response_start_line(hdr)
+                        try:
+                            hdr = parse_response_start_line(hdr)
+                        except HTTPInputError:
+                            hdr = parse_response_start_line(hdr.strip())
                     except HTTPInputError:
                         # Not the first line, do nothing
                         return


### PR DESCRIPTION
### What does this PR do?

Changes https://github.com/openSUSE/salt/pull/736/changes/cd384bad2f77c5a06dc941d2b04ab1244b13e7af and https://github.com/openSUSE/salt/pull/755 are causing regression with Python 3.11 and Tornado older than 6.5 leading to empty output from the remote files requested by `http(s)://...` refs.

No upstream PR is required as it relies on tornado 6.5 already.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/30387

### Previous Behavior
Tests failing:
```
FAILED tests/integration/modules/test_cp.py::CPModuleTest::test_get_file_str_https - AssertionError: 'Index of saltproject' not found in ''
FAILED tests/integration/modules/test_cp.py::CPModuleTest::test_get_url_https - AssertionError: 'Index of saltproject' not found in ''
FAILED tests/integration/modules/test_cp.py::CPModuleTest::test_get_url_https_dest_empty - AssertionError: 'Index of saltproject' not found in ''
FAILED tests/integration/modules/test_cp.py::CPModuleTest::test_get_url_https_no_dest - AssertionError: 'Index of saltproject' not found in ''
```
And getting empty content on requesting the files with `cp` module functions like `cp.get_file_str` and `cp.get_url`.

### New Behavior
No test fails and `cp` module functioning as usual.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
