### PR TITLE
Patch tornado for GHSA-8423-8fgw-73vq

### DIFF
--- a/changelog/70269.fixed.md
+++ b/changelog/70269.fixed.md
@@ -1,0 +1,1 @@
+- Patch tornado for GHSA-8423-8fgw-73vq

--- a/salt/ext/tornado/httputil.py
+++ b/salt/ext/tornado/httputil.py
@@ -916,7 +916,9 @@ def parse_multipart_form_data(boundary, data, arguments, files, config=None):
     final_boundary_index = data.rfind(b"--" + boundary + b"--")
     if final_boundary_index == -1:
         raise HTTPInputError("Invalid multipart/form-data: no final boundary found")
-    parts = data[:final_boundary_index].split(b"--" + boundary + b"\r\n")
+    parts = data[:final_boundary_index].split(
+        b"--" + boundary + b"\r\n", config.max_parts + 1
+    )
     if len(parts) > config.max_parts:
         raise HTTPInputError("multipart/form-data has too many parts")
     for part in parts:


### PR DESCRIPTION
### What does this PR do?

This PR backports https://github.com/saltstack/salt/pull/70269 to `openSUSE/release/3006.0` branch.

---

httputil: Apply multipart max_parts limit earlier
This prevents some CPU and memory amplification attacks.

https://github.com/tornadoweb/tornado/security/advisories/GHSA-8423-8fgw-73vq 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes

Please review [Salt's Contributing Guide](https://docs.saltproject.io/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
