### PR TITLE
Fix test_tcp for pytest >=8

### DIFF
--- a/tests/unit/transport/test_tcp.py
+++ b/tests/unit/transport/test_tcp.py
@@ -17,7 +17,7 @@ import tornado.gen
 import tornado.ioloop
 import salt.utils.platform
 import salt.utils.process
-from tornado.testing import AsyncTestCase
+import tornado.testing
 from tests.support.mixins import AdaptedConfigurationTestCaseMixin
 from tests.unit.transport.mixins import run_loop_in_thread
 
@@ -30,10 +30,13 @@ log = logging.getLogger(__name__)
 
 
 @pytest.mark.skip(reason="Skip until we can devote time to fix this test")
-class AsyncPubServerTest(AsyncTestCase, AdaptedConfigurationTestCaseMixin):
+class AsyncPubServerTest(tornado.testing.AsyncTestCase, AdaptedConfigurationTestCaseMixin):
     """
     Tests around the publish system
     """
+
+    def runTest(self):
+        pass
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
### What does this PR do?

When executing this test with pytest>=8, it fails with the following error:

```
04:28:49  ERROR tests/unit/transport/test_tcp.py::AsyncTestCase - AttributeError: 'AsyncTestCase' object has no attribute 'runTest'
04:28:49  ERROR tests/unit/transport/test_tcp.py::AsyncPubServerTest - AttributeError: 'AsyncPubServerTest' object has no attribute 'runTest'
```

This commit fixes the failure. This is a continuation of https://github.com/openSUSE/salt/pull/774 

I also realized that while upstream is migrating the tests to pytest (which fixes the issue), we might want to fix these upstream as well in case the migration takes a long time, so I created https://github.com/saltstack/salt/pull/70172 which contains all the relevant fixes in https://github.com/openSUSE/salt/pull/774 and this PR. 

### What issues does this PR fix or reference?

### Previous Behavior
Tests errors out

### New Behavior
Test can execute

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
