### PR TITLE
Switch apache2ctl to apachectl for SUSE OSes (bsc#1252286)

### DIFF
--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -45,7 +45,7 @@ def _detect_os():
     os_family = __grains__["os_family"]
     if os_family == "RedHat":
         return "apachectl"
-    elif os_family == "Debian" or os_family == "Suse":
+    elif os_family == "Debian":
         return "apache2ctl"
     else:
         return "apachectl"

--- a/salt/modules/suse_apache.py
+++ b/salt/modules/suse_apache.py
@@ -19,7 +19,7 @@ def __virtual__():
     """
     Only load the module if apache is installed.
     """
-    if salt.utils.path.which("apache2ctl") and __grains__["os_family"] == "Suse":
+    if salt.utils.path.which("apachectl") and __grains__["os_family"] == "Suse":
         return __virtualname__
     return (False, "apache execution module not loaded: apache not installed.")
 


### PR DESCRIPTION
### What does this PR do?

On Leap 15.6 we had

```
root@localhost ~# ls -l /usr/sbin/apache{,2}ctl
lrwxrwxrwx 1 root root    9 Jul 21 08:56 /usr/sbin/apache2ctl -> apachectl*
-rwxr-xr-x 1 root root 3548 Jul 21 08:56 /usr/sbin/apachectl*
```

But on Leap 16 we have

```
eee3b01ad40c:/ # ls -l /usr/sbin/apache{,2}ctl
ls: cannot access '/usr/sbin/apache2ctl': No such file or directory
-rwxr-xr-x 1 root root 3548 Jul 21 04:06 /usr/sbin/apachectl
```

The module tries to look up apache2ctl, that fails now.

Backport of https://github.com/salt-extensions/saltext-apache/pull/14
bsc#1252286

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
