### PR TITLE
Stabilize testsuite

### DIFF
--- a/tests/pytests/unit/test_minion.py
+++ b/tests/pytests/unit/test_minion.py
@@ -65,7 +65,7 @@ def test_minion_load_grains_default(minion_opts):
         ),
     ],
 )
-def test_send_req_tries(req_channel, minion_opts):
+def test_send_req_tries(req_channel, minion_opts, io_loop):
     channel_enter = MagicMock()
     channel_enter.send.side_effect = req_channel[1]
     channel = MagicMock()
@@ -83,7 +83,7 @@ def test_send_req_tries(req_channel, minion_opts):
             timeout = 60
 
             if "Async" in req_channel[0]:
-                rtn = minion._send_req_async(load, timeout).result()
+                rtn = io_loop.run_sync(lambda: minion._send_req_async(load, timeout))
             else:
                 rtn = minion._send_req_sync(load, timeout)
 

--- a/tests/pytests/unit/transport/test_tcp.py
+++ b/tests/pytests/unit/transport/test_tcp.py
@@ -450,7 +450,7 @@ def test_presence_events_callback_passed(temp_salt_master, salt_message_client):
         )
 
 
-def test_presence_removed_on_stream_closed():
+def test_presence_removed_on_stream_closed(io_loop):
     opts = {"presence_events": True}
 
     io_loop_mock = MagicMock(spec=tornado.ioloop.IOLoop)
@@ -468,7 +468,6 @@ def test_presence_removed_on_stream_closed():
     client._closing = True
     server.clients = {client}
 
-    io_loop = tornado.ioloop.IOLoop.current()
     package = {
         "topic_lst": [],
         "payload": "test-payload",

--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -223,8 +223,12 @@ class HTTPPostTestCase(TestCase):
         }
 
         mock_curl = MagicMock()
+        def mock_sync_wrapper(cls, args=None, kwargs=None, **_):
+            return cls(*args or [], **kwargs or {})
 
-        with patch("tornado.httpclient.HTTPClient.fetch", mock_curl):
+        with patch("salt.utils.http.SyncWrapper", side_effect=mock_sync_wrapper), patch(
+            "tornado.httpclient.AsyncHTTPClient.fetch", mock_curl
+        ):
             ret = http.query(
                 self.post_web_root,
                 method="POST",


### PR DESCRIPTION
### What does this PR do?

Because we now use async-based Tornado, we have to ensure `io_loop` is not closed for a particular test.

The `test_http` change is necessary due to  https://github.com/openSUSE/salt/pull/768 (which is necessary for us again due to async-based Tornado)

Backporting to `saltstack/salt` is not necessary because upstream 3006 doesn't use async Tornado, so the tests don't fail upstream.


### What issues does this PR fix or reference?
Related to: https://github.com/SUSE/spacewalk/issues/31354

### Previous Behavior
Tests fail.

### New Behavior
Tests pass.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
