### PR TITLE
Allow user.present to be test-evaluated with not-yet-existing groups

### DIFF
--- a/.github/workflows/add-upstream-bugfix-note.yml
+++ b/.github/workflows/add-upstream-bugfix-note.yml
@@ -1,0 +1,261 @@
+name: Upstream Bug-fix Notes
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: 'The SHA of the commit in openSUSE/salt to add the note to (default: HEAD)'
+        required: false
+        default: 'HEAD'
+      upstream_ref:
+        description: 'Comma-separated upstream Salt PR numbers or full links (e.g., 66240 or https://github.com/saltstack/salt/pull/66240,https://github.com/saltstack/salt/commit/abc123)'
+        required: true
+  push:
+    branches:
+      - 'openSUSE/release/3008.*'
+
+concurrency:
+  group: upstream-notes-push
+  cancel-in-progress: false
+
+jobs:
+  manage-notes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch existing notes
+        run: |
+          git fetch origin refs/notes/*:refs/notes/* || true
+
+      - name: Process Manual Input
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          REF="${{ github.event.inputs.upstream_ref }}"
+
+          # Parse comma-separated URLs
+          IFS=',' read -ra REFS <<< "$REF"
+          URLS=()
+
+          for ref in "${REFS[@]}"; do
+            # Trim whitespace
+            ref=$(echo "$ref" | xargs)
+
+            if [[ "$ref" =~ ^[0-9]+$ ]]; then
+              # Just a number - convert to PR URL
+              url="https://github.com/saltstack/salt/pull/$ref"
+            else
+              url="$ref"
+              # Normalize to https
+              if [[ "$url" =~ ^http:// ]]; then
+                url="https://${url#http://}"
+              elif [[ ! "$url" =~ ^https:// ]]; then
+                url="https://$url"
+              fi
+
+              # Validate format - allow both PR and commit URLs
+              if [[ ! "$url" =~ ^https://github\.com/saltstack/salt/(pull/[0-9]+|commit/[a-f0-9]+)$ ]]; then
+                echo "Error: Invalid upstream reference: $ref"
+                echo "Got: $url"
+                echo "Expected format: https://github.com/saltstack/salt/pull/<number> or https://github.com/saltstack/salt/commit/<sha>"
+                exit 1
+              fi
+            fi
+            if [[ " ${URLS[*]} " != *" ${url} "* ]]; then
+              URLS+=("$url")
+            fi
+          done
+
+          SHA="${{ github.event.inputs.commit_sha }}"
+
+          # Try to resolve provided commit first and if it fails, 
+          # fetch all branches.
+          if ! RESOLVED_SHA=$(git rev-parse --verify "$SHA" 2>/dev/null); then
+            echo "Commit $SHA not found locally. Attempting to fetch all branches..."
+            git fetch --all
+
+            if ! RESOLVED_SHA=$(git rev-parse --verify "$SHA" 2>/dev/null); then
+              echo "Error: Commit $SHA not found in repository after fetching all branches."
+              echo "Please verify the commit SHA exists and is pushed to the remote."
+              exit 1
+            fi
+          fi
+
+          echo "Resolved commit: $RESOLVED_SHA"
+
+          # Use unique random delimiters to prevent env-file injection.
+          # A fixed delimiter (EOF) is vulnerable if the value contains a line equal to "EOF",
+          # which would close the heredoc early and allow variable injection.
+          DELIMITER="ghadelimiter_${RANDOM}_${RANDOM}_${RANDOM}"
+          {
+            echo "URLS<<${DELIMITER}"
+            printf '%s\n' "${URLS[@]}"
+            echo "${DELIMITER}"
+            echo "COMMITS<<${DELIMITER}"
+            echo "$RESOLVED_SHA"
+            echo "${DELIMITER}"
+          } >> "$GITHUB_ENV"
+
+      - name: Process Merged PR
+        if: github.event_name == 'push'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # We trigger on 'push' instead of 'pull_request' because:
+          # - pull_request event: GITHUB_TOKEN is read-only for PRs from forks (security measure)
+          # - push event: GITHUB_TOKEN has write permissions since code is already merged into trusted branch
+          # This ensures git notes can be pushed regardless of whether the PR originated from a fork.
+
+          PUSH_SHA="${{ github.event.after }}"
+
+          PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/$PUSH_SHA/pulls" \
+            --jq '[.[] | select(.merged_at != null)][0].number // empty' || echo "")
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No merged PR found for commit $PUSH_SHA. Skipping notes."
+            exit 0
+          fi
+
+          echo "Found merged PR #$PR_NUMBER"
+
+          BODY=$(gh pr view "$PR_NUMBER" --json body --jq '.body')
+
+          # Extract all saltstack/salt URLs (PR or commit) from the PR body
+          # Matches:
+          # - https://github.com/saltstack/salt/pull/12345
+          # - https://github.com/saltstack/salt/commit/abc123...
+          # - http://github.com/saltstack/salt/pull/12345 (converted to https)
+          # - github.com/saltstack/salt/pull/12345 (converted to https)
+          # Ignore saltstack/salt URLs that start with "!ignore"
+          URLS=()
+
+          # Find all matching URLs using grep
+          while IFS= read -r line; do
+            if [[ -n "$line" ]]; then
+              # Normalize URL to https
+              url="$line"
+              if [[ "$url" =~ ^http:// ]]; then
+                url="https://${url#http://}"
+              elif [[ ! "$url" =~ ^https:// ]]; then
+                url="https://$url"
+              fi
+              if [[ " ${URLS[*]} " != *" ${url} "* ]]; then
+                URLS+=("$url")
+              fi
+            fi
+          done < <(echo "$BODY" | sed '/!ignore.*github\.com\/saltstack\/salt\//d' | grep -oE '(https?://)?github\.com/saltstack/salt/(pull/[0-9]+|commit/[a-f0-9]+)' || true)
+
+          if [ ${#URLS[@]} -eq 0 ]; then
+            echo "No upstream PR or commit links found in PR #$PR_NUMBER description. Skipping notes."
+            exit 0
+          fi
+
+          echo "Found ${#URLS[@]} upstream reference(s)"
+
+          # Since the repository only uses squash-and-merge, exactly one new commit ($PUSH_SHA)
+          # is added to the base branch representing the merged PR.
+          COMMITS="$PUSH_SHA"
+
+          DELIMITER="ghadelimiter_${RANDOM}_${RANDOM}_${RANDOM}"
+          {
+            echo "URLS<<${DELIMITER}"
+            printf '%s\n' "${URLS[@]}"
+            echo "${DELIMITER}"
+            echo "COMMITS<<${DELIMITER}"
+            echo "$COMMITS"
+            echo "${DELIMITER}"
+          } >> "$GITHUB_ENV"
+
+      - name: Add Notes
+        if: env.URLS != ''
+        run: |
+          NOTES_ADDED=false
+
+          # Read URLs into array
+          mapfile -t URL_ARRAY <<< "$URLS"
+
+          for SHA in $COMMITS; do
+            if ! git cat-file -e "$SHA" 2>/dev/null; then
+              echo "Warning: Commit $SHA not found. Skipping."
+              continue
+            fi
+
+            EXISTING_NOTE=$(git notes show "$SHA" 2>/dev/null || true)
+
+            # Build list of URLs to add
+            URLS_TO_ADD=()
+            for url in "${URL_ARRAY[@]}"; do
+              if [[ -z "$url" ]]; then
+                continue
+              fi
+
+              if echo "$EXISTING_NOTE" | grep -qFw "$url"; then
+                echo "Note already contains $url for $SHA. Skipping."
+              else
+                URLS_TO_ADD+=("$url")
+              fi
+            done
+
+            # Add all new URLs in a single git notes append command
+            if [ ${#URLS_TO_ADD[@]} -gt 0 ]; then
+              echo "Adding ${#URLS_TO_ADD[@]} note(s) to $SHA"
+
+              NOTE_ARGS=()
+              for url in "${URLS_TO_ADD[@]}"; do
+                NOTE_ARGS+=(-m "Upstream PR: $url")
+              done
+
+              git notes append "${NOTE_ARGS[@]}" "$SHA"
+              NOTES_ADDED=true
+            else
+              echo "All URLs already present in notes for $SHA"
+            fi
+          done
+
+          echo "NOTES_ADDED=$NOTES_ADDED" >> "$GITHUB_ENV"
+
+      - name: Push notes
+        if: env.URLS != '' && env.NOTES_ADDED == 'true'
+        run: |
+          MAX_RETRIES=3
+          RETRY_COUNT=0
+
+          while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+            if git push origin refs/notes/commits; then
+              echo "Successfully pushed notes"
+              exit 0
+            else
+              RETRY_COUNT=$((RETRY_COUNT + 1))
+              if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+                echo "Push failed, retrying ($RETRY_COUNT/$MAX_RETRIES)..."
+                # When concurrent workflows race:
+                #   1. Workflow A adds note and pushes successfully
+                #   2. Workflow B adds note and push fails (non-fast-forward)
+                #   3. If we fetch with refs/notes/*:refs/notes/*, we overwrite our local.
+                #      ref with remote, discarding the note we just added in step 2.
+                #   4. Next push succeeds but loses note in workflow B.
+                # Instead, fetch without updating local ref, then merge both sets of notes.
+                git fetch origin refs/notes/commits
+                git notes merge -s cat_sort_uniq FETCH_HEAD || {
+                  echo "Notes merge failed"
+                  exit 1
+                }
+                sleep 2
+              else
+                echo "Failed to push notes after $MAX_RETRIES attempts"
+                exit 1
+              fi
+            fi
+          done
+

--- a/changelog/68110.fixed.md
+++ b/changelog/68110.fixed.md
@@ -1,0 +1,1 @@
+Fixed `user.present` to not fail with `result: False` in test mode when a referenced group does not yet exist; the state now reports the pending changes so users can preview states that depend on groups created by a `group.present` requisite in the same run.

--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -45,7 +45,7 @@ def _detect_os():
     os_family = __grains__["os_family"]
     if os_family == "RedHat":
         return "apachectl"
-    elif os_family == "Debian" or os_family == "Suse":
+    elif os_family == "Debian":
         return "apache2ctl"
     else:
         return "apachectl"

--- a/salt/modules/suse_apache.py
+++ b/salt/modules/suse_apache.py
@@ -19,7 +19,7 @@ def __virtual__():
     """
     Only load the module if apache is installed.
     """
-    if salt.utils.path.which("apache2ctl") and __grains__["os_family"] == "Suse":
+    if salt.utils.path.which("apachectl") and __grains__["os_family"] == "Suse":
         return __virtualname__
     return (False, "apache execution module not loaded: apache not installed.")
 

--- a/salt/netapi/rest_tornado/saltnado_websockets.py
+++ b/salt/netapi/rest_tornado/saltnado_websockets.py
@@ -313,6 +313,7 @@ class AllEventsHandler(
     """
 
     # pylint: disable=W0221
+    @tornado.gen.coroutine
     def get(self, token):
         """
         Check the token, returns a 401 if the token is invalid.
@@ -326,7 +327,7 @@ class AllEventsHandler(
             log.debug("Refusing websocket connection, bad token!")
             self.send_error(401)
             return
-        super().get(token)
+        yield super().get(token)
 
     def open(self, token):  # pylint: disable=W0221
         """

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -541,14 +541,25 @@ def present(
             ret["result"] = False
             return ret
 
+    missing_groups = []
     if groups:
         missing_groups = [x for x in groups if not __salt__["group.info"](x)]
         if missing_groups:
-            ret["comment"] = "The following group(s) are not present: {}".format(
-                ",".join(missing_groups)
-            )
-            ret["result"] = False
-            return ret
+            if __opts__.get("test"):
+                # In test mode, a missing group is not necessarily an error:
+                # a `group.present` requisite may create it during the real
+                # run. Note the missing groups in the result, drop them from
+                # the membership check below (they cannot be diffed against
+                # the user's current groups since they do not yet exist),
+                # and let the rest of the function report whatever else
+                # would change. Issue #68110.
+                groups = [x for x in groups if x not in missing_groups]
+            else:
+                ret["comment"] = "The following group(s) are not present: {}".format(
+                    ",".join(missing_groups)
+                )
+                ret["result"] = False
+                return ret
 
     if optional_groups:
         present_optgroups = [x for x in optional_groups if __salt__["group.info"](x)]
@@ -630,6 +641,10 @@ def present(
                 elif key == "group" and not remove_groups:
                     key = "ensure groups"
                 ret["comment"] += "{}: {}\n".format(key, val)
+            if missing_groups:
+                ret["comment"] += "groups (pending creation): {}\n".format(
+                    ",".join(missing_groups)
+                )
             return ret
         # The user is present
         if "shadow.info" in __salt__:
@@ -811,6 +826,10 @@ def present(
         if __opts__["test"]:
             ret["result"] = None
             ret["comment"] = "User {} set to be added".format(name)
+            if missing_groups:
+                ret["comment"] += " (pending groups: {})".format(
+                    ",".join(missing_groups)
+                )
             return ret
         if groups and present_optgroups:
             groups.extend(present_optgroups)

--- a/tests/pytests/functional/netapi/rest_tornado/test_utils.py
+++ b/tests/pytests/functional/netapi/rest_tornado/test_utils.py
@@ -20,6 +20,7 @@ async def test_any_future():
     futures[0].set_result("foo")
 
     await futures[0]
+    await any_
 
     assert any_.done() is True
     assert futures[0].done() is True
@@ -34,6 +35,7 @@ async def test_any_future():
     any_ = saltnado.Any(futures)
     futures[0].set_result("foo")
     await futures[0]
+    await any_
 
     assert any_.done() is True
     assert futures[0].done() is True

--- a/tests/pytests/functional/netapi/rest_tornado/test_webhooks_handler.py
+++ b/tests/pytests/functional/netapi/rest_tornado/test_webhooks_handler.py
@@ -1,6 +1,7 @@
 import urllib.parse
 
 import pytest
+import tornado
 
 import salt.utils.json
 from salt.netapi.rest_tornado import saltnado
@@ -28,15 +29,21 @@ async def test_hook_can_handle_get_parameters(http_client, app, content_type_map
             )
             assert response.code == 200
             host = urllib.parse.urlparse(response.effective_url).netloc
+
+            expected_headers = {
+                "Content-Length": "2",
+                "Connection": "close",
+                "Content-Type": "application/json",
+                "Host": host,
+                "Accept-Encoding": "gzip",
+            }
+
+            if tornado.version_info >= (6,):
+                expected_headers["User-Agent"] = f"Tornado/{tornado.version}"
+
             event.fire_event.assert_called_once_with(
                 {
-                    "headers": {
-                        "Content-Length": "2",
-                        "Connection": "close",
-                        "Content-Type": "application/json",
-                        "Host": host,
-                        "Accept-Encoding": "gzip",
-                    },
+                    "headers": expected_headers,
                     "post": {},
                     "get": {"param": ["1", "2"]},
                 },

--- a/tests/pytests/unit/states/test_user.py
+++ b/tests/pytests/unit/states/test_user.py
@@ -461,3 +461,63 @@ def test_present_password_unlock():
         else:
             unlock_password.assert_called_once()
             unlock_account.assert_not_called()
+
+
+def test_present_test_mode_missing_group_new_user():
+    """
+    Regression test for #68110: user.present should not fail in test mode
+    when a referenced group does not yet exist (e.g. it will be created by
+    a group.present requisite during the actual run). When the user also
+    does not yet exist, the state should report it would be added and that
+    the missing groups are pending.
+    """
+    mock_false = MagicMock(return_value=False)
+    mock_empty_list = MagicMock(return_value=[])
+    with patch.dict(user.__grains__, {"kernel": "Linux"}), patch.dict(
+        user.__salt__,
+        {
+            "group.info": mock_false,
+            "user.info": mock_empty_list,
+            "user.chkey": mock_empty_list,
+            "user.add": mock_false,
+        },
+    ), patch.dict(user.__opts__, {"test": True}):
+        ret = user.present("foo", groups=["foo"])
+        assert ret["result"] is None, ret
+        assert "set to be added" in ret["comment"], ret
+        assert "foo" in ret["comment"], ret
+
+
+def test_present_test_mode_missing_group_existing_user():
+    """
+    Regression test for #68110: when the user already exists, a missing
+    required group should not cause a hard failure in test mode. The
+    pending group(s) should appear in the test-mode comment.
+    """
+    mock_info = MagicMock(
+        return_value={
+            "uid": 5000,
+            "gid": 5000,
+            "groups": ["bar"],
+            "home": "/home/baz",
+            "fullname": "Baz",
+        }
+    )
+    # group.info: "foo" missing, "bar" exists.
+    group_info = MagicMock(
+        side_effect=lambda name: False if name == "foo" else {"gid": 5000}
+    )
+    dunder_salt = {
+        "group.info": group_info,
+        "user.info": mock_info,
+        "file.group_to_gid": MagicMock(return_value=5000),
+        "file.gid_to_group": MagicMock(return_value="bar"),
+    }
+    with patch.dict(user.__grains__, {"kernel": "Linux"}), patch.dict(
+        user.__salt__, dunder_salt
+    ), patch.dict(user.__opts__, {"test": True}):
+        ret = user.present("baz", groups=["foo", "bar"])
+        assert ret["result"] is not False, ret
+        assert "not present" not in ret["comment"], ret
+        # Pending group should be reported somewhere in the comment.
+        assert "foo" in ret["comment"], ret


### PR DESCRIPTION
### What does this PR do?

Backport/cherry-pick of upstream change from https://github.com/saltstack/salt/pull/69438 to solve stray failure upon user.present in test mode if groups created in the same run do not yet exist.

Reference commit message or upstream PR for details.

### What issues does this PR fix or reference?
Fixes: https://github.com/saltstack/salt/issues/68110

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [x] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [x] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
