### PR TITLE
Add `__pillar__` global in templates and matchers

### DIFF
--- a/salt/loader/__init__.py
+++ b/salt/loader/__init__.py
@@ -418,19 +418,34 @@ def metaproxy(opts, loaded_base_name=None):
     )
 
 
-def matchers(opts, loaded_base_name=None):
+def matchers(opts, loaded_base_name=None, context=None, pillar=None):
     """
     Return the matcher services plugins
 
     :param dict opts: The Salt options dictionary
     :param str loaded_base_name: The imported modules namespace when imported
                                  by the salt loader.
+    :param dict context: The Salt context dictionary
+    :param dict pillar: The Salt pillar dictionary
     """
+    if context is None:
+        context = {}
+
+    pack = {
+        "__salt__": {},
+        "__runners__": {},
+        "__grains__": opts.get("grains", {}),
+        "__context__": context,
+    }
+    if pillar is not None:
+        pack["__pillar__"] = pillar
+
     return LazyLoader(
         _module_dirs(opts, "matchers"),
         opts,
         tag="matchers",
         loaded_base_name=loaded_base_name,
+        pack=pack,
     )
 
 

--- a/salt/matchers/confirm_top.py
+++ b/salt/matchers/confirm_top.py
@@ -24,7 +24,11 @@ def confirm_top(match, data, nodegroups=None):
     if "matchers" in __context__:
         matchers = __context__["matchers"]
     else:
-        matchers = salt.loader.matchers(__opts__)
+        # Matchers need pillar data if available
+        pillar = __pillar__ if "__pillar__" in globals() else None
+        if hasattr(pillar, "value"):
+            pillar = pillar.value()
+        matchers = salt.loader.matchers(__opts__, context=__context__, pillar=pillar)
         __context__["matchers"] = matchers
     funcname = matcher + "_match.match"
     if matcher == "nodegroup":

--- a/salt/matchers/pillar_exact_match.py
+++ b/salt/matchers/pillar_exact_match.py
@@ -20,11 +20,16 @@ def match(tgt, delimiter=":", opts=None, minion_id=None):
         log.error("Got insufficient arguments for pillar match statement from master")
         return False
 
-    if "pillar" in opts:
+    if opts.get("pillar"):
         pillar = opts["pillar"]
-    elif "ext_pillar" in opts:
-        log.info("No pillar found, fallback to ext_pillar")
+    elif "__pillar__" in globals():
+        pillar = __pillar__
+        if hasattr(pillar, "value"):
+            pillar = pillar.value()
+    elif opts.get("ext_pillar"):
         pillar = opts["ext_pillar"]
+    else:
+        pillar = {}
 
     return salt.utils.data.subdict_match(
         pillar, tgt, delimiter=delimiter, exact_match=True

--- a/salt/matchers/pillar_match.py
+++ b/salt/matchers/pillar_match.py
@@ -21,10 +21,15 @@ def match(tgt, delimiter=DEFAULT_TARGET_DELIM, opts=None, minion_id=None):
         log.error("Got insufficient arguments for pillar match statement from master")
         return False
 
-    if "pillar" in opts:
+    if opts.get("pillar"):
         pillar = opts["pillar"]
-    elif "ext_pillar" in opts:
-        log.info("No pillar found, fallback to ext_pillar")
+    elif "__pillar__" in globals():
+        pillar = __pillar__
+        if hasattr(pillar, "value"):
+            pillar = pillar.value()
+    elif opts.get("ext_pillar"):
         pillar = opts["ext_pillar"]
+    else:
+        pillar = {}
 
     return salt.utils.data.subdict_match(pillar, tgt, delimiter=delimiter)

--- a/salt/matchers/pillar_pcre_match.py
+++ b/salt/matchers/pillar_pcre_match.py
@@ -23,11 +23,16 @@ def match(tgt, delimiter=DEFAULT_TARGET_DELIM, opts=None, minion_id=None):
         )
         return False
 
-    if "pillar" in opts:
+    if opts.get("pillar"):
         pillar = opts["pillar"]
