### PR TITLE
Fix file handlers leaking on using SyncWrapper (bsc#1272939)

### DIFF
--- a/salt/utils/asynchronous.py
+++ b/salt/utils/asynchronous.py
@@ -124,6 +124,28 @@ class SyncWrapper:
     def __repr__(self):
         return f"<SyncWrapper(cls={self.cls})"
 
+    @staticmethod
+    def _loop_can_run_until_complete(loop):
+        """
+        Return ``True`` iff ``loop.run_until_complete(coro)`` can drive a
+        freshly created coroutine to completion without immediately raising.
+
+        ``BaseEventLoop.run_until_complete`` raises ``RuntimeError`` if the
+        loop is closed or already running, but only *after* its
+        ``future`` argument has been evaluated.  Constructing the
+        coroutine without being able to await it leaks it through
+        ``coroutine.__del__`` as ``RuntimeWarning: coroutine '...' was
+        never awaited`` (see ``close()``).  We avoid that by inspecting
+        the loop's state up front.
+        """
+        if loop is None:
+            return False
+        if loop.is_closed():
+            return False
+        if loop.is_running():
+            return False
+        return True
+
     def close(self):
         for method in self._close_methods:
             if method in self._async_methods:
@@ -138,8 +160,66 @@ class SyncWrapper:
                 method()
             except AttributeError:
                 log.error("No async method %s on object %r", method, self.obj)
-            except Exception:  # pylint: disable=broad-except
-                log.exception("Exception encountered while running stop method")
+            except Exception as exc:  # pylint: disable=broad-except
+                log.exception(
+                    "Exception encountered while running stop method: %s", exc
+                )
+        # Shut down asyncio resources before closing the IOLoop so file descriptors
+        # held by pending tasks, async generators, and the default executor are released.
+        #
+        # Each of the three ``run_until_complete`` calls below takes a freshly
+        # constructed coroutine object as its argument.  If the loop is already
+        # closed (or running) at that point ``run_until_complete`` raises
+        # ``RuntimeError`` *after* the coroutine has been created but *before*
+        # ``ensure_future`` wraps it — and the bare coroutine object is then
+        # garbage-collected unawaited, emitting a
+        # ``RuntimeWarning: coroutine '...' was never awaited`` on stderr.  On
+        # Python 3.14 / Windows the batch CLI integration tests
+        # (``tests/pytests/integration/cli/test_batch.py::test_batch_retcode``
+        # and ``test_multiple_modules_in_batch``) gate on ``assert not
+        # cmd.stderr`` and turn that warning into a hard failure.
+        #
+        # Gate every call on ``not _loop_can_run_until_complete(loop)`` so we
+        # never even *construct* the inner coroutine when the loop can't drive
+        # it to completion.
+        try:
+            if self._loop_can_run_until_complete(self.asyncio_loop):
+                pending_tasks = [
+                    task
+                    for task in asyncio.all_tasks(self.asyncio_loop)
+                    if not task.done()
+                ]
+                if pending_tasks:
+                    for task in pending_tasks:
+                        task.cancel()
+                    gathered = asyncio.gather(*pending_tasks, return_exceptions=True)
+                    try:
+                        self.asyncio_loop.run_until_complete(gathered)
+                    except Exception:  # pylint: disable=broad-except
+                        # ``gathered`` is a Future; if run_until_complete bailed
+                        # part-way we still need to make sure the Future is
+                        # consumed so its exception (if any) isn't logged as
+                        # unhandled.  Tasks already cancelled above.
+                        if not gathered.done():
+                            gathered.cancel()
+
+            if self._loop_can_run_until_complete(self.asyncio_loop):
+                shutdown_agens = self.asyncio_loop.shutdown_asyncgens()
+                try:
+                    self.asyncio_loop.run_until_complete(shutdown_agens)
+                except Exception:  # pylint: disable=broad-except
+                    shutdown_agens.close()
+
+            if self._loop_can_run_until_complete(self.asyncio_loop):
+                shutdown_exec = self.asyncio_loop.shutdown_default_executor()
+                try:
+                    self.asyncio_loop.run_until_complete(shutdown_exec)
+                except Exception:  # pylint: disable=broad-except
+                    shutdown_exec.close()
+
+        except Exception as exc:  # pylint: disable=broad-except
+            log.error("Error during asyncio shutdown: %s", exc)
+
         io_loop = self.io_loop
         io_loop.stop()
         try:

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -607,12 +607,15 @@ def query(
         req_kwargs = salt.utils.data.decode(req_kwargs, to_str=True)
 
         try:
-            download_client = SyncWrapper(
-                AsyncHTTPClient,
-                kwargs={"max_body_size": max_body} if supports_max_body_size else {},
-                async_methods=["fetch"],
+            download_client_kwargs = (
+                {"max_body_size": max_body} if supports_max_body_size else {}
             )
-            result = download_client.fetch(url_full, **req_kwargs)
+            with SyncWrapper(
+                AsyncHTTPClient,
+                kwargs=download_client_kwargs,
+                async_methods=["fetch"],
+            ) as download_client:
+                result = download_client.fetch(url_full, **req_kwargs)
         except tornado.httpclient.HTTPError as exc:
             ret["status"] = exc.code
             ret["error"] = str(exc)

--- a/tests/pytests/unit/utils/test_http.py
+++ b/tests/pytests/unit/utils/test_http.py
@@ -1,8 +1,65 @@
 import pytest
 import requests
+import tornado.httpclient
 
 import salt.utils.http
 from tests.support.mock import MagicMock, patch
+
+
+class _FakeFetchResponse:
+    """Simple object mimicking the bits of tornado's HTTPResponse we rely on."""
+
+    def __init__(self, code=200, body=b"payload", headers=None):
+        self.code = code
+        self.body = body
+        self.headers = headers or {"Content-Type": "text/plain; charset=utf-8"}
+
+
+@pytest.fixture
+def syncwrapper_stub(monkeypatch):
+    """Patch ``salt.utils.http.SyncWrapper`` with a controllable test double."""
+
+    class SyncWrapperStub:
+        fetch_return = _FakeFetchResponse()
+        fetch_side_effect = None
+        enter_calls = 0
+        close_calls = 0
+        fetch_calls = 0
+
+        def __init__(self, *args, **kwargs):
+            # Mirror SyncWrapper signature but we only need to track usage.
+            pass
+
+        def __enter__(self):
+            SyncWrapperStub.enter_calls += 1
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.close()
+            # Propagate exceptions so http.query can handle them
+            return False
+
+        def close(self):
+            SyncWrapperStub.close_calls += 1
+
+        def fetch(self, *args, **kwargs):
+            SyncWrapperStub.fetch_calls += 1
+            if SyncWrapperStub.fetch_side_effect is not None:
+                raise SyncWrapperStub.fetch_side_effect
+            return SyncWrapperStub.fetch_return
+
+        @classmethod
+        def reset_counters(cls, *, clear_fetch=True):
+            cls.enter_calls = 0
+            cls.close_calls = 0
+            cls.fetch_calls = 0
+            if clear_fetch:
+                cls.fetch_side_effect = None
+                cls.fetch_return = _FakeFetchResponse()
+
+    monkeypatch.setattr(salt.utils.http, "SyncWrapper", SyncWrapperStub)
+    SyncWrapperStub.reset_counters()
+    return SyncWrapperStub
 
 
 def test_requests_session_verify_ssl_false(ssl_webserver, integration_files_dir):
@@ -69,3 +126,37 @@ def test_query_tornado_httperror_no_response():
     # http.query() uses SyncWrapper as a context manager; ensure
     # __enter__() returns the mock_client itself.
     mock_client.__enter__.return_value = mock_client
+
+
+def test_query_tornado_closes_syncwrapper_on_success(syncwrapper_stub):
+    syncwrapper_stub.reset_counters()
+    syncwrapper_stub.fetch_return = _FakeFetchResponse(body=b"test-body")
+
+    ret = salt.utils.http.query("http://example.com", backend="tornado", status=True)
+
+    assert syncwrapper_stub.enter_calls == 1
+    assert syncwrapper_stub.close_calls == 1
+    assert syncwrapper_stub.fetch_calls == 1
+    assert ret["body"] == "test-body"
+    assert ret["status"] == 200
+
+
+def test_query_tornado_closes_syncwrapper_on_http_error(syncwrapper_stub):
+    syncwrapper_stub.reset_counters()
+    response = MagicMock(body=b"", headers={"Content-Type": "text/plain"})
+    syncwrapper_stub.fetch_side_effect = tornado.httpclient.HTTPError(
+        599, "Unit test failure", response=response
+    )
+
+    ret = salt.utils.http.query(
+        "http://example.com",
+        backend="tornado",
+        status=True,
+        raise_error=True,
+    )
+
+    assert syncwrapper_stub.enter_calls == 1
+    assert syncwrapper_stub.close_calls == 1
+    assert syncwrapper_stub.fetch_calls == 1
+    assert ret["status"] == 599
+    assert "Unit test failure" in ret["error"]

--- a/tests/pytests/unit/utils/test_http.py
+++ b/tests/pytests/unit/utils/test_http.py
@@ -51,3 +51,21 @@ def test_session_ca_bundle():
     with patch_os:
         ret = salt.utils.http.session(ca_bundle=fpath)
     assert ret.verify == fpath
+
+
+def test_query_tornado_httperror_no_response():
+    """
+    Tests that http.query handles a Tornado HTTPError where exc.response is None.
+    This happens on connection-level failures such as a connect timeout (HTTP 599)
+    where no HTTP response is ever received from the server.
+    """
+    import tornado.httpclient
+
+    http_error = tornado.httpclient.HTTPError(599, "Timeout while connecting")
+    assert http_error.response is None
+
+    mock_client = MagicMock()
+    mock_client.fetch.side_effect = http_error
+    # http.query() uses SyncWrapper as a context manager; ensure
+    # __enter__() returns the mock_client itself.
+    mock_client.__enter__.return_value = mock_client


### PR DESCRIPTION
### What does this PR do?

Backport of:
https://github.com/saltstack/salt/pull/68456
and
https://github.com/saltstack/salt/commit/64aae7bff10cbfa48c352a4a40b31b941e47f689 (a part of more complex change: https://github.com/saltstack/salt/pull/69444)

Fixes leaking of file handlers opened on each SyncWrapper use. There is a missing cleanup in `asyncio` implementation used by `tornado`. https://github.com/saltstack/salt/pull/68456 is closing stuck threads used by `asyncio` and https://github.com/saltstack/salt/commit/64aae7bff10cbfa48c352a4a40b31b941e47f689 is cleaning up the file handlers used for communication with the thread. In case of not having this part the file handlers leak is slower, but causing issues anyway.

The problem is not that visible in most cases, but could cause issues when the minion is deployed in the public cloud when [public_cloud gains module](https://github.com/uyuni-project/uyuni/blob/master/susemanager-utils/susemanager-sls/src/grains/public_cloud.py) used by Uyuni and SUSE Multi Linux Manager is checking if the instance is running in the public cloud as SyncWrapper is used internally.

### What issues does this PR fix or reference?
Tracks: https://github.com/SUSE/spacewalk/issues/31447

### Previous Behavior
Possible file handlers leak leading to `"OSError: [Errno 24] Too many open file`

### New Behavior
No issues with keeping too many open files.

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
