### PR TITLE
Use AsyncHTTPClient in salt.utils.http (bsc#1268325)

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -38,9 +38,10 @@ import salt.utils.stringutils
 import salt.utils.xmlutil as xml
 import salt.utils.yaml
 import salt.version
-from tornado.httpclient import HTTPClient
+from tornado.httpclient import AsyncHTTPClient
 from salt.template import compile_template
 from salt.utils.decorators.jinja import jinja_filter
+from salt.utils.asynchronous import SyncWrapper
 
 try:
     from ssl import CertificateError, match_hostname
@@ -564,14 +565,14 @@ def query(
                 log.error(ret["error"])
                 return ret
 
-            tornado.httpclient.AsyncHTTPClient.configure(
+            AsyncHTTPClient.configure(
                 "tornado.curl_httpclient.CurlAsyncHTTPClient"
             )
             client_argspec = salt.utils.args.get_function_argspec(
                 tornado.curl_httpclient.CurlAsyncHTTPClient.initialize
             )
         else:
-            tornado.httpclient.AsyncHTTPClient.configure(None)
+            AsyncHTTPClient.configure(None)
             client_argspec = salt.utils.args.get_function_argspec(
                 tornado.simple_httpclient.SimpleAsyncHTTPClient.initialize
             )
@@ -606,10 +607,10 @@ def query(
         req_kwargs = salt.utils.data.decode(req_kwargs, to_str=True)
 
         try:
-            download_client = (
-                HTTPClient(max_body_size=max_body)
-                if supports_max_body_size
-                else HTTPClient()
+            download_client = SyncWrapper(
+                AsyncHTTPClient,
+                kwargs={"max_body_size": max_body} if supports_max_body_size else {},
+                async_methods=["fetch"],
             )
             result = download_client.fetch(url_full, **req_kwargs)
         except tornado.httpclient.HTTPError as exc:


### PR DESCRIPTION
### What does this PR do?

Currently, our `public_cloud.py` grain is failing with the following error:

```
[ERROR   ] Exception raised when processing __virtual__ function for salt.loaded.ext.grains.public_c
loud. Module will not be loaded: Cannot run the event loop while another loop is running
Traceback (most recent call last):
  File "/usr/lib/venv-salt-minion/lib64/python3.11/site-packages/salt/loader/lazy.py", line 1139, in
 _process_virtual
    virtual = self.run(virtual_attr)
              ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/venv-salt-minion/lib64/python3.11/site-packages/salt/loader/lazy.py", line 1234, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/venv-salt-minion/lib64/python3.11/site-packages/salt/loader/lazy.py", line 1249, in _run_as
    ret = _func_or_method(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/cache/venv-salt-minion/minion/extmods/grains/public_cloud.py", line 140, in __virtual__
    INSTANCE_ID = http.query(
                  ^^^^^^^^^^^
  File "/usr/lib/venv-salt-minion/lib64/python3.11/site-packages/salt/utils/http.py", line 610, in query
    HTTPClient(max_body_size=max_body)
  File "/usr/lib/venv-salt-minion/lib64/python3.11/site-packages/tornado/httpclient.py", line 109, in __init__
    self._async_client = self._io_loop.run_sync(make_client)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/venv-salt-minion/lib64/python3.11/site-packages/tornado/ioloop.py", line 521, in run_sync
    self.start()
  File "/usr/lib/venv-salt-minion/lib64/python3.11/site-packages/tornado/platform/asyncio.py", line 195, in start
    self.asyncio_loop.run_forever()
  File "/usr/lib/venv-salt-minion/lib64/python3.11/asyncio/base_events.py", line 597, in run_forever
    self._check_running()
  File "/usr/lib/venv-salt-minion/lib64/python3.11/asyncio/base_events.py", line 591, in _check_running
    raise RuntimeError(
RuntimeError: Cannot run the event loop while another loop is running
```

This change uses AsyncHTTPClient as per [0] to avoid the error.

Backport of https://github.com/saltstack/salt/commit/0b92bfdf80ab40787072d546b6962c77dd24e0b7

[0] https://github.com/tornadoweb/tornado/issues/2838

### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/30975

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