-    elif "ext_pillar" in opts:
-        log.info("No pillar found, fallback to ext_pillar")
+    elif "__pillar__" in globals():
+        pillar = __pillar__
+        if hasattr(pillar, "value"):
+            pillar = pillar.value()
+    elif opts.get("ext_pillar"):
         pillar = opts["ext_pillar"]
+    else:
+        pillar = {}
 
     return salt.utils.data.subdict_match(
         pillar, tgt, delimiter=delimiter, regex_match=True

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -572,6 +572,12 @@ class Pillar:
         self.saltenv = saltenv
         self.client = salt.fileclient.get_file_client(self.opts, True)
         self.avail = self.__gather_avail()
+        self.pillar_data = self.opts.get("pillar", {})
+        if not isinstance(self.pillar_data, dict):
+            self.pillar_data = {}
+        else:
+            # Ensure we have a plain dict and not a proxy into opts
+            self.pillar_data = dict(self.pillar_data)
 
         if opts.get("file_client", "") == "local" and not opts.get(
             "use_master_when_local", False
@@ -589,7 +595,9 @@ class Pillar:
             self.functions = functions
 
         self.opts["minion_id"] = minion_id
-        self.matchers = salt.loader.matchers(self.opts)
+        self.matchers = salt.loader.matchers(self.opts, pillar=self.pillar_data)
+        if hasattr(self.matchers, "pack"):
+            self.matchers.pack["__pillar__"] = self.pillar_data
         self.rend = salt.loader.render(self.opts, self.functions)
         ext_pillar_opts = copy.deepcopy(self.opts)
         # Keep the incoming opts ID intact, ie, the master id
@@ -883,7 +891,7 @@ class Pillar:
         """
         matches = {}
         if reload:
-            self.matchers = salt.loader.matchers(self.opts)
+            self.matchers = salt.loader.matchers(self.opts, pillar=self.pillar_data)
         for saltenv, body in top.items():
             if self.opts["pillarenv"]:
                 if saltenv != self.opts["pillarenv"]:
@@ -1254,12 +1262,13 @@ class Pillar:
         top, top_errors = self.get_top()
         if ext:
             if self.opts.get("ext_pillar_first", False):
-                self.opts["pillar"], errors = self.ext_pillar(self.pillar_override)
+                pillar, errors = self.ext_pillar(self.pillar_override)
+                self.pillar_data.update(pillar)
                 self.rend = salt.loader.render(self.opts, self.functions)
                 matches = self.top_matches(top, reload=True)
                 pillar, errors = self.render_pillar(matches, errors=errors)
                 pillar = merge(
-                    self.opts["pillar"],
+                    self.pillar_data,
                     pillar,
                     self.merge_strategy,
                     self.opts.get("renderer", "yaml"),

--- a/tests/pytests/unit/pillar/test_pillar.py
+++ b/tests/pytests/unit/pillar/test_pillar.py
@@ -7,7 +7,7 @@ import salt.loader
 import salt.pillar
 import salt.utils.cache
 from salt.utils.odict import OrderedDict
-from tests.support.mock import MagicMock
+from tests.support.mock import MagicMock, patch
 
 
 @pytest.mark.parametrize(
@@ -175,3 +175,25 @@ def test_remote_pillar_timeout(temp_salt_minion, tmp_path):
     pillar.channel.crypted_transfer_decode_dictentry = mock
     with pytest.raises(salt.exceptions.SaltClientError):
         pillar.compile_pillar()
+
+
+def test_ssh_merge_pillar_in_dunder_pillar(temp_salt_minion):
+    """
+    Test that ssh_merge_pillar correctly merges extra pillar data from opts["pillar"] into __pillar__
+    """
+    opts = temp_salt_minion.config.copy()
+    opts["ssh_merge_pillar"] = True
+    opts["pillar"] = {"ssh_key": "ssh_value"}
+
+    grains = salt.loader.grains(opts)
+    pillar = salt.pillar.Pillar(opts, grains, temp_salt_minion.id, "base")
+
+    pil_value = {"normal_key": "normal_value"}
+    with patch.object(pillar, "render_pillar", return_value=(pil_value, [])):
+        compiled = pillar.compile_pillar()
+        assert compiled["ssh_key"] == "ssh_value"
+        assert compiled["normal_key"] == "normal_value"
+
+    # The loader pack should contain the merged SSH pillar
+    assert pillar.functions.pack["__pillar__"]["ssh_key"] == "ssh_value"
+    assert pillar.functions["pillar.get"]("ssh_key") == "ssh_value"

--- a/tests/unit/test_pillar.py
+++ b/tests/unit/test_pillar.py
@@ -89,6 +89,7 @@ class PillarTestCase(TestCase):
             "renderer_blacklist": [],
             "renderer_whitelist": [],
             "state_top": "",
+            "pillar": {},
             "pillar_roots": {"dev": [], "base": []},
             "file_roots": {"dev": [], "base": []},
             "extension_modules": "",


### PR DESCRIPTION
This is a partial cherry-pick of https://github.com/saltstack/salt/pull/64043

When using the Pillar Glob matcher, like such:

```
base:
  '*':
  'I@group_ids:72':
    - somepillarfile
```

The pillar matcher was throwing an exception:

```
# salt-call --local --no-color status.ping_master localhost
[ERROR   ] An un-handled exception was caught by Salt's global exception handler:
UnboundLocalError: cannot access local variable 'pillar' where it is not associated with a value
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 10, in <module>
    salt_call()
  File "/usr/lib/python3.11/site-packages/salt/scripts.py", line 444, in salt_call
    client.run()
  File "/usr/lib/python3.11/site-packages/salt/cli/call.py", line 49, in run
    caller = salt.cli.caller.Caller.factory(self.config)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/salt/cli/caller.py", line 42, in factory
    return ZeroMQCaller(opts, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/salt/cli/caller.py", line 303, in __init__
    super().__init__(opts)
  File "/usr/lib/python3.11/site-packages/salt/cli/caller.py", line 63, in __init__
    self.minion = salt.minion.SMinion(opts)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/salt/minion.py", line 934, in __init__
    self.gen_modules(initial_load=True, context=context)
  File "/usr/lib/python3.11/site-packages/salt/minion.py", line 454, in gen_modules
    ).compile_pillar()
      ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/salt/pillar/__init__.py", line 1269, in compile_pillar
    matches = self.top_matches(top)
              ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/salt/pillar/__init__.py", line 892, in top_matches
    if self.matchers["confirm_top.confirm_top"](
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/salt/loader/lazy.py", line 149, in __call__
    return self.loader.run(run_func, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/salt/loader/lazy.py", line 1234, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/salt/loader/lazy.py", line 1249, in _run_as
    ret = _func_or_method(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/salt/matchers/confirm_top.py", line 34, in confirm_top
    return m(match)
           ^^^^^^^^
  File "/usr/lib/python3.11/site-packages/salt/loader/lazy.py", line 149, in __call__
    return self.loader.run(run_func, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/salt/loader/lazy.py", line 1234, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/salt/loader/lazy.py", line 1249, in _run_as
    ret = _func_or_method(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/salt/matchers/compound_match.py", line 115, in match
    __context__["matchers"]["{}_match.match".format(engine)](
  File "/usr/lib/python3.11/site-packages/salt/loader/lazy.py", line 149, in __call__
    return self.loader.run(run_func, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/salt/loader/lazy.py", line 1234, in run
    return self._last_context.run(self._run_as, _func_or_method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/salt/loader/lazy.py", line 1249, in _run_as
    ret = _func_or_method(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/salt/matchers/pillar_match.py", line 30, in match
    return salt.utils.data.subdict_match(pillar, tgt, delimiter=delimiter)
                                         ^^^^^^
UnboundLocalError: cannot access local variable 'pillar' where it is not associated with a value
``` 

This PR cherry-picks changes related to matchers from https://github.com/saltstack/salt/pull/64043 to fix the undefined pillar variable in the matchers.

### What does this PR do?

### What issues does this PR fix or reference?
Fixes: https://github.com/SUSE/spacewalk/issues/31616

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
