### PR TITLE
Repair gpgkey/refresh handling in pkgrepo.managed

### DIFF
--- a/.github/workflows/add-upstream-bugfix-note.yml
+++ b/.github/workflows/add-upstream-bugfix-note.yml
@@ -1,0 +1,261 @@
+name: Upstream Bug-fix Notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: 'The SHA of the commit in openSUSE/salt to add the note to (default: HEAD)'
+        required: false
+        default: 'HEAD'
+      upstream_ref:
+        description: 'Comma-separated upstream Salt PR numbers or full links (e.g., 66240 or https://github.com/saltstack/salt/pull/66240,https://github.com/saltstack/salt/commit/abc123)'
+        required: true
+  push:
+    branches:
+      - 'openSUSE/release/3008.*'
+
+concurrency:
+  group: upstream-notes-push
+  cancel-in-progress: false
+
+jobs:
+  manage-notes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch existing notes
+        run: |
+          git fetch origin refs/notes/*:refs/notes/* || true
+
+      - name: Process Manual Input
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          REF="${{ github.event.inputs.upstream_ref }}"
+
+          # Parse comma-separated URLs
+          IFS=',' read -ra REFS <<< "$REF"
+          URLS=()
+
+          for ref in "${REFS[@]}"; do
+            # Trim whitespace
+            ref=$(echo "$ref" | xargs)
+
+            if [[ "$ref" =~ ^[0-9]+$ ]]; then
+              # Just a number - convert to PR URL
+              url="https://github.com/saltstack/salt/pull/$ref"
+            else
+              url="$ref"
+              # Normalize to https
+              if [[ "$url" =~ ^http:// ]]; then
+                url="https://${url#http://}"
+              elif [[ ! "$url" =~ ^https:// ]]; then
+                url="https://$url"
+              fi
+
+              # Validate format - allow both PR and commit URLs
+              if [[ ! "$url" =~ ^https://github\.com/saltstack/salt/(pull/[0-9]+|commit/[a-f0-9]+)$ ]]; then
+                echo "Error: Invalid upstream reference: $ref"
+                echo "Got: $url"
+                echo "Expected format: https://github.com/saltstack/salt/pull/<number> or https://github.com/saltstack/salt/commit/<sha>"
+                exit 1
+              fi
+            fi
+            if [[ " ${URLS[*]} " != *" ${url} "* ]]; then
+              URLS+=("$url")
+            fi
+          done
+
+          SHA="${{ github.event.inputs.commit_sha }}"
+
+          # Try to resolve provided commit first and if it fails, 
+          # fetch all branches.
+          if ! RESOLVED_SHA=$(git rev-parse --verify "$SHA" 2>/dev/null); then
+            echo "Commit $SHA not found locally. Attempting to fetch all branches..."
+            git fetch --all
+
+            if ! RESOLVED_SHA=$(git rev-parse --verify "$SHA" 2>/dev/null); then
+              echo "Error: Commit $SHA not found in repository after fetching all branches."
+              echo "Please verify the commit SHA exists and is pushed to the remote."
+              exit 1
+            fi
+          fi
+
+          echo "Resolved commit: $RESOLVED_SHA"
+
+          # Use unique random delimiters to prevent env-file injection.
+          # A fixed delimiter (EOF) is vulnerable if the value contains a line equal to "EOF",
+          # which would close the heredoc early and allow variable injection.
+          DELIMITER="ghadelimiter_${RANDOM}_${RANDOM}_${RANDOM}"
+          {
+            echo "URLS<<${DELIMITER}"
+            printf '%s\n' "${URLS[@]}"
+            echo "${DELIMITER}"
+            echo "COMMITS<<${DELIMITER}"
+            echo "$RESOLVED_SHA"
+            echo "${DELIMITER}"
+          } >> "$GITHUB_ENV"
+
+      - name: Process Merged PR
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # We trigger on 'push' instead of 'pull_request' because:
+          # - pull_request event: GITHUB_TOKEN is read-only for PRs from forks (security measure)
+          # - push event: GITHUB_TOKEN has write permissions since code is already merged into trusted branch
+          # This ensures git notes can be pushed regardless of whether the PR originated from a fork.
+
+          PUSH_SHA="${{ github.event.after }}"
+
+          PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/$PUSH_SHA/pulls" \
+            --jq '[.[] | select(.merged_at != null)][0].number // empty' || echo "")
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No merged PR found for commit $PUSH_SHA. Skipping notes."
+            exit 0
+          fi
+
+          echo "Found merged PR #$PR_NUMBER"
+
+          BODY=$(gh pr view "$PR_NUMBER" --json body --jq '.body')
+
+          # Extract all saltstack/salt URLs (PR or commit) from the PR body
+          # Matches:
+          # - https://github.com/saltstack/salt/pull/12345
+          # - https://github.com/saltstack/salt/commit/abc123...
+          # - http://github.com/saltstack/salt/pull/12345 (converted to https)
+          # - github.com/saltstack/salt/pull/12345 (converted to https)
+          # Ignore saltstack/salt URLs that start with "!ignore"
+          URLS=()
+
+          # Find all matching URLs using grep
+          while IFS= read -r line; do
+            if [[ -n "$line" ]]; then
+              # Normalize URL to https
+              url="$line"
+              if [[ "$url" =~ ^http:// ]]; then
+                url="https://${url#http://}"
+              elif [[ ! "$url" =~ ^https:// ]]; then
+                url="https://$url"
+              fi
+              if [[ " ${URLS[*]} " != *" ${url} "* ]]; then
+                URLS+=("$url")
+              fi
+            fi
+          done < <(echo "$BODY" | sed '/!ignore.*github\.com\/saltstack\/salt\//d' | grep -oE '(https?://)?github\.com/saltstack/salt/(pull/[0-9]+|commit/[a-f0-9]+)' || true)
+
+          if [ ${#URLS[@]} -eq 0 ]; then
+            echo "No upstream PR or commit links found in PR #$PR_NUMBER description. Skipping notes."
+            exit 0
+          fi
+
+          echo "Found ${#URLS[@]} upstream reference(s)"
+
+          # Since the repository only uses squash-and-merge, exactly one new commit ($PUSH_SHA)
+          # is added to the base branch representing the merged PR.
+          COMMITS="$PUSH_SHA"
+
+          DELIMITER="ghadelimiter_${RANDOM}_${RANDOM}_${RANDOM}"
+          {
+            echo "URLS<<${DELIMITER}"
+            printf '%s\n' "${URLS[@]}"
+            echo "${DELIMITER}"
+            echo "COMMITS<<${DELIMITER}"
+            echo "$COMMITS"
+            echo "${DELIMITER}"
+          } >> "$GITHUB_ENV"
+
+      - name: Add Notes
+        if: env.URLS != ''
+        run: |
+          NOTES_ADDED=false
+
+          # Read URLs into array
+          mapfile -t URL_ARRAY <<< "$URLS"
+
+          for SHA in $COMMITS; do
+            if ! git cat-file -e "$SHA" 2>/dev/null; then
+              echo "Warning: Commit $SHA not found. Skipping."
+              continue
+            fi
+
+            EXISTING_NOTE=$(git notes show "$SHA" 2>/dev/null || true)
+
+            # Build list of URLs to add
+            URLS_TO_ADD=()
+            for url in "${URL_ARRAY[@]}"; do
+              if [[ -z "$url" ]]; then
+                continue
+              fi
+
+              if echo "$EXISTING_NOTE" | grep -qFw "$url"; then
+                echo "Note already contains $url for $SHA. Skipping."
+              else
+                URLS_TO_ADD+=("$url")
+              fi
+            done
+
+            # Add all new URLs in a single git notes append command
+            if [ ${#URLS_TO_ADD[@]} -gt 0 ]; then
+              echo "Adding ${#URLS_TO_ADD[@]} note(s) to $SHA"
+
+              NOTE_ARGS=()
+              for url in "${URLS_TO_ADD[@]}"; do
+                NOTE_ARGS+=(-m "Upstream PR: $url")
+              done
+
+              git notes append "${NOTE_ARGS[@]}" "$SHA"
+              NOTES_ADDED=true
+            else
+              echo "All URLs already present in notes for $SHA"
+            fi
+          done
+
+          echo "NOTES_ADDED=$NOTES_ADDED" >> "$GITHUB_ENV"
+
+      - name: Push notes
+        if: env.URLS != '' && env.NOTES_ADDED == 'true'
+        run: |
+          MAX_RETRIES=3
+          RETRY_COUNT=0
+
+          while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+            if git push origin refs/notes/commits; then
+              echo "Successfully pushed notes"
+              exit 0
+            else
+              RETRY_COUNT=$((RETRY_COUNT + 1))
+              if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+                echo "Push failed, retrying ($RETRY_COUNT/$MAX_RETRIES)..."
+                # When concurrent workflows race:
+                #   1. Workflow A adds note and pushes successfully
+                #   2. Workflow B adds note and push fails (non-fast-forward)
+                #   3. If we fetch with refs/notes/*:refs/notes/*, we overwrite our local.
+                #      ref with remote, discarding the note we just added in step 2.
+                #   4. Next push succeeds but loses note in workflow B.
+                # Instead, fetch without updating local ref, then merge both sets of notes.
+                git fetch origin refs/notes/commits
+                git notes merge -s cat_sort_uniq FETCH_HEAD || {
+                  echo "Notes merge failed"
+                  exit 1
+                }
+                sleep 2
+              else
+                echo "Failed to push notes after $MAX_RETRIES attempts"
+                exit 1
+              fi
+            fi
+          done
+

--- a/salt/modules/zypperpkg.py
+++ b/salt/modules/zypperpkg.py
@@ -1188,17 +1188,40 @@ def list_repo_pkgs(*args, **kwargs):
         return byrepo_ret
 
 
+def _get_repos_directory(root=None):
+    return os.path.join(root, os.path.relpath(REPOS, os.path.sep)) if root else REPOS
+
+
+def _get_configured_repo(repo, root=None):
+    repos = _get_repos_directory(root=root)
+
+    for fname in os.listdir(repos):
+        if not fname.endswith(".repo"):
+            continue
+
+        repo_file = os.path.join(repos, fname)
+
+        repo_cfg = configparser.ConfigParser()
+        repo_cfg.read(repo_file)
+
+        if repo in repo_cfg:
+            # return whole config for processing as there might be multiple repository sections in one file
+            return {repo_file: repo_cfg}
+
+    return {}
+
+
 def _get_configured_repos(root=None):
     """
     Get all the info about repositories from the configurations.
     """
 
-    repos = os.path.join(root, os.path.relpath(REPOS, os.path.sep)) if root else REPOS
+    repos = _get_repos_directory(root=root)
     repos_cfg = configparser.ConfigParser()
     if os.path.exists(repos):
         repos_cfg.read(
             [
-                repos + "/" + fname
+                os.path.join(repos, fname)
                 for fname in os.listdir(repos)
                 if fname.endswith(".repo")
             ]
@@ -1219,10 +1242,14 @@ def _get_repo_info(alias, repos_cfg=None, root=None):
         )
         meta["alias"] = alias
         for key, val in meta.items():
-            if val in ["0", "1"]:
+            if key == "priority":
+                meta[key] = int(meta[key])
+            elif val in ["0", "1"]:
                 meta[key] = int(meta[key]) == 1
             elif val == "NONE":
                 meta[key] = None
+        if "priority" not in meta:
+            meta["priority"] = DEFAULT_PRIORITY
         return meta
     except (ValueError, configparser.NoSectionError):
         return {}
@@ -1444,6 +1471,18 @@ def mod_repo(repo, **kwargs):
     if cmd_opt:
         cmd_opt = global_cmd_opt + ["mr"] + cmd_opt + [repo]
         __zypper__(root=root).refreshable.xml.call(*cmd_opt)
+
+    if "gpgkey" in kwargs:
+        # TODO: factor file based configuration to helper function
+        repo_map = _get_configured_repo(repo, root=root)
+        if repo_map:
+            repo_file, repo_file_cfg = tuple(repo_map.items())[0]
+            repo_cfg = repo_file_cfg[repo]
+
+            if repo_cfg.get("gpgkey") != kwargs["gpgkey"]:
+                repo_cfg["gpgkey"] = kwargs["gpgkey"]
+                with salt.utils.files.fopen(repo_file, "w") as _fp:
+                    repo_file_cfg.write(_fp)
 
     comment = None
     if call_refresh:

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -117,7 +117,6 @@ Using ``aptkey: False`` with ``keyserver`` and ``keyid``:
         - aptkey: False
 """
 
-
 import os
 import sys
 
@@ -484,6 +483,10 @@ def managed(name, ppa=None, copr=None, aptkey=True, **kwargs):
     else:
         sanitizedkwargs = kwargs
 
+        if __grains__["os_family"] == "Suse":
+            pre = _normalize_repo(pre, for_mod=True)
+            sanitizedkwargs = _normalize_repo(sanitizedkwargs, for_mod=True)
+
     if pre:
         # 22412: Remove file attribute in case same repo is set up multiple times but with different files
         pre.pop("file", None)
@@ -501,11 +504,8 @@ def managed(name, ppa=None, copr=None, aptkey=True, **kwargs):
                     else:
                         break
                 else:
-                    if kwarg in ("comps", "key_url"):
-                        break
-                    else:
-                        continue
-            elif kwarg in ("comps", "key_url"):
+                    break
+            elif kwarg in ("comments", "comps", "key_url"):
                 if sorted(sanitizedkwargs[kwarg]) != sorted(pre[kwarg]):
                     break
             elif kwarg == "line" and __grains__["os_family"] == "Debian":
@@ -579,6 +579,7 @@ def managed(name, ppa=None, copr=None, aptkey=True, **kwargs):
         )
         if pre:
             for kwarg in sanitizedkwargs:
+                # TODO: if new is an integer, it should be displayed as bool to align with the format used in old
                 if sanitizedkwargs.get(kwarg) != pre.get(kwarg):
                     ret["changes"][kwarg] = {
                         "new": sanitizedkwargs.get(kwarg),
@@ -607,6 +608,8 @@ def managed(name, ppa=None, copr=None, aptkey=True, **kwargs):
 
     try:
         post = __salt__["pkg.get_repo"](repo=repo, **kwargs)
+        if __grains__["os_family"] == "Suse":
+            post = _normalize_repo(post, for_mod=True)
         if pre:
             for kwarg in sanitizedkwargs:
                 if post.get(kwarg) != pre.get(kwarg):
@@ -792,7 +795,7 @@ def absent(name, **kwargs):
     return ret
 
 
-def _normalize_repo(repo):
+def _normalize_repo(repo, for_mod=False):
     """Normalize the get_repo information"""
     # `pkg.get_repo()` specific virtual module implementation is
     # parsing the information directly from the repository
@@ -802,14 +805,19 @@ def _normalize_repo(repo):
     # If the field is not present will be dropped
     suse = {
         # "alias": "repo",
-        "name": "humanname",
+        "name": "name",
         "priority": "priority",
         "enabled": "enabled",
         "autorefresh": "refresh",
+        "refresh": "refresh",
         "gpgcheck": "gpgcheck",
+        "gpgkey": "gpgkey",
         "keepackages": "cache",
         "baseurl": "url",
     }
+    if not for_mod:
+        suse["name"] = "humanname"
+
     translator = {
         "Suse": suse,
     }

--- a/tests/pytests/functional/states/pkgrepo/test_suse.py
+++ b/tests/pytests/functional/states/pkgrepo/test_suse.py
@@ -27,7 +27,6 @@ def suse_state_tree(grains, pkgrepo, state_tree):
         - gpgcheck: 1
         - comments:
           - '# Salt Test'
-        - refresh: 1
     {% if grains['osfullname'] == 'openSUSE Tumbleweed' %}
         - baseurl: http://download.opensuse.org/tumbleweed/repo/oss/
         - humanname: openSUSE Tumbleweed OSS
@@ -36,6 +35,21 @@ def suse_state_tree(grains, pkgrepo, state_tree):
         - baseurl: https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP4/standard/
         - humanname: openSUSE Backports for SLE 15 SP4
         - gpgkey: https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP4/standard/repodata/repomd.xml.key
+    {% endif %}
+    """
+
+    managed_sls_contents_no_gpgkey = """
+    salttest-gpgkey-only-later:
+      pkgrepo.managed:
+        - enabled: 1
+        - gpgcheck: 1
+        - refresh: 1
+    {% if grains['osfullname'] == 'openSUSE Tumbleweed' %}
+        - baseurl: http://download.opensuse.org/tumbleweed/repo/oss/
+        - humanname: openSUSE Tumbleweed OSS later gpgkey
+    {% else %}
+        - baseurl: https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP5/standard/
+        - humanname: openSUSE Backports for SLE 15 SP5 later gpgkey
     {% endif %}
     """
 
@@ -56,16 +70,36 @@ def suse_state_tree(grains, pkgrepo, state_tree):
     {% if grains['osfullname'] == 'openSUSE Tumbleweed' %}
         - baseurl: http://download.opensuse.org/tumbleweed/repo/oss/
         - humanname: Salt modified OSS
-        - gpgkey: https://download.opensuse.org/tumbleweed/repo/oss/repodata/repomd.xml.key
+        - gpgkey: https://download.opensuse.org/tumbleweed/repo/oss/repodata/repomd.xml.key-modified
     {% else %}
         - baseurl: https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP4/standard/
         - humanname: Salt modified Backports
-        - gpgkey: https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP4/standard/repodata/repomd.xml.key
+        - gpgkey: https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP4/standard/repodata/repomd.xml.key-modified
+    {% endif %}
+    """
+
+    modified_sls_contents_new_gpgkey = """
+    salttest-gpgkey-only-later:
+      pkgrepo.managed:
+        - enabled: 1
+        - gpgcheck: 1
+        - refresh: 1
+    {% if grains['osfullname'] == 'openSUSE Tumbleweed' %}
+        - baseurl: http://download.opensuse.org/tumbleweed/repo/oss/
+        - humanname: openSUSE Tumbleweed OSS later gpgpkey
+        - gpgkey: https://download.opensuse.org/tumbleweed/repo/oss/repodata/repomd.xml.key-new
+    {% else %}
+        - baseurl: https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP5/standard/
+        - humanname: openSUSE Backports for SLE 15 SP5 later gpgkey
+        - gpgkey: https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP5/standard/repodata/repomd.xml.key-new
     {% endif %}
     """
 
     managed_state_file = pytest.helpers.temp_file(
         "pkgrepo/managed.sls", managed_sls_contents, state_tree
+    )
+    managed_no_gpgkey_state_file = pytest.helpers.temp_file(
+        "pkgrepo/managed_no_gpgkey.sls", managed_sls_contents_no_gpgkey, state_tree
     )
     absent_state_file = pytest.helpers.temp_file(
         "pkgrepo/absent.sls", absent_sls_contents, state_tree
@@ -73,9 +107,12 @@ def suse_state_tree(grains, pkgrepo, state_tree):
     modified_state_file = pytest.helpers.temp_file(
         "pkgrepo/modified.sls", modified_sls_contents, state_tree
     )
+    modified_new_gpgkey_state_file = pytest.helpers.temp_file(
+        "pkgrepo/modified_new_gpgkey.sls", modified_sls_contents_new_gpgkey, state_tree
+    )
 
     try:
-        with managed_state_file, absent_state_file, modified_state_file:
+        with managed_state_file, managed_no_gpgkey_state_file, absent_state_file, modified_state_file, modified_new_gpgkey_state_file:
             yield
     finally:
         pass
@@ -175,6 +212,28 @@ def test_pkgrepo_managed_modify(grains, modules, subtests, suse_state_tree):
             assert state.result is True
         add_repo_test_passed = True
 
+    with subtests.test("Add repository without gpgkey, test"):
+        ret = _run("pkgrepo.managed_no_gpgkey", test=True)
+        assert ret.failed is False
+        for state in ret:
+            assert state.changes == {"repo": "salttest-gpgkey-only-later"}
+            assert state.comment.startswith(
+                "Package repo 'salttest-gpgkey-only-later' would be configured."
+            )
+            assert state.result is None
+
+    with subtests.test("Add repository without gpgkey"):
+        ret = _run("pkgrepo.managed_no_gpgkey")
+        assert ret.failed is False
+        for state in ret:
+            assert state.changes == {"repo": "salttest-gpgkey-only-later"}
+            assert (
+                state.comment == "Configured package repo 'salttest-gpgkey-only-later'"
+            )
+            assert state.result is True
+        if add_repo_test_passed is not False:
+            add_repo_test_passed = True
+
     if add_repo_test_passed is False:
         pytest.skip("Adding the repository failed, skipping modification tests.")
 
@@ -194,16 +253,38 @@ def test_pkgrepo_managed_modify(grains, modules, subtests, suse_state_tree):
             assert state.changes == {}
             assert state.comment == "Package repo 'salttest' already configured"
 
+    with subtests.test("Add repository without gpgkey again, test"):
+        ret = _run("pkgrepo.managed_no_gpgkey", test=True)
+        assert ret.failed is False
+        for state in ret:
+            assert state.changes == {}
+            assert (
+                state.comment
+                == "Package repo 'salttest-gpgkey-only-later' already configured"
+            )
+            assert state.result is True
+
+    with subtests.test("Add repository without gpgkey again"):
+        ret = _run("pkgrepo.managed_no_gpgkey")
+        assert ret.failed is False
+        for state in ret:
+            assert state.result is True
+            assert state.changes == {}
+            assert (
+                state.comment
+                == "Package repo 'salttest-gpgkey-only-later' already configured"
+            )
+
     with subtests.test("Modify repository, test"):
         ret = _run("pkgrepo.modified", test=True)
         assert ret.failed is False
         for state in ret:
             assert state.changes == {
-                "comments": {"new": ["# Salt Test (modified)"], "old": None},
-                "refresh": {"new": 1, "old": None},
+                # new as int here, ref. TODO in state function
+                "refresh": {"new": 1, "old": False},
                 "gpgkey": {
-                    "new": "https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP4/standard/repodata/repomd.xml.key",
-                    "old": None,
+                    "new": "https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP4/standard/repodata/repomd.xml.key-modified",
+                    "old": "https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP4/standard/repodata/repomd.xml.key",
                 },
                 "name": {
                     "new": "Salt modified Backports",
@@ -224,6 +305,41 @@ def test_pkgrepo_managed_modify(grains, modules, subtests, suse_state_tree):
                 "name": {
                     "new": "Salt modified Backports",
                     "old": "openSUSE Backports for SLE 15 SP4",
-                }
+                },
+                "gpgkey": {
+                    "new": "https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP4/standard/repodata/repomd.xml.key-modified",
+                    "old": "https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP4/standard/repodata/repomd.xml.key",
+                },
+                "refresh": {"new": True, "old": False},
             }
             assert state.comment == "Configured package repo 'salttest'"
+
+    with subtests.test("Modify repository with new gpgkey, test"):
+        ret = _run("pkgrepo.modified_new_gpgkey", test=True)
+        assert ret.failed is False
+        for state in ret:
+            assert state.changes == {
+                "gpgkey": {
+                    "new": "https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP5/standard/repodata/repomd.xml.key-new",
+                    "old": None,
+                },
+            }
+            assert state.comment.startswith(
+                "Package repo 'salttest-gpgkey-only-later' would be configured."
+            )
+            assert state.result is None
+
+    with subtests.test("Modify repository with new gpgkey"):
+        ret = _run("pkgrepo.modified_new_gpgkey")
+        assert ret.failed is False
+        for state in ret:
+            assert state.result is True
+            assert state.changes == {
+                "gpgkey": {
+                    "new": "https://download.opensuse.org/repositories/openSUSE:/Backports:/SLE-15-SP5/standard/repodata/repomd.xml.key-new",
+                    "old": None,
+                },
+            }
+            assert (
+                state.comment == "Configured package repo 'salttest-gpgkey-only-later'"
+            )


### PR DESCRIPTION
Hi,

I wanted to submit this upstream, but I notice some dependent commits are missing from 3006.x and I could not find any pending PRs for them.

### What does this PR do?

These were so implicitly ignored so far.
Zypper command line does not support modification of "gpgkey", hence extend functions to handle it via ConfigParser and expand the tests respectively.
The logic from the previous change "Fix zypper repository reconfiguration" is reverted in favor of including the missing attributes in _get_repo_info(). The gpgkey option itself was not included there, as returning "None" in case of no gpgkey might be confusing, given zypp implying a gpgkey if none is set if the baseurl matches a hardcoded list of mirrors.

### What issues does this PR fix or reference?
Fixes:
- https://github.com/saltstack/salt/issues/60520
- https://github.com/openSUSE/salt/issues/740

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes
