### PR TITLE
Stabilize testsuite tests and fix AllEventsHandler

### DIFF
--- a/salt/netapi/rest_tornado/saltnado_websockets.py
+++ b/salt/netapi/rest_tornado/saltnado_websockets.py
@@ -313,6 +313,7 @@ class AllEventsHandler(
     """
 
     # pylint: disable=W0221
+    @tornado.gen.coroutine
     def get(self, token):
         """
         Check the token, returns a 401 if the token is invalid.
@@ -326,7 +327,7 @@ class AllEventsHandler(
             log.debug("Refusing websocket connection, bad token!")
             self.send_error(401)
             return
-        super().get(token)
+        yield super().get(token)
 
     def open(self, token):  # pylint: disable=W0221
         """

--- a/tests/pytests/functional/netapi/rest_tornado/test_utils.py
+++ b/tests/pytests/functional/netapi/rest_tornado/test_utils.py
@@ -20,6 +20,7 @@ async def test_any_future():
     futures[0].set_result("foo")
 
     await futures[0]
+    await any_
 
     assert any_.done() is True
     assert futures[0].done() is True
@@ -34,6 +35,7 @@ async def test_any_future():
     any_ = saltnado.Any(futures)
     futures[0].set_result("foo")
     await futures[0]
+    await any_
 
     assert any_.done() is True
     assert futures[0].done() is True

--- a/tests/pytests/functional/netapi/rest_tornado/test_webhooks_handler.py
+++ b/tests/pytests/functional/netapi/rest_tornado/test_webhooks_handler.py
@@ -1,6 +1,7 @@
 import urllib.parse
 
 import pytest
+import tornado
 
 import salt.utils.json
 from salt.netapi.rest_tornado import saltnado
@@ -28,15 +29,21 @@ async def test_hook_can_handle_get_parameters(http_client, app, content_type_map
             )
             assert response.code == 200
             host = urllib.parse.urlparse(response.effective_url).netloc
+
+            expected_headers = {
+                "Content-Length": "2",
+                "Connection": "close",
+                "Content-Type": "application/json",
+                "Host": host,
+                "Accept-Encoding": "gzip",
+            }
+
+            if tornado.version_info >= (6,):
+                expected_headers["User-Agent"] = f"Tornado/{tornado.version}"
+
             event.fire_event.assert_called_once_with(
                 {
-                    "headers": {
-                        "Content-Length": "2",
-                        "Connection": "close",
-                        "Content-Type": "application/json",
-                        "Host": host,
-                        "Accept-Encoding": "gzip",
-                    },
+                    "headers": expected_headers,
                     "post": {},
                     "get": {"param": ["1", "2"]},
                 },


### PR DESCRIPTION
In `AllEventsHandler`, new Tornado uses async method for `tornado.websocket.WebSocketHandler:get`, 
which means calls to `ws://IP:PORT/all_events/` are broken with
Tornados >= 6. To fix that, `AllEventsHandler:get`
now uses `tornado.gen.coroutine` to work on old and
new Tornado versions.

Changes to test_utils.py and test_webhooks_handler.py are partial cherrypick of:
- https://github.com/saltstack/salt/commit/4c4d017ddb45e4e689d978ae1deb975ad7a4c220


### Previous Behavior
The following tests are failing with Python 3.11:

```
tests/pytests/functional/netapi/rest_tornado/test_utils.py::test_any_future
tests/pytests/functional/netapi/rest_tornado/test_webhooks_handler.py::test_hook_can_handle_get_parameters
tests/pytests/functional/netapi/rest_tornado/test_websockets_handler.py::test_websocket_handler_upgrade_to_websocket
tests/pytests/functional/netapi/rest_tornado/test_websockets_handler.py::test_websocket_handler_cors_origin_wildcard
tests/pytests/functional/netapi/rest_tornado/test_websockets_handler.py::test_cors_origin_single
tests/pytests/functional/netapi/rest_tornado/test_websockets_handler.py::test_cors_origin_multiple
```

### New Behavior
The tests are passing with both Python 3.11 and Python 3.6

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
